### PR TITLE
Force the compiler to reattempt failed compilation repeatedly

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/CompiledGenerator.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/CompiledGenerator.java
@@ -50,6 +50,9 @@ public class CompiledGenerator extends AutoUpdatingFile {
 				generator = x;
 			}
 		});
+		if (!result.isPresent()) {
+			retry(2);
+		}
 		errors = compiler.errors().collect(Collectors.joining("<br/>"));
 	}
 


### PR DESCRIPTION
Sometimes, compilation fails because action or function repositories have not
finished scanning. Whenever compilation fails, it will wait 2 minutes and then
attempt compilation again, even if the file has not changed on disk.