### PR TITLE
Created a subsample package and unit tests

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/Fixed.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/Fixed.java
@@ -1,0 +1,26 @@
+package ca.on.oicr.gsi.shesmu.subsample;
+
+import java.util.List;
+
+public class Fixed<T> extends Subsampler<T> {
+
+	private final long numberOfItems;
+	private final Subsampler<T> parent;
+
+	public Fixed(Subsampler<T> parent, long numberOfItems) {
+		this.parent = parent;
+		this.numberOfItems = numberOfItems;
+		
+	}
+
+	@Override
+	protected int subsample(List<T> input, List<T> output) {
+		int position = parent.subsample(input, output);
+		int counter;
+		for(counter = 0; position + counter < input.size() && counter < numberOfItems; counter++) {
+			output.add(input.get(position + counter));
+		}
+		return position + counter;
+	}
+
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/FixedWithConditions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/FixedWithConditions.java
@@ -1,0 +1,33 @@
+package ca.on.oicr.gsi.shesmu.subsample;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class FixedWithConditions<T> extends Subsampler<T> {
+
+	private final long numberOfItems;
+	private final Subsampler<T> parent;
+	private final Predicate<T> condition;
+
+	public FixedWithConditions(Subsampler<T> parent, long numberOfItems, Predicate<T> condition) {
+		this.parent = parent;
+		this.numberOfItems = numberOfItems;
+		this.condition = condition;
+		
+	}
+
+	@Override
+	protected int subsample(List<T> input, List<T> output) {
+		int position = parent.subsample(input, output);
+		int counter;
+		for(counter = 0; position + counter < input.size() && counter < numberOfItems; counter++) {
+			T item = input.get(position + counter);
+			if (!condition.test(item)) {
+				break;
+			}
+			output.add(item);
+		}
+		return position + counter;
+	}
+
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/Squish.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/Squish.java
@@ -1,0 +1,31 @@
+package ca.on.oicr.gsi.shesmu.subsample;
+
+import java.util.List;
+
+public class Squish<T> extends Subsampler<T> {
+
+	private final Subsampler<T> parent;
+	private final long numberOfItems;
+
+	public Squish(Subsampler<T> parent, long numberOfItems) {
+		this.parent = parent;
+		this.numberOfItems = numberOfItems;
+	}
+
+	@Override
+	protected int subsample(List<T> input, List<T> output) {
+		int position = parent.subsample(input, output);
+		if (input.size() - position <= numberOfItems) {
+			output.addAll(input.subList(position, input.size()));
+			return input.size();
+		}
+		int step = (int) ((input.size() - position) / numberOfItems);
+		int counter;
+		for(counter = 0; position + counter * step < input.size() && counter < numberOfItems; counter++) {
+			output.add(input.get(position + counter * step));
+		}
+		return position + counter;
+		
+	}
+
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/Start.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/Start.java
@@ -1,0 +1,15 @@
+package ca.on.oicr.gsi.shesmu.subsample;
+
+import java.util.List;
+
+public class Start<T> extends Subsampler<T>{
+
+	public Start() {
+	}
+
+	@Override
+	protected int subsample(List<T> input, List<T> output) {
+		return 0;
+	}
+
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/Subsampler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/subsample/Subsampler.java
@@ -1,0 +1,21 @@
+package ca.on.oicr.gsi.shesmu.subsample;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public abstract class Subsampler<T> {
+
+	public Subsampler() {
+	}
+	
+	public Stream<T> subsample(Stream<T> input) {
+		List<T> output = new ArrayList<>();
+		subsample(input.collect(Collectors.toList()), output);
+		return output.stream();
+	}
+	
+	protected abstract int subsample(List<T> input, List<T> output);
+	
+}

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/SubsamplerTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/SubsamplerTest.java
@@ -1,0 +1,87 @@
+package ca.on.oicr.gsi.shesmu;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import ca.on.oicr.gsi.shesmu.subsample.Fixed;
+import ca.on.oicr.gsi.shesmu.subsample.FixedWithConditions;
+import ca.on.oicr.gsi.shesmu.subsample.Squish;
+import ca.on.oicr.gsi.shesmu.subsample.Start;
+
+public class SubsamplerTest {
+
+	public SubsamplerTest() {
+	}
+	
+	@Test
+	public void testData() throws IOException {
+		System.err.println("Testing subsamplers");
+		Start<Integer> start = new Start<Integer>();
+		
+		// Test for the Start<T> class
+		// checking if the number of items is correct
+		Assert.assertTrue("Start subsample program failed to run!", start
+				.subsample(Stream.of())
+				.count() == 0);
+		Assert.assertTrue("Start subsample program failed to run!", start
+				.subsample(Stream.of(5, 8, 9))
+				.count() == 0);
+		
+		// Tests for the Fixed<T> class
+		Fixed<Integer> fixed = new Fixed<Integer>(start, 6);
+		// Empty Stream
+		Assert.assertTrue("FixedEmpty subsample program failed to run!", fixed
+				.subsample(Stream.of())
+				.count() == 0);
+		// Stream with more data than the limit
+		Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6),
+				fixed.subsample(Stream.of(1, 2, 3, 4, 5, 6, 7))
+				.collect(Collectors.toList()));
+		// Stream with less data than the limit
+		Assert.assertEquals(Arrays.asList(1, 2, 3),
+				fixed.subsample(Stream.of(1, 2, 3))
+				.collect(Collectors.toList()));
+		
+		// Tests for the FixedWithConditions<T> class
+		Predicate<Integer> lesserThan = i -> (i < 10);
+		FixedWithConditions<Integer> conditioned = new FixedWithConditions<Integer>(start, 8, lesserThan);
+		Assert.assertTrue("FixedWithConditionsEmpty subsample program failed to run!", conditioned
+				.subsample(Stream.of())
+				.count() == 0);
+		Assert.assertEquals(Arrays.asList(-9, -4, 0, 2, 6, 8, 9),
+				conditioned.subsample(Stream.of(-9, -4, 0, 2, 6, 8, 9, 10, 2, 3, 6))
+				.collect(Collectors.toList()));
+		Assert.assertEquals(Arrays.asList(-9, -4, 0, 2),
+				conditioned.subsample(Stream.of(-9, -4, 0, 2))
+				.collect(Collectors.toList()));
+		Assert.assertEquals(Arrays.asList(),
+				conditioned.subsample(Stream.of(10, 12, 15, 543))
+				.collect(Collectors.toList()));
+		
+		// Tests for the Squish<T> class
+		Squish<Integer> squish = new Squish<Integer>(start, 10);
+		Assert.assertTrue("SquishEmpty subsample program failed to run!", conditioned
+				.subsample(Stream.of())
+				.count() == 0);
+		Assert.assertEquals(Arrays.asList(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5),
+				squish.subsample(Stream.of(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5))
+				.collect(Collectors.toList()));
+		Assert.assertEquals(Arrays.asList(-4, -2, 0, 2, 4, 6, 8, 10, 12, 14),
+				squish.subsample(Stream.of(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+				.collect(Collectors.toList()));
+		Assert.assertEquals(Arrays.asList(-4, -2, 0),
+				squish.subsample(Stream.of(-4, -2, 0))
+				.collect(Collectors.toList()));
+		Assert.assertEquals(Arrays.asList(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5),
+				squish.subsample(Stream.of(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+				.collect(Collectors.toList()));
+
+	}
+
+}


### PR DESCRIPTION
* Fixed some small issues 
* Wrote unit tests for each class. I think when we use `assertEquals` to compare the expect result with the actual result, both the number of items and the item content will be checked, so I removed the `assertTrue` statement which was used to assert `count`. ( `assertTrue` was used only if we are working with an empty stream.)