### PR TITLE
SeqWare Rate Limiting

### DIFF
--- a/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/CellRangerAction.java
+++ b/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/CellRangerAction.java
@@ -61,8 +61,8 @@ public class CellRangerAction extends SeqWareWorkflowAction {
 
 	private List<LimsKey> limsKeys;
 
-	public CellRangerAction(long workflowAccession, long[] previousAccessions, String jarPath, String settingsPath) {
-		super(workflowAccession, previousAccessions, jarPath, settingsPath);
+	public CellRangerAction(long workflowAccession, long[] previousAccessions, String jarPath, String settingsPath, String[] services) {
+		super(workflowAccession, previousAccessions, jarPath, settingsPath, services);
 	}
 
 	@RuntimeInterop

--- a/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/SeqWareActionRepository.java
+++ b/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/SeqWareActionRepository.java
@@ -43,7 +43,7 @@ public class SeqWareActionRepository implements ActionRepository {
 			actionDefinitions = Stream.of(value.getWorkflows())//
 					.<ActionDefinition>map(wc -> SeqWareWorkflowAction.create(wc.getName(), wc.getType().type(),
 							wc.getAccession(), wc.getPreviousAccessions(), value.getJar(), value.getSettings(),
-							wc.getType().parameters()))//
+							wc.getServices(), wc.getType().parameters()))//
 					.collect(Collectors.toList());
 			return Optional.empty();
 		}

--- a/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/SeqWareActionRepository.java
+++ b/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/SeqWareActionRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,6 +42,8 @@ public class SeqWareActionRepository implements ActionRepository {
 		protected Optional<Integer> update(Configuration value) {
 			properties.put("settings", value.getSettings());
 			actionDefinitions = Stream.of(value.getWorkflows())//
+					.peek(wc -> SeqWareWorkflowAction.MAX_IN_FLIGHT.putIfAbsent(wc.getAccession(),
+							new Semaphore(wc.getMaxInFlight())))//
 					.<ActionDefinition>map(wc -> SeqWareWorkflowAction.create(wc.getName(), wc.getType().type(),
 							wc.getAccession(), wc.getPreviousAccessions(), value.getJar(), value.getSettings(),
 							wc.getServices(), wc.getType().parameters()))//

--- a/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/WorkflowConfiguration.java
+++ b/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/WorkflowConfiguration.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.shesmu.variables.provenance;
 
 public class WorkflowConfiguration {
 	private long accession;
+	private int maxInFlight;
 	private String name;
 	private long[] previousAccessions;
 	private String[] services;
@@ -9,6 +10,10 @@ public class WorkflowConfiguration {
 
 	public long getAccession() {
 		return accession;
+	}
+
+	public int getMaxInFlight() {
+		return maxInFlight;
 	}
 
 	public String getName() {
@@ -29,6 +34,10 @@ public class WorkflowConfiguration {
 
 	public void setAccession(long accession) {
 		this.accession = accession;
+	}
+
+	public void setMaxInFlight(int maxInFlight) {
+		this.maxInFlight = maxInFlight;
 	}
 
 	public void setName(String name) {

--- a/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/WorkflowConfiguration.java
+++ b/source-pinery/src/main/java/ca/on/oicr/gsi/shesmu/variables/provenance/WorkflowConfiguration.java
@@ -4,6 +4,7 @@ public class WorkflowConfiguration {
 	private long accession;
 	private String name;
 	private long[] previousAccessions;
+	private String[] services;
 	private WorkflowType type;
 
 	public long getAccession() {
@@ -16,6 +17,10 @@ public class WorkflowConfiguration {
 
 	public long[] getPreviousAccessions() {
 		return previousAccessions;
+	}
+
+	public String[] getServices() {
+		return services;
 	}
 
 	public WorkflowType getType() {
@@ -32,6 +37,10 @@ public class WorkflowConfiguration {
 
 	public void setPreviousAccessions(long[] previousAccessions) {
 		this.previousAccessions = previousAccessions;
+	}
+
+	public void setServices(String[] services) {
+		this.services = services;
 	}
 
 	public void setType(WorkflowType type) {


### PR DESCRIPTION
I'm adding two rate limiters to SeqWare actions:

* throttlers, just like everything else. This will let us limit resources from Prometheus or elsewhere
* a max-in-flight limit (this came up during production meeting) that limits the total number of concurrent jobs for a particular accession. The config settings on this are a bit awkward: they are shared across all actions of the same accession (even if they are different Shesmu accessions) and they won't update even if the config file is changed