### PR TITLE
Change `PartitionCount`'s return type from tuple to object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
+  - openjdk10
 sudo: required
 env:
   global:

--- a/language.md
+++ b/language.md
@@ -118,8 +118,9 @@ In total, the collectors in a `Group` operation are:
 - `Max` and `Min` to collect the most extreme value; if none are collected, the
   group is rejected
 - `Count` to count the number of matched rows
-- `PartitionCount` which returns a tuple of the number of rows that matched and
-  failed the provided condition
+- `PartitionCount` which returns an object with two fields: `matched_count`
+  with the number of rows that satisfied the condition and `not_matched_count`
+  with the number that failed the provided condition
 - `Any`, `All`, and `None` which check that a condition is satisfied for any,
   all, and, none of the rows, respectively.
 
@@ -721,8 +722,9 @@ condition specified in _expr_, which must return a Boolean.
 #### Partitioned Counter
 - `PartitionCount` _expr_
 
-Produces a tuple with two elements: the first is the number of items for which
-_expr_ was true, the second is the number of items for which _expr_ was false.
+Produces an object with two field: `matched_count` is the number of items for
+which _expr_ was true, the `not_matched_count` is the number of items for which
+_expr_ was false.
 
 #### Reduce
 - `Reduce(`_a_ `=` _initialexpr_ `)` _expr_

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodePartitionCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodePartitionCount.java
@@ -85,7 +85,7 @@ public class CollectNodePartitionCount extends CollectNode {
 
 	@Override
 	public Imyhat type() {
-		return Imyhat.tuple(Imyhat.INTEGER, Imyhat.INTEGER);
+		return PartitionCount.TYPE;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodePartitionCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodePartitionCount.java
@@ -9,10 +9,10 @@ import java.util.function.Predicate;
 import ca.on.oicr.gsi.shesmu.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.Imyhat;
+import ca.on.oicr.gsi.shesmu.runtime.PartitionCount;
 
 public class GroupNodePartitionCount extends GroupNode {
 
-	private static final Imyhat TYPE = Imyhat.tuple(Imyhat.INTEGER, Imyhat.INTEGER);
 	private final ExpressionNode condition;
 	private final String name;
 
@@ -51,7 +51,7 @@ public class GroupNodePartitionCount extends GroupNode {
 
 	@Override
 	public Imyhat type() {
-		return TYPE;
+		return PartitionCount.TYPE;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/PartitionCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/PartitionCount.java
@@ -7,9 +7,12 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.Imyhat;
 
 public class PartitionCount {
-
 	@RuntimeInterop
 	public static final Collector<Boolean, PartitionCount, Tuple> COLLECTOR = new Collector<Boolean, PartitionCount, Tuple>() {
 
@@ -39,27 +42,29 @@ public class PartitionCount {
 		}
 
 	};
+	public static final Imyhat TYPE = new Imyhat.ObjectImyhat(
+			Stream.of(new Pair<>("matched_count", Imyhat.INTEGER), new Pair<>("not_matched_count", Imyhat.INTEGER)));
 
-	private long falseCount;
-	private long trueCount;
+	private long matchedCount;
+	private long notMatchedCount;
 
 	@RuntimeInterop
 	public void accumulate(boolean value) {
 		if (value) {
-			trueCount++;
+			matchedCount++;
 		} else {
-			falseCount++;
+			notMatchedCount++;
 		}
 	}
 
 	public PartitionCount combine(PartitionCount other) {
-		trueCount += other.trueCount;
-		falseCount += other.falseCount;
+		matchedCount += other.matchedCount;
+		notMatchedCount += other.notMatchedCount;
 		return this;
 	}
 
 	@RuntimeInterop
 	public Tuple toTuple() {
-		return new Tuple(trueCount, falseCount);
+		return new Tuple(matchedCount, notMatchedCount);
 	}
 }

--- a/shesmu-server/src/test/resources/run/group-partitioncount.shesmu
+++ b/shesmu-server/src/test/resources/run/group-partitioncount.shesmu
@@ -2,4 +2,4 @@ Input test;
 
 Olive
  Group a = PartitionCount library_size == 307 By workflow
- Run ok With ok = a[0] == 1 && a[1] == 1;
+ Run ok With ok = a.matched_count == 1 && a.not_matched_count == 1;

--- a/shesmu-server/src/test/resources/run/list-bool.shesmu
+++ b/shesmu-server/src/test/resources/run/list-bool.shesmu
@@ -1,4 +1,4 @@
 Input test;
 
 Olive
- Run ok With ok = (For x In [ {1,True}, {2, False}, {3, True} ]: PartitionCount x[1])[0] == 2;
+ Run ok With ok = (For x In [ {1,True}, {2, False}, {3, True} ]: PartitionCount x[1]).matched_count == 2;


### PR DESCRIPTION
Rather than return two counts in a tuple, return two counts with helpful
labels.