### PR TITLE
Fix compiler bugs

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Check.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Check.java
@@ -29,13 +29,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import ca.on.oicr.gsi.shesmu.ActionDefinition;
+import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.ConstantDefinition;
 import ca.on.oicr.gsi.shesmu.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.FunctionParameter;
 import ca.on.oicr.gsi.shesmu.Imyhat;
 import ca.on.oicr.gsi.shesmu.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.LoadedConfiguration;
-import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import ca.on.oicr.gsi.shesmu.util.NameLoader;
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
@@ -83,7 +83,7 @@ public abstract class Compiler {
 		}
 		if (parseOk && program.get().validate(this::getInputFormats, this::getFunction, this::getAction,
 				this::errorHandler, constants)) {
-			Instant compileTime = Instant.now();
+			final Instant compileTime = Instant.now();
 			if (dashboardOutput != null && skipRender) {
 				dashboardOutput.accept(program.get().dashboard(path, compileTime, "Bytecode not available."));
 			}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNode.java
@@ -44,7 +44,7 @@ public abstract class DiscriminatorNode extends DefinedTarget {
 	private final int column;
 
 	private final int line;
-public abstract VariableInformation dashboard();
+
 	public DiscriminatorNode(int line, int column) {
 		super();
 		this.line = line;
@@ -56,10 +56,14 @@ public abstract VariableInformation dashboard();
 	 */
 	public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
 
+	@Override
 	public int column() {
 		return column;
 	}
 
+	public abstract VariableInformation dashboard();
+
+	@Override
 	public int line() {
 		return line;
 	}
@@ -85,6 +89,7 @@ public abstract VariableInformation dashboard();
 	 *
 	 * This should return {@link Imyhat#BAD} if no type can be determined
 	 */
+	@Override
 	public abstract Imyhat type();
 
 	/**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeRename.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeRename.java
@@ -13,8 +13,8 @@ import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 
 public class DiscriminatorNodeRename extends DiscriminatorNode {
 
-	private ExpressionNode expression;
-	private String name;
+	private final ExpressionNode expression;
+	private final String name;
 
 	public DiscriminatorNodeRename(int line, int column, String name, ExpressionNode expression) {
 		super(line, column);
@@ -28,6 +28,23 @@ public class DiscriminatorNodeRename extends DiscriminatorNode {
 	}
 
 	@Override
+	public VariableInformation dashboard() {
+		final Set<String> freeStreamVariables = new HashSet<>();
+		expression.collectFreeVariables(freeStreamVariables, Flavour::isStream);
+		return new VariableInformation(name, expression.type(), freeStreamVariables.stream(), Behaviour.PASSTHROUGH);
+	}
+
+	@Override
+	public Flavour flavour() {
+		return Flavour.STREAM;
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
+
+	@Override
 	public void render(RegroupVariablesBuilder builder) {
 		builder.addKey(expression.type().asmType(), name, expression::render);
 	}
@@ -36,7 +53,7 @@ public class DiscriminatorNodeRename extends DiscriminatorNode {
 	public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
 		boolean ok = expression.resolve(defs, errorHandler);
 		if (ok) {
-			Set<String> freeStreamVariables = new HashSet<>();
+			final Set<String> freeStreamVariables = new HashSet<>();
 			expression.collectFreeVariables(freeStreamVariables, Flavour::isStream);
 			if (freeStreamVariables.isEmpty()) {
 				errorHandler.accept(String.format("%d:%d: New variable “%s” in By does not use any stream variables.",
@@ -45,13 +62,6 @@ public class DiscriminatorNodeRename extends DiscriminatorNode {
 			}
 		}
 		return ok;
-	}
-
-	@Override
-	public VariableInformation dashboard() {
-		Set<String> freeStreamVariables = new HashSet<>();
-		expression.collectFreeVariables(freeStreamVariables, Flavour::isStream);
-		return new VariableInformation(name, expression.type(), freeStreamVariables.stream(), Behaviour.PASSTHROUGH);
 	}
 
 	@Override
@@ -68,16 +78,6 @@ public class DiscriminatorNodeRename extends DiscriminatorNode {
 	@Override
 	public boolean typeCheck(Consumer<String> errorHandler) {
 		return expression.typeCheck(errorHandler);
-	}
-
-	@Override
-	public Flavour flavour() {
-		return Flavour.STREAM;
-	}
-
-	@Override
-	public String name() {
-		return name;
 	}
 
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeSimple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeSimple.java
@@ -19,6 +19,8 @@ public class DiscriminatorNodeSimple extends DiscriminatorNode {
 
 	private final String name;
 
+	private Target target = Target.BAD;
+
 	public DiscriminatorNodeSimple(int line, int column, String name) {
 		super(line, column);
 		this.name = name;
@@ -30,7 +32,20 @@ public class DiscriminatorNodeSimple extends DiscriminatorNode {
 
 	}
 
-	private Target target = Target.BAD;
+	@Override
+	public VariableInformation dashboard() {
+		return new VariableInformation(name, target.type(), Stream.of(name), Behaviour.PASSTHROUGH);
+	}
+
+	@Override
+	public Flavour flavour() {
+		return target.flavour();
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
 
 	@Override
 	public void render(RegroupVariablesBuilder builder) {
@@ -70,20 +85,5 @@ public class DiscriminatorNodeSimple extends DiscriminatorNode {
 	@Override
 	public boolean typeCheck(Consumer<String> errorHandler) {
 		return true;
-	}
-
-	@Override
-	public Flavour flavour() {
-		return target.flavour();
-	}
-
-	@Override
-	public String name() {
-		return name;
-	}
-
-	@Override
-	public VariableInformation dashboard() {
-		return new VariableInformation(name, target.type(), Stream.of(name), Behaviour.PASSTHROUGH);
 	}
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeSimple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeSimple.java
@@ -30,7 +30,7 @@ public class DiscriminatorNodeSimple extends DiscriminatorNode {
 
 	}
 
-	private Target target;
+	private Target target = Target.BAD;
 
 	@Override
 	public void render(RegroupVariablesBuilder builder) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFor.java
@@ -52,7 +52,7 @@ public class ExpressionNodeFor extends ExpressionNode {
 					throw new UnsupportedOperationException();
 				});
 
-		ok &= nextName.map(name -> collector.resolve(name, defs, errorHandler)).orElse(false);
+		ok = ok && nextName.map(name -> collector.resolve(name, defs, errorHandler)).orElse(false);
 		return ok;
 	}
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObject.java
@@ -50,7 +50,7 @@ public class ExpressionNodeObject extends ExpressionNode {
 		renderer.methodGen().dup();
 		renderer.methodGen().push(fields.size());
 		renderer.methodGen().newArray(A_OBJECT_TYPE);
-		AtomicInteger index = new AtomicInteger();
+		final AtomicInteger index = new AtomicInteger();
 		fields.stream()//
 				.sorted(Comparator.comparing(Pair::first))//
 				.forEach(field -> {
@@ -86,7 +86,7 @@ public class ExpressionNodeObject extends ExpressionNode {
 	@Override
 	public boolean typeCheck(Consumer<String> errorHandler) {
 		boolean ok = fields.stream().filter(field -> field.second().typeCheck(errorHandler)).count() == fields.size();
-		Map<String, Long> fieldCounts = fields.stream()//
+		final Map<String, Long> fieldCounts = fields.stream()//
 				.map(Pair::first)//
 				.collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 		if (fieldCounts.entrySet().stream()//

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObjectGet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObjectGet.java
@@ -22,9 +22,9 @@ public class ExpressionNodeObjectGet extends ExpressionNode {
 
 	private final ExpressionNode expression;
 
-	private int index = -1;
-
 	private final String field;
+
+	private int index = -1;
 
 	private Imyhat type = Imyhat.BAD;
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
@@ -87,7 +87,13 @@ public class ExpressionNodeVariable extends ExpressionNode {
 
 	@Override
 	public boolean typeCheck(Consumer<String> errorHandler) {
-		return !target.type().isBad();
+		boolean ok = !target.type().isBad();
+		if (!ok) {
+			errorHandler.accept(
+					String.format("%d:%d: Variable %s is bad but still being type checked. This is a compiler bug.",
+							line(), column(), name));
+		}
+		return ok;
 	}
 
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
@@ -134,6 +134,7 @@ public abstract class GroupNode extends DefinedTarget {
 
 	public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
 
+	@Override
 	public final int column() {
 		return column;
 	}
@@ -143,6 +144,7 @@ public abstract class GroupNode extends DefinedTarget {
 		return Flavour.STREAM;
 	}
 
+	@Override
 	public final int line() {
 		return line;
 	}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFirst.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFirst.java
@@ -37,13 +37,13 @@ public final class GroupNodeFirst extends GroupNodeDefaultable {
 	}
 
 	@Override
-	public void render(Regrouper regroup, RootBuilder rootBuilder) {
-		regroup.addFirst(expression.type().asmType(), name(), expression::render);
+	public void render(Regrouper regroup, ExpressionNode initial, RootBuilder rootBuilder) {
+		regroup.addFirst(expression.type().asmType(), name(), expression::render, initial::render);
 	}
 
 	@Override
-	public void render(Regrouper regroup, ExpressionNode initial, RootBuilder rootBuilder) {
-		regroup.addFirst(expression.type().asmType(), name(), expression::render, initial::render);
+	public void render(Regrouper regroup, RootBuilder rootBuilder) {
+		regroup.addFirst(expression.type().asmType(), name(), expression::render);
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeMatches.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeMatches.java
@@ -39,7 +39,7 @@ public class GroupNodeMatches extends GroupNode {
 	}
 
 	@Override
-	public boolean resolve(NameDefinitions defs,NameDefinitions outerDefs,  Consumer<String> errorHandler) {
+	public boolean resolve(NameDefinitions defs, NameDefinitions outerDefs, Consumer<String> errorHandler) {
 		return condition.resolve(defs, errorHandler);
 	}
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodePartitionCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodePartitionCount.java
@@ -38,7 +38,7 @@ public class GroupNodePartitionCount extends GroupNode {
 	}
 
 	@Override
-	public boolean resolve(NameDefinitions defs,NameDefinitions outerDefs,  Consumer<String> errorHandler) {
+	public boolean resolve(NameDefinitions defs, NameDefinitions outerDefs, Consumer<String> errorHandler) {
 		return condition.resolve(defs, errorHandler);
 	}
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWithDefault.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWithDefault.java
@@ -28,6 +28,11 @@ public class GroupNodeWithDefault extends GroupNode {
 	}
 
 	@Override
+	public String name() {
+		return inner.name();
+	}
+
+	@Override
 	public void render(Regrouper regroup, RootBuilder builder) {
 		inner.render(regroup, initial, builder);
 	}
@@ -46,6 +51,11 @@ public class GroupNodeWithDefault extends GroupNode {
 	}
 
 	@Override
+	public Imyhat type() {
+		return inner.type();
+	}
+
+	@Override
 	public boolean typeCheck(Consumer<String> errorHandler) {
 		boolean ok = inner.typeCheck(errorHandler) & initial.typeCheck(errorHandler);
 		if (ok && !inner.type().isSame(initial.type())) {
@@ -53,16 +63,6 @@ public class GroupNodeWithDefault extends GroupNode {
 			ok = false;
 		}
 		return ok;
-	}
-
-	@Override
-	public String name() {
-		return inner.name();
-	}
-
-	@Override
-	public Imyhat type() {
-		return inner.type();
 	}
 
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNodeObject.java
@@ -19,7 +19,7 @@ public class ImyhatNodeObject extends ImyhatNode {
 
 	@Override
 	public Imyhat render(Function<String, Imyhat> definedTypes, Consumer<String> errorHandler) {
-		Map<String, Long> fieldCounts = types.stream()//
+		final Map<String, Long> fieldCounts = types.stream()//
 				.map(Pair::first)//
 				.collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 		if (fieldCounts.entrySet().stream()//

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNodeUnobject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNodeUnobject.java
@@ -21,8 +21,7 @@ public class ImyhatNodeUnobject extends ImyhatNode {
 		if (type instanceof Imyhat.ObjectImyhat) {
 			final Imyhat inner = ((Imyhat.ObjectImyhat) type).get(field);
 			if (inner.isBad()) {
-				errorHandler.accept(
-						String.format("Object type %s does not contain an field %s.", type.name(), field));
+				errorHandler.accept(String.format("Object type %s does not contain an field %s.", type.name(), field));
 			}
 			return inner;
 		}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNode.java
@@ -6,9 +6,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.Imyhat;
-import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 
 /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNodeOptional.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNodeOptional.java
@@ -8,9 +8,9 @@ import java.util.function.Predicate;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
+import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.Imyhat;
-import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 
 /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNodeProvided.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNodeProvided.java
@@ -5,9 +5,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.Imyhat;
-import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 
 /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
@@ -225,6 +225,8 @@ public abstract class OliveClauseNode {
 		return input.raise("Expected olive clause.");
 	}
 
+	public abstract int column();
+
 	public abstract OliveClauseRow dashboard();
 
 	/**
@@ -235,6 +237,8 @@ public abstract class OliveClauseNode {
 	 */
 	public abstract ClauseStreamOrder ensureRoot(ClauseStreamOrder state, Set<String> signableNames,
 			Consumer<String> errorHandler);
+
+	public abstract int line();
 
 	/**
 	 * Generate byte code for this clause.

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
@@ -93,7 +93,7 @@ public class OliveClauseNodeCall extends OliveClauseNode {
 				.count() == arguments.size();
 		final Optional<Stream<Target>> replacements = target.outputStreamVariables(inputFormatDefinition,
 				definedFormats, errorHandler, constants);
-		good &= replacements.isPresent();
+		good = good && replacements.isPresent();
 		return defs.replaceStream(replacements.orElseGet(Stream::empty), good);
 
 	}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
@@ -36,6 +36,11 @@ public class OliveClauseNodeCall extends OliveClauseNode {
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		final String prettyName = name + "(" + (target.parameterCount() == 0 ? "" : "...") + ")";
 		return new OliveClauseRow(prettyName, line, column, true, !target.isRoot(), //
@@ -54,8 +59,7 @@ public class OliveClauseNodeCall extends OliveClauseNode {
 		case BAD:
 			return ClauseStreamOrder.BAD;
 		case TRANSFORMED:
-			errorHandler
-					.accept(String.format("%d:%d: Call clause cannot be applied to grouped result.", line, column));
+			errorHandler.accept(String.format("%d:%d: Call clause cannot be applied to grouped result.", line, column));
 			return ClauseStreamOrder.BAD;
 		case PURE:
 			signableNames.addAll(target.signableNames);
@@ -63,6 +67,11 @@ public class OliveClauseNodeCall extends OliveClauseNode {
 		default:
 			return ClauseStreamOrder.BAD;
 		}
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override
@@ -118,8 +127,8 @@ public class OliveClauseNodeCall extends OliveClauseNode {
 			}
 			final boolean isSame = arguments.get(index).type().isSame(target.parameterType(index));
 			if (!isSame) {
-				errorHandler.accept(String.format("%d:%d: Parameter %d to “%s” expects %s, but got %s.", line,
-						column, index, name, target.parameterType(index).name(), arguments.get(index).type().name()));
+				errorHandler.accept(String.format("%d:%d: Parameter %d to “%s” expects %s, but got %s.", line, column,
+						index, name, target.parameterType(index).name(), arguments.get(index).type().name()));
 
 			}
 			return isSame;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
@@ -54,6 +54,11 @@ public final class OliveClauseNodeDump extends OliveClauseNode implements Reject
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		return new OliveClauseRow("Dump", line, column, false, false, columns.stream()//
 				.map(new Function<ExpressionNode, VariableInformation>() {
@@ -74,6 +79,11 @@ public final class OliveClauseNodeDump extends OliveClauseNode implements Reject
 	public ClauseStreamOrder ensureRoot(ClauseStreamOrder state, Set<String> signableNames,
 			Consumer<String> errorHandler) {
 		return state;
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
@@ -67,6 +67,11 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		return new OliveClauseRow("Group", line, column, true, true, //
 				Stream.concat(//
@@ -92,6 +97,11 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
 			return ClauseStreamOrder.TRANSFORMED;
 		}
 		return state;
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
@@ -172,7 +172,7 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
 
 	@Override
 	public final boolean typeCheck(Consumer<String> errorHandler) {
-		return children.stream().filter(group -> group.typeCheck(errorHandler)).count() == children.size();
+		return children.stream().filter(group -> group.typeCheck(errorHandler)).count() == children.size() && discriminators.stream().filter(discriminator -> discriminator.typeCheck(errorHandler)).count() == discriminators.size();
 	}
 
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
@@ -133,7 +133,7 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
 								.filter(discriminator -> discriminator.resolve(defs, errorHandler))//
 								.count() == discriminators.size();
 
-		ok &= children.stream().noneMatch(group -> {
+		ok = ok && children.stream().noneMatch(group -> {
 			final boolean isDuplicate = defs.get(group.name()).filter(variable -> !variable.flavour().isStream())
 					.isPresent();
 			if (isDuplicate) {
@@ -156,7 +156,7 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
 				& discriminators.stream().filter(group -> group.resolveFunctions(definedFunctions, errorHandler))
 						.count() == discriminators.size();
 
-		ok &= Stream.<DefinedTarget>concat(discriminators.stream(), children.stream())//
+		ok = ok && Stream.<DefinedTarget>concat(discriminators.stream(), children.stream())//
 				.collect(Collectors.groupingBy(DefinedTarget::name))//
 				.entrySet().stream()//
 				.filter(e -> e.getValue().size() > 1)//

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
@@ -36,6 +36,11 @@ public class OliveClauseNodeJoin extends OliveClauseNode {
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		return new OliveClauseRow("Join", line, column, true, false, inputFormat.baseStreamVariables()//
 				.map(variable -> new VariableInformation(variable.name(), variable.type(), Stream.empty(),
@@ -46,6 +51,11 @@ public class OliveClauseNodeJoin extends OliveClauseNode {
 	public ClauseStreamOrder ensureRoot(ClauseStreamOrder state, Set<String> signableNames,
 			Consumer<String> errorHandler) {
 		return state == ClauseStreamOrder.PURE ? ClauseStreamOrder.TRANSFORMED : state;
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
@@ -45,6 +45,11 @@ public final class OliveClauseNodeLeftJoin extends OliveClauseNode {
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		final Set<String> joinedNames = inputFormat.baseStreamVariables()//
 				.map(Target::name)//
@@ -74,6 +79,11 @@ public final class OliveClauseNodeLeftJoin extends OliveClauseNode {
 			return ClauseStreamOrder.TRANSFORMED;
 		}
 		return state;
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
@@ -35,6 +35,11 @@ public class OliveClauseNodeLet extends OliveClauseNode {
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		return new OliveClauseRow("Let", line, column, false, true, arguments.stream()//
 				.map(arg -> {
@@ -53,6 +58,11 @@ public class OliveClauseNodeLet extends OliveClauseNode {
 			return ClauseStreamOrder.TRANSFORMED;
 		}
 		return state;
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
@@ -59,6 +59,11 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		return new OliveClauseRow("Monitor", line, column, false, false, labels.stream()//
 				.map(label -> {
@@ -78,6 +83,11 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
 
 	private List<String> labelNames() {
 		return labels.stream().map(MonitorArgumentNode::name).collect(Collectors.toList());
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	private void render(Renderer renderer) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
@@ -42,6 +42,11 @@ public class OliveClauseNodePick extends OliveClauseNode {
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		final Set<String> inputs = new TreeSet<>();
 		extractor.collectFreeVariables(inputs, Flavour::isStream);
@@ -66,6 +71,11 @@ public class OliveClauseNodePick extends OliveClauseNode {
 			extractor.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals);
 		}
 		return state;
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
@@ -40,6 +40,11 @@ public class OliveClauseNodeReject extends OliveClauseNode {
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		final Set<String> inputs = new TreeSet<>();
 		expression.collectFreeVariables(inputs, Flavour::isStream);
@@ -54,6 +59,11 @@ public class OliveClauseNodeReject extends OliveClauseNode {
 			expression.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals);
 		}
 		return state;
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
@@ -34,6 +34,11 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
 	}
 
 	@Override
+	public int column() {
+		return column;
+	}
+
+	@Override
 	public OliveClauseRow dashboard() {
 		final Set<String> inputs = new TreeSet<>();
 		expression.collectFreeVariables(inputs, Flavour::isStream);
@@ -48,6 +53,11 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
 			expression.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals);
 		}
 		return state;
+	}
+
+	@Override
+	public int line() {
+		return line;
 	}
 
 	@Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -15,11 +15,11 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import ca.on.oicr.gsi.shesmu.ActionDefinition;
+import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.ConstantDefinition;
 import ca.on.oicr.gsi.shesmu.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.Imyhat;
 import ca.on.oicr.gsi.shesmu.InputFormatDefinition;
-import ca.on.oicr.gsi.shesmu.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.description.OliveTable;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
@@ -135,12 +135,12 @@ public class ProgramNode {
 
 		boolean ok = olives.stream().filter(olive -> olive.collectDefinitions(definedOlives, errorHandler))
 				.count() == olives.size();
-		ok &= olives.stream().allMatch(olive -> olive.resolveTypes(userDefinedTypes::get, errorHandler));
-		ok &= olives.stream()
+		ok = ok && olives.stream().allMatch(olive -> olive.resolveTypes(userDefinedTypes::get, errorHandler));
+		ok = ok && olives.stream()
 				.allMatch(olive -> olive.collectFunctions(
 						name -> userDefinedFunctions.containsKey(name) || definedFunctions.apply(name) != null,
 						f -> userDefinedFunctions.put(f.name(), f), errorHandler));
-		ok &= olives.stream()
+		ok = ok && olives.stream()
 				.filter(olive -> olive.resolveDefinitions(definedOlives,
 						n -> userDefinedFunctions.containsKey(n) ? userDefinedFunctions.get(n)
 								: definedFunctions.apply(n),
@@ -148,19 +148,13 @@ public class ProgramNode {
 				.count() == olives.size();
 
 		// Resolve variables
-		if (ok) {
-			ok = olives.stream().filter(
-					olive -> olive.resolve(inputFormatDefinition, inputFormatDefinitions, errorHandler, constants))
-					.count() == olives.size();
-		}
-		if (ok) {
-			ok = olives.stream().filter(olive -> olive.checkVariableStream(errorHandler)).count() == olives.size();
-		}
+		ok = ok && olives.stream()
+				.filter(olive -> olive.resolve(inputFormatDefinition, inputFormatDefinitions, errorHandler, constants))
+				.count() == olives.size();
+		ok = ok && olives.stream().filter(olive -> olive.checkVariableStream(errorHandler)).count() == olives.size();
 
 		// Type check the resolved structure
-		if (ok) {
-			ok = olives.stream().filter(olive -> olive.typeCheck(errorHandler)).count() == olives.size();
-		}
+		ok = ok && olives.stream().filter(olive -> olive.typeCheck(errorHandler)).count() == olives.size();
 		return ok;
 	}
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Target.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Target.java
@@ -23,6 +23,24 @@ public abstract class Target {
 		}
 	}
 
+	public static final Target BAD = new Target() {
+
+		@Override
+		public Flavour flavour() {
+			return Flavour.CONSTANT;
+		}
+
+		@Override
+		public String name() {
+			return "<BAD>";
+		}
+
+		@Override
+		public Imyhat type() {
+			return Imyhat.BAD;
+		}
+	};
+
 	/**
 	 * What category of variables this one belongs to
 	 */

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/package-info.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/package-info.java
@@ -1,4 +1,5 @@
 /**
- * This contains the compiler that converts <tt>.shesmu<tt> files into an {@link ca.on.oicr.gsi.shesmu.ActionGenerator}
+ * This contains the compiler that converts <tt>.shesmu<tt> files into an
+ * {@link ca.on.oicr.gsi.shesmu.ActionGenerator}
  */
 package ca.on.oicr.gsi.shesmu.compiler;

--- a/shesmu-server/src/test/resources/compiler/bad-missing-action-param.shesmu
+++ b/shesmu-server/src/test/resources/compiler/bad-missing-action-param.shesmu
@@ -4,7 +4,7 @@ Input test;
 
 Define standard_fastq(string s)
   Where workflow == {"BamQC 2.7+", 3 }[0]
-  Where metatype == "chemical/fastq-gzip"
+  Where project == "blah"
   Where str_len(path) == file_size;
 
 Olive

--- a/shesmu-server/src/test/resources/run/group-by-rename2.shesmu
+++ b/shesmu-server/src/test/resources/run/group-by-rename2.shesmu
@@ -1,0 +1,7 @@
+Input test;
+
+Olive
+ Group
+    z = Max library_size
+  By v = workflow_version[0]
+ Run ok With ok = z == 307 && v == 1;


### PR DESCRIPTION
This addresses two main bugs:

- renaming discriminators (`By x = expr`) where not being type checked properly
- a `By` clause that named a variable that didn't exist would result in an NPE