### PR TITLE
Fix NPE when drawing diagrams with renaming By

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/description/VariableInformation.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/description/VariableInformation.java
@@ -10,7 +10,7 @@ import ca.on.oicr.gsi.shesmu.Imyhat;
 public class VariableInformation {
 
 	public enum Behaviour {
-		DEFINITION, OBSERVER, PASSTHROUGH
+		DEFINITION, DEFINITION_BY, OBSERVER, PASSTHROUGH
 	}
 
 	private final Behaviour behaviour;


### PR DESCRIPTION
For normal By clauses, it's assumed that the variable already exists. When
defining a new variable in a By, this is not the case. It needs to be handled
more like a definition, but be drawn like other By variables.