### PR TITLE
Don't throw an error when getting Prometheus throttler data

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/prometheus/PrometheusThrottler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/prometheus/PrometheusThrottler.java
@@ -47,7 +47,7 @@ public class PrometheusThrottler implements Throttler {
 			protected Stream<AlertDto> fetch(Instant lastUpdated) throws Exception {
 				final String url = configuration.map(Configuration::getAlertmanager).orElse(null);
 				if (url == null) {
-					throw new IllegalStateException();
+					return Stream.empty();
 				}
 				try (CloseableHttpResponse response = HTTP_CLIENT
 						.execute(new HttpGet(String.format("%s/api/v1/alerts", url)))) {


### PR DESCRIPTION
It's always in the bad state on startup, so it always throws, pointlessly.