### PR TITLE
Fix race condition in caches

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/util/cache/InvalidatableRecord.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/util/cache/InvalidatableRecord.java
@@ -30,12 +30,6 @@ public class InvalidatableRecord<V> implements Record<Optional<V>> {
     this.fetcher = fetcher;
     this.isValid = isValid;
     this.destructor = destructor;
-    try {
-      value = fetcher.update(lastUpdated);
-      lastUpdated = Instant.now();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/util/cache/MergingRecord.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/util/cache/MergingRecord.java
@@ -37,18 +37,7 @@ public final class MergingRecord<V, I> implements Record<Stream<V>> {
     this.owner = owner;
     this.fetcher = fetcher;
     this.getId = getId;
-    List<V> value;
-    try {
-      value =
-          Optional.of(fetcher.update(fetchTime))
-              .orElse(Stream.empty())
-              .collect(Collectors.toList());
-      fetchTime = Instant.now();
-    } catch (final Exception e) {
-      e.printStackTrace();
-      value = Collections.emptyList();
-    }
-    this.value = value;
+    this.value = Collections.emptyList();
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/util/cache/ReplacingRecord.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/util/cache/ReplacingRecord.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,18 +20,7 @@ public final class ReplacingRecord<V> implements Record<Stream<V>> {
   public ReplacingRecord(Owner owner, Updater<Stream<V>> fetcher) {
     this.owner = owner;
     this.fetcher = fetcher;
-    List<V> value;
-    try {
-      value =
-          Optional.ofNullable(fetcher.update(fetchTime))
-              .orElse(Stream.empty())
-              .collect(Collectors.toList());
-      fetchTime = Instant.now();
-    } catch (final Exception e) {
-      e.printStackTrace();
-      value = Collections.emptyList();
-    }
-    this.value = value;
+    this.value = Collections.emptyList();
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/util/cache/SimpleRecord.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/util/cache/SimpleRecord.java
@@ -19,15 +19,7 @@ public final class SimpleRecord<V> implements Record<Optional<V>> {
   public SimpleRecord(Owner owner, Updater<Optional<V>> fetcher) {
     this.owner = owner;
     this.fetcher = fetcher;
-    Optional<V> value;
-    try {
-      value = fetcher.update(fetchTime);
-      fetchTime = Instant.now();
-    } catch (final Exception e) {
-      e.printStackTrace();
-      value = Optional.empty();
-    }
-    this.value = value;
+    this.value = Optional.empty();
   }
 
   @Override


### PR DESCRIPTION
Caches were automatically prefilled, but this happens outside of the
`synchronized` method, so if the cache is accessed separately, the referesh
function can be entered simultaneously. This change avoids the race by not
filling the cache until it is requested.