### PR TITLE
Starvation and Pinery fixes

### DIFF
--- a/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/RunReport.java
+++ b/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/RunReport.java
@@ -314,7 +314,7 @@ public class RunReport extends JsonParameterisedAction {
   public static String printHexBinary(byte[] data) {
     final StringBuilder buffer = new StringBuilder();
     for (byte b : data) {
-      buffer.append(String.format("%0x", b));
+      buffer.append(String.format("%02x", b));
     }
     return buffer.toString();
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
@@ -118,7 +118,7 @@ public class ProgramNode {
   }
 
   public int timeout() {
-    AtomicInteger timeout = new AtomicInteger(20);
+    AtomicInteger timeout = new AtomicInteger(20 * 60);
     pragmas.forEach(pragma -> pragma.timeout(timeout));
     return timeout.get();
   }


### PR DESCRIPTION
Fixes three major problems:

- slow olives would starve the thread pool and the tasks meant to kill them
- change olive timeout to correct units
- move Pinery IUS provider method to a place where the annotation scanner will see it