### PR TITLE
Make sure that `Run` and `Alert` olives capture correctly

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -154,10 +154,17 @@ public class OliveNodeAlert extends OliveNodeWithClauses {
 
   @Override
   public void render(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+    final Set<String> captures = new HashSet<>();
+    ttl.collectFreeVariables(captures, Flavour::needsCapture);
+    labels.forEach(label -> label.collectFreeVariables(captures, Flavour::needsCapture));
+    annotations.forEach(
+        annotation -> annotation.collectFreeVariables(captures, Flavour::needsCapture));
     final OliveBuilder oliveBuilder = builder.buildRunOlive(line, column, signableNames);
     clauses().forEach(clause -> clause.render(builder, oliveBuilder, definitions));
     oliveBuilder.line(line);
-    final Renderer action = oliveBuilder.finish("Alert");
+    final Renderer action =
+        oliveBuilder.finish(
+            "Alert", oliveBuilder.loadableValues().filter(v -> captures.contains(v.name())));
     action.methodGen().visitCode();
     action.methodGen().visitLineNumber(line, action.methodGen().mark());
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
@@ -91,10 +91,15 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
 
   @Override
   public void render(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+    final Set<String> captures = new HashSet<>();
+    arguments.forEach(arg -> arg.collectFreeVariables(captures, Flavour::needsCapture));
     final OliveBuilder oliveBuilder = builder.buildRunOlive(line, column, signableNames);
     clauses().forEach(clause -> clause.render(builder, oliveBuilder, definitions));
     oliveBuilder.line(line);
-    final Renderer action = oliveBuilder.finish("Run " + actionName);
+    final Renderer action =
+        oliveBuilder.finish(
+            "Run " + actionName,
+            oliveBuilder.loadableValues().filter(v -> captures.contains(v.name())));
     action.methodGen().visitCode();
     action.methodGen().visitLineNumber(line, action.methodGen().mark());
     definition.initialize(action.methodGen());

--- a/shesmu-server/src/test/resources/run/arg-capture.shesmu
+++ b/shesmu-server/src/test/resources/run/arg-capture.shesmu
@@ -1,0 +1,5 @@
+Input test;
+
+foo = True;
+
+Olive Run ok With ok = foo;


### PR DESCRIPTION
Ensure that any local constants are captured by the `Consumer` that is used by the final `forEach`.