### PR TITLE
Replace `box` with `valueOf`

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeOptima.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeOptima.java
@@ -16,7 +16,7 @@ public final class CollectNodeOptima extends CollectNodeWithDefault {
 
   @Override
   protected void finishMethod(Renderer renderer) {
-    renderer.methodGen().box(selector.type().apply(TypeUtils.TO_ASM));
+    renderer.methodGen().valueOf(selector.type().apply(TypeUtils.TO_ASM));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeContains.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeContains.java
@@ -40,7 +40,7 @@ public class ExpressionNodeContains extends ExpressionNode {
     needle.render(renderer);
     renderer.mark(line());
 
-    renderer.methodGen().box(needle.type().apply(TypeUtils.TO_ASM));
+    renderer.methodGen().valueOf(needle.type().apply(TypeUtils.TO_ASM));
     renderer.methodGen().invokeInterface(A_SET_TYPE, METHOD_SET__CONTAINS);
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeList.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeList.java
@@ -47,7 +47,7 @@ public class ExpressionNodeList extends ExpressionNode {
         item -> {
           renderer.methodGen().dup();
           item.render(renderer);
-          renderer.methodGen().box(item.type().apply(TypeUtils.TO_ASM));
+          renderer.methodGen().valueOf(item.type().apply(TypeUtils.TO_ASM));
           renderer.methodGen().invokeInterface(A_SET_TYPE, METHOD_SET__ADD);
           renderer.methodGen().pop();
         });

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObject.java
@@ -57,7 +57,7 @@ public class ExpressionNodeObject extends ExpressionNode {
               renderer.methodGen().dup();
               renderer.methodGen().push(index.getAndIncrement());
               field.second().render(renderer);
-              renderer.methodGen().box(field.second().type().apply(TypeUtils.TO_ASM));
+              renderer.methodGen().valueOf(field.second().type().apply(TypeUtils.TO_ASM));
               renderer.methodGen().arrayStore(A_OBJECT_TYPE);
             });
     renderer.mark(line());

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTuple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTuple.java
@@ -47,7 +47,7 @@ public class ExpressionNodeTuple extends ExpressionNode {
       renderer.methodGen().dup();
       renderer.methodGen().push(index);
       items.get(index).render(renderer);
-      renderer.methodGen().box(items.get(index).type().apply(TypeUtils.TO_ASM));
+      renderer.methodGen().valueOf(items.get(index).type().apply(TypeUtils.TO_ASM));
       renderer.methodGen().arrayStore(A_OBJECT_TYPE);
     }
     renderer.mark(line());

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JavaStreamBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JavaStreamBuilder.java
@@ -475,7 +475,7 @@ public final class JavaStreamBuilder {
 
     finish();
     initial.accept(renderer);
-    renderer.methodGen().box(accumulatorType.apply(TypeUtils.TO_ASM));
+    renderer.methodGen().valueOf(accumulatorType.apply(TypeUtils.TO_ASM));
     renderer.methodGen().loadThis();
     Arrays.stream(capturedVariables).forEach(var -> var.accept(renderer));
     renderer.loadStream();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeSort.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeSort.java
@@ -10,7 +10,7 @@ public class ListNodeSort extends ListNodeWithExpression {
 
   @Override
   protected void finishMethod(Renderer renderer) {
-    renderer.methodGen().box(expression.type().apply(TypeUtils.TO_ASM));
+    renderer.methodGen().valueOf(expression.type().apply(TypeUtils.TO_ASM));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
@@ -130,7 +130,7 @@ public final class OliveClauseNodeDump extends OliveClauseNode implements Reject
       renderer.methodGen().dup();
       renderer.methodGen().push(it);
       columns.get(it).render(renderer);
-      renderer.methodGen().box(columns.get(it).type().apply(TypeUtils.TO_ASM));
+      renderer.methodGen().valueOf(columns.get(it).type().apply(TypeUtils.TO_ASM));
       renderer.methodGen().arrayStore(A_OBJECT_TYPE);
     }
     renderer.methodGen().invokeInterface(A_DUMPER_TYPE, DUMPER__WRITE);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
@@ -115,7 +115,7 @@ public class OliveClauseNodePick extends OliveClauseNode {
                 .toArray(LoadableValue[]::new));
     extractorMethod.methodGen().visitCode();
     extractor.render(extractorMethod);
-    extractorMethod.methodGen().box(extractor.type().apply(TypeUtils.TO_ASM));
+    extractorMethod.methodGen().valueOf(extractor.type().apply(TypeUtils.TO_ASM));
     extractorMethod.methodGen().returnValue();
     extractorMethod.methodGen().visitMaxs(0, 0);
     extractorMethod.methodGen().visitEnd();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RegroupVariablesBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RegroupVariablesBuilder.java
@@ -42,7 +42,7 @@ public final class RegroupVariablesBuilder implements Regrouper {
           .methodGen()
           .invokeVirtual(self, new Method(fieldName, A_SET_TYPE, new Type[] {}));
       loader.accept(collectRenderer);
-      collectRenderer.methodGen().box(valueType.apply(TypeUtils.TO_ASM));
+      collectRenderer.methodGen().valueOf(valueType.apply(TypeUtils.TO_ASM));
       collectRenderer.methodGen().invokeInterface(A_SET_TYPE, METHOD_SET__ADD);
       collectRenderer.methodGen().pop();
     }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
@@ -75,7 +75,7 @@ public abstract class ConstantDefinition implements Target {
       handle.push("value");
       handle.invokeConstructor(A_PACK_JSON_OBJECT_TYPE, PACK_JSON_OBJECT_CTOR);
       ConstantDefinition.this.load(handle);
-      handle.box(type.apply(TypeUtils.TO_ASM));
+      handle.valueOf(type.apply(TypeUtils.TO_ASM));
       handle.invokeVirtual(A_IMYHAT_TYPE, METHOD_IMYHAT__ACCEPT_OBJ);
       handle.visitInsn(Opcodes.RETURN);
       handle.visitMaxs(0, 0);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureVariableForDynamicSigner.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureVariableForDynamicSigner.java
@@ -46,7 +46,7 @@ public abstract class SignatureVariableForDynamicSigner extends SignatureDefinit
                 initialType,
                 new Method(target.name(), target.type().apply(TypeUtils.TO_ASM), new Type[] {}));
           }
-          method.box(target.type().apply(TypeUtils.TO_ASM));
+          method.valueOf(target.type().apply(TypeUtils.TO_ASM));
           method.invokeInterface(A_DYNAMIC_SIGNER_TYPE, METHOD_DYNAMIC_SIGNER__ADD_VARIABLE);
         });
     method.invokeInterface(A_DYNAMIC_SIGNER_TYPE, METHOD_DYNAMIC_SIGNER__FINISH);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/FunctionRunnerCompiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/FunctionRunnerCompiler.java
@@ -126,7 +126,7 @@ public final class FunctionRunnerCompiler extends BaseHotloadingCompiler {
               handle.unbox(type.second().apply(TypeUtils.TO_ASM));
             });
     function.render(handle);
-    handle.box(function.returnType().apply(TypeUtils.TO_ASM));
+    handle.valueOf(function.returnType().apply(TypeUtils.TO_ASM));
     handle.invokeVirtual(A_IMYHAT_TYPE, METHOD_IMYHAT__ACCEPT_OBJ);
     handle.visitInsn(Opcodes.RETURN);
     handle.visitMaxs(0, 0);


### PR DESCRIPTION
Both `box` and `valueOf` convert a primitive type to a wrapper type. `box` uses the constructor of the wrapper type, which is deprecated in Java 11. `valueOf` uses a static method of the wrapper type.