### PR TITLE
Allow removing pauses from dead olives

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -747,12 +747,16 @@ public final class ActionProcessor implements OliveServices, InputProvider {
     return false;
   }
 
+  public boolean isPaused(SourceLocation location) {
+    return pausedOlives.contains(location);
+  }
+
   public void pause(SourceLocation location) {
     pausedOlives.add(location);
   }
 
-  public boolean isPaused(SourceLocation location) {
-    return pausedOlives.contains(location);
+  public Stream<SourceLocation> pauses() {
+    return pausedOlives.stream();
   }
 
   public long purge(Filter... filters) {

--- a/shesmu-server/src/main/resources/main.css
+++ b/shesmu-server/src/main/resources/main.css
@@ -68,6 +68,11 @@ font-weight: bold;
 .state_unknown { border: 1px dashed #000; background-color: #fdd; }
 .state_waiting { border: 1px solid #f80; background-color: #fed; }
 
+.inset {
+padding: 0.5em;
+margin: 0.5em;
+}
+
 .action a {
 text-decoration: none;
 }

--- a/shesmu-server/src/main/resources/shesmu.js
+++ b/shesmu-server/src/main/resources/shesmu.js
@@ -1268,3 +1268,53 @@ export function pauseOlive(element, target) {
       element.className = "load";
     });
 }
+
+export function clearDeadPause(row, target, purgeFirst) {
+  const removePause = () => {
+    target.pause = false;
+    return fetch("/pauseolive", {
+      body: JSON.stringify(target),
+      method: "POST"
+    })
+      .then(response => {
+        if (response.ok) {
+          return Promise.resolve(response);
+        } else {
+          return Promise.reject(new Error("Failed to load"));
+        }
+      })
+      .then(response => response.json())
+      .then(response => {
+        if (!response) {
+          const tbody = row.parentNode;
+          tbody.removeChild(row);
+          if (tbody.childNodes.length == 1) {
+            const div = tbody.parentNode.parentNode;
+            div.parentNode.removeChild(div);
+          }
+        }
+      })
+      .catch(function(error) {});
+  };
+  if (purgeFirst) {
+    fetch("/purge", {
+      body: JSON.stringify([
+        {
+          type: "sourcelocation",
+          locations: [target]
+        }
+      ]),
+      method: "POST"
+    })
+      .then(response => {
+        if (response.ok) {
+          return Promise.resolve(response);
+        } else {
+          return Promise.reject(new Error("Failed to load"));
+        }
+      })
+      .then(removePause);
+  } else {
+    removePause();
+  }
+}


### PR DESCRIPTION
Once an olive has been updated or deleted, there might still be pauses
associated with it. This allows removing these pauses for which there is no
olive on the dashboard.