### PR TITLE
Allow doing string expansion for 10X barcodes

### DIFF
--- a/plugin-tsv/README.md
+++ b/plugin-tsv/README.md
@@ -32,6 +32,33 @@ epoch) depending on the type.
 A string set is a file, ending in `.set` that will be available to olives as a
 set of strings where each string is a line in a file.
 
+## String Expansions
+A string expansion is a TSV file, ending in `.strexpand`, that substitutes a
+string to multiple values or returns the input as a list. This was designed to
+cope with 10X barcodes: 10X symbolic barcodes need to be replaced by their set
+of real barcodes, but real barcodes should remain.
+
+    SI-GA-A1     GGTTTACT    CTAAACGG    TCGGCGTC    AACCGTAA
+    SI-GA-A2     TTTCATGA    ACGTCCCT    CGCATGTG    GAAGGAAC
+    SI-GA-A3     CAGTACTG    AGTAGTCT    GCAGTAGA    TTCCCGAC
+    SI-GA-A4     TATGATTC    CCCACAGT    ATGCTGAA    GGATGCCG
+    SI-GA-A5     CTAGGTGA    TCGTTCAG    AGCCAATT    GATACGCC
+    SI-GA-A6     CGCTATGT    GCTGTCCA    TTGAGATC    AAACCGAG
+    SI-GA-A7     ACAGAGGT    TATAGTTG    CGGTCCCA    GTCCTAAC
+    SI-GA-A8     GCATCTCC    TGTAAGGT    CTGCGATG    AACGTCAA
+    SI-GA-A9     TCTTAAAG    CGAGGCTC    GTCCTTCT    AAGACGGA
+    SI-GA-A10    GAAACCCT    TTTCTGTC    CCGTGTGA    AGCGAAAG
+    SI-GA-A11    GTCCGGTC    AAGATCAT    CCTGAAGG    TGATCTCA
+    SI-GA-A12    AGTGGAAC    GTCTCCTT    TCACATCA    CAGATGGG
+
+If this is placed in a file named `expand_chromium.strexpand`, then an olive
+can do `expand_chromium("SI-GA-A1")` to get back `["GGTTTACT", "CTAAACGG",
+"TCGGCGTC", "AACCGTAA"]` while `expand_chromium("ATTGCC")` will result in
+`["ATTGCC"]`.
+
+If a line has only one column (_i.e._, only a key), it will return an empty
+set. Blank lines and lines starting with # are ignored.
+
 ## TSV Dumper
 This allows writing values to a tab-separated file using a `Dump` clause. For
 set up, create a file ending in `.tsvdump` as follows:

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/StringExpandFile.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/StringExpandFile.java
@@ -1,0 +1,71 @@
+package ca.on.oicr.gsi.shesmu.tsv;
+
+import ca.on.oicr.gsi.shesmu.plugin.Definer;
+import ca.on.oicr.gsi.shesmu.plugin.PluginFile;
+import ca.on.oicr.gsi.shesmu.plugin.functions.ShesmuMethod;
+import ca.on.oicr.gsi.shesmu.plugin.functions.ShesmuParameter;
+import ca.on.oicr.gsi.status.SectionRenderer;
+import io.prometheus.client.Gauge;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class StringExpandFile extends PluginFile {
+
+  private static final Pattern TAB = Pattern.compile("\t");
+  private static final Gauge tableBad =
+      Gauge.build("shesmu_strexpand_lookup_bad", "A string expansion table is badly formed.")
+          .labelNames("fileName")
+          .register();
+  private final Definer definer;
+  private Map<String, Set<String>> expansions = Collections.emptyMap();
+  private boolean good;
+
+  public StringExpandFile(Path fileName, String instanceName, Definer<StringExpandFile> definer) {
+    super(fileName, instanceName);
+    this.definer = definer;
+  }
+
+  @Override
+  public void configuration(SectionRenderer renderer) {
+    renderer.line("Is valid?", good ? "Yes" : "No");
+  }
+
+  @ShesmuMethod(
+      name = "$",
+      type = "as",
+      description =
+          "Expand a string to a set of strings or a set containing only the input string.")
+  public Set<String> get(
+      @ShesmuParameter(
+              description =
+                  "The input string to find the in the table; if it does not exist in the table, it is returned as a list containing the input")
+          String input) {
+    return expansions.getOrDefault(input, Collections.singleton(input));
+  }
+
+  @Override
+  public Optional<Integer> update() {
+    good = false;
+    try (Stream<String> lines = Files.lines(fileName(), StandardCharsets.UTF_8)) {
+      expansions =
+          lines
+              .map(String::trim)
+              .filter(l -> !l.startsWith("#"))
+              .map(TAB::split)
+              .collect(
+                  Collectors.toMap(
+                      x -> x[0], x -> new TreeSet<>(Arrays.asList(x).subList(1, x.length))));
+      good = true;
+    } catch (final Exception e) {
+      good = false;
+      e.printStackTrace();
+    }
+    tableBad.labels(fileName().toString()).set(good ? 0 : 1);
+    return Optional.empty();
+  }
+}

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/StringExpandFileType.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/StringExpandFileType.java
@@ -1,0 +1,24 @@
+package ca.on.oicr.gsi.shesmu.tsv;
+
+import ca.on.oicr.gsi.shesmu.plugin.Definer;
+import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import org.kohsuke.MetaInfServices;
+
+/** Converts a TSV file into a series of string expansions */
+@MetaInfServices(PluginFileType.class)
+public class StringExpandFileType extends PluginFileType<StringExpandFile> {
+
+  static final String EXTENSION = ".strexpand";
+
+  public StringExpandFileType() {
+    super(MethodHandles.lookup(), StringExpandFile.class, EXTENSION);
+  }
+
+  @Override
+  public StringExpandFile create(
+      Path filePath, String instanceName, Definer<StringExpandFile> definer) {
+    return new StringExpandFile(filePath, instanceName, definer);
+  }
+}


### PR DESCRIPTION
There's a bug in the functions page that means this can't be tested with the UI. It's fixed in the histogram PR.
```
$ curl -d '{"name":"expand_index", "args": ["A"]}' localhost:8081/function
{"value":["A"]}
$ curl -d '{"name":"expand_index", "args": ["SI-NA-A9"]}' localhost:8081/function
{"value":["ACAACTTG","CTCCAACA","GAGTGCGT","TGTGTGAC"]}
```