### PR TITLE
Make TypeGuarantee more flexible and change Cell Ranger LIMS key

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CellRangerIUSEntry.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CellRangerIUSEntry.java
@@ -1,9 +1,6 @@
 package ca.on.oicr.gsi.shesmu.niassa;
 
 import ca.on.oicr.gsi.provenance.model.LimsKey;
-import ca.on.oicr.gsi.shesmu.plugin.Tuple;
-import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -18,19 +15,18 @@ final class CellRangerIUSEntry implements LimsKey {
   private final String sampleId;
   private final String version;
 
-  public CellRangerIUSEntry(Tuple t) {
-    final Tuple ius = (Tuple) t.get(0);
-    ius_1 = ((Long) ius.get(1)).intValue();
-    ius_2 = (String) ius.get(2);
+  public CellRangerIUSEntry(IusTriple ius, String libraryName, LimsKey limsKey, String groupId) {
+    ius_1 = ius.lane();
+    ius_2 = ius.barcode();
 
-    libraryName = (String) t.get(1);
-    final Tuple lims = (Tuple) t.get(2);
-    sampleId = (String) lims.get(0);
-    version = (String) lims.get(1);
-    provider = (String) lims.get(2);
+    this.libraryName = libraryName;
 
-    lastModified = ZonedDateTime.ofInstant((Instant) t.get(3), ZoneId.of("Z"));
-    groupId = (String) t.get(4);
+    sampleId = limsKey.getId();
+    version = limsKey.getVersion();
+    provider = limsKey.getProvider();
+    lastModified = limsKey.getLastModified();
+
+    this.groupId = groupId;
   }
 
   public String asLaneString(int swid) {

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CellRangerInputLimsCollection.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CellRangerInputLimsCollection.java
@@ -1,18 +1,16 @@
 package ca.on.oicr.gsi.shesmu.niassa;
 
 import ca.on.oicr.gsi.provenance.model.LimsKey;
-import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import java.util.*;
 import java.util.function.ToIntFunction;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class CellRangerInputLimsCollection implements InputLimsCollection {
   final List<CellRangerIUSEntry> limsKeys;
 
-  public CellRangerInputLimsCollection(Set<Tuple> value) {
-    limsKeys = value.stream().map(CellRangerIUSEntry::new).collect(Collectors.toList());
+  public CellRangerInputLimsCollection(List<CellRangerIUSEntry> value) {
+    limsKeys = value;
   }
 
   @Override

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/FilesInputFile.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/FilesInputFile.java
@@ -1,9 +1,6 @@
 package ca.on.oicr.gsi.shesmu.niassa;
 
 import ca.on.oicr.gsi.provenance.model.LimsKey;
-import ca.on.oicr.gsi.shesmu.plugin.Tuple;
-import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -16,16 +13,15 @@ public final class FilesInputFile implements LimsKey {
   private final int swid;
   private final String version;
 
-  public FilesInputFile(Tuple tuple) {
-    swid = Integer.parseUnsignedInt((String) tuple.get(0));
+  public FilesInputFile(String swid, LimsKey limsKey, boolean stale) {
+    this.swid = Integer.parseUnsignedInt(swid);
 
-    final Tuple lims = (Tuple) tuple.get(1);
-    sampleId = (String) lims.get(0);
-    version = (String) lims.get(1);
-    provider = (String) lims.get(2);
-    lastModified = ((Instant) lims.get(3)).atZone(ZoneId.of("Z"));
+    sampleId = limsKey.getId();
+    version = limsKey.getVersion();
+    provider = limsKey.getProvider();
+    lastModified = limsKey.getLastModified();
 
-    stale = (Boolean) tuple.get(2);
+    this.stale = stale;
   }
 
   @Override

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/FilesInputLimsCollection.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/FilesInputLimsCollection.java
@@ -1,22 +1,18 @@
 package ca.on.oicr.gsi.shesmu.niassa;
 
 import ca.on.oicr.gsi.provenance.model.LimsKey;
-import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.Set;
 import java.util.function.ToIntFunction;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class FilesInputLimsCollection implements InputLimsCollection {
   final List<FilesInputFile> filesInputFileInformation;
 
-  public FilesInputLimsCollection(Set<Tuple> value) {
-    filesInputFileInformation =
-        value.stream().map(FilesInputFile::new).collect(Collectors.toList());
+  public FilesInputLimsCollection(List<FilesInputFile> value) {
+    filesInputFileInformation = value;
   }
 
   @Override

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/InputLimsKeyType.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/InputLimsKeyType.java
@@ -1,7 +1,6 @@
 package ca.on.oicr.gsi.shesmu.niassa;
 
 import ca.on.oicr.gsi.shesmu.plugin.action.CustomActionParameter;
-import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.plugin.types.TypeGuarantee;
 import java.util.function.Function;
 
@@ -18,36 +17,51 @@ public enum InputLimsKeyType {
       CellRangerInputLimsCollection::new,
       TypeGuarantee.list(
           TypeGuarantee.tuple(
-              Imyhat.tuple(Imyhat.STRING, Imyhat.INTEGER, Imyhat.STRING), // IUS
-              Imyhat.STRING, // library name
-              Imyhat.tuple(Imyhat.STRING, Imyhat.STRING, Imyhat.STRING), // LIMS key
-              Imyhat.DATE, // last modified
-              Imyhat.STRING) // group id
+              CellRangerIUSEntry::new,
+              TypeGuarantee.tuple(
+                  IusTriple::new,
+                  TypeGuarantee.STRING,
+                  TypeGuarantee.LONG,
+                  TypeGuarantee.STRING), // IUS
+              TypeGuarantee.STRING, // library name
+              TypeGuarantee.tuple(
+                  SimpleLimsKey::new,
+                  TypeGuarantee.STRING,
+                  TypeGuarantee.STRING,
+                  TypeGuarantee.STRING,
+                  TypeGuarantee.DATE), // LIMS key
+              TypeGuarantee.STRING) // group id
           )),
   FILES(
       "inputs",
       FilesInputLimsCollection::new,
       TypeGuarantee.list(
           TypeGuarantee.tuple(
-              Imyhat.STRING, // SWID
-              Imyhat.tuple(Imyhat.STRING, Imyhat.STRING, Imyhat.STRING, Imyhat.DATE), // LIMS key
-              Imyhat.BOOLEAN))); // staleness
+              FilesInputFile::new,
+              TypeGuarantee.STRING, // SWID
+              TypeGuarantee.tuple(
+                  SimpleLimsKey::new,
+                  TypeGuarantee.STRING,
+                  TypeGuarantee.STRING,
+                  TypeGuarantee.STRING,
+                  TypeGuarantee.DATE), // LIMS key
+              TypeGuarantee.BOOLEAN))); // staleness
 
-  private final CustomActionParameter<WorkflowAction, ?> parameter;
+  private final CustomActionParameter<WorkflowAction> parameter;
 
   <T> InputLimsKeyType(
       String name, Function<T, InputLimsCollection> create, TypeGuarantee<T> type) {
     this.parameter =
-        new CustomActionParameter<WorkflowAction, T>(name, true, type) {
+        new CustomActionParameter<WorkflowAction>(name, true, type.type()) {
 
           @Override
-          public void store(WorkflowAction action, T value) {
-            action.limsKeyCollection(create.apply(value));
+          public void store(WorkflowAction action, Object value) {
+            action.limsKeyCollection(create.apply(type.unpack(value)));
           }
         };
   }
 
-  public final CustomActionParameter<WorkflowAction, ?> parameter() {
+  public final CustomActionParameter<WorkflowAction> parameter() {
     return parameter;
   }
 }

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/IusTriple.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/IusTriple.java
@@ -1,0 +1,29 @@
+package ca.on.oicr.gsi.shesmu.niassa;
+
+public class IusTriple {
+  private final String barcode;
+  private final int lane;
+  private final String run;
+
+  public IusTriple(String run, Long lane, String barcode) {
+    this(run, lane.intValue(), barcode);
+  }
+
+  public IusTriple(String run, int lane, String barcode) {
+    this.run = run;
+    this.lane = lane;
+    this.barcode = barcode;
+  }
+
+  public String barcode() {
+    return barcode;
+  }
+
+  public int lane() {
+    return lane;
+  }
+
+  public String run() {
+    return run;
+  }
+}

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/SimpleLimsKey.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/SimpleLimsKey.java
@@ -1,6 +1,8 @@
 package ca.on.oicr.gsi.shesmu.niassa;
 
 import ca.on.oicr.gsi.provenance.model.LimsKey;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
@@ -9,6 +11,14 @@ public class SimpleLimsKey implements LimsKey {
   private final ZonedDateTime lastModified;
   private final String provider;
   private final String version;
+
+  public SimpleLimsKey(String id, String version, String provider, Instant lastModified) {
+
+    this.id = id;
+    this.version = version;
+    this.provider = provider;
+    this.lastModified = ZonedDateTime.ofInstant(lastModified, ZoneId.of("Z"));
+  }
 
   public SimpleLimsKey(LimsKey original) {
     provider = original.getProvider();

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Definer.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Definer.java
@@ -7,6 +7,7 @@ import ca.on.oicr.gsi.shesmu.plugin.functions.VariadicFunction;
 import ca.on.oicr.gsi.shesmu.plugin.signature.DynamicSigner;
 import ca.on.oicr.gsi.shesmu.plugin.signature.StaticSigner;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.ReturnTypeGuarantee;
 import ca.on.oicr.gsi.shesmu.plugin.types.TypeGuarantee;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -40,7 +41,7 @@ public interface Definer<T> extends Supplier<T> {
       String description,
       Class<A> clazz,
       Supplier<A> supplier,
-      Stream<CustomActionParameter<A, ?>> parameters);
+      Stream<CustomActionParameter<A>> parameters);
 
   /**
    * Define a constant using a particular value
@@ -60,7 +61,8 @@ public interface Definer<T> extends Supplier<T> {
    * @param returnType the Shesmu type for the constant
    * @param value the current value of the object
    */
-  <R> void defineConstant(String name, String description, TypeGuarantee<R> returnType, R value);
+  <R> void defineConstant(
+      String name, String description, ReturnTypeGuarantee<R> returnType, R value);
 
   /**
    * Define a constant using a particular value
@@ -71,7 +73,7 @@ public interface Definer<T> extends Supplier<T> {
    * @param constant a callback to compute the current value of the constant
    */
   <R> void defineConstant(
-      String name, String description, TypeGuarantee<R> returnType, Supplier<R> constant);
+      String name, String description, ReturnTypeGuarantee<R> returnType, Supplier<R> constant);
 
   /**
    * Define a new signature format that looks at input objects
@@ -80,8 +82,8 @@ public interface Definer<T> extends Supplier<T> {
    * @param returnType the return type of the signature
    * @param signer a function to construct new signers
    */
-  <T> void defineDynamicSigner(
-      String name, TypeGuarantee<T> returnType, Supplier<? extends DynamicSigner<T>> signer);
+  <R> void defineDynamicSigner(
+      String name, ReturnTypeGuarantee<R> returnType, Supplier<? extends DynamicSigner<R>> signer);
 
   /**
    * Define a function taking many parameters
@@ -112,7 +114,7 @@ public interface Definer<T> extends Supplier<T> {
   <A, R> void defineFunction(
       String name,
       String description,
-      TypeGuarantee<R> returnType,
+      ReturnTypeGuarantee<R> returnType,
       String parameterName,
       TypeGuarantee<A> parameterType,
       Function<A, R> function);
@@ -132,7 +134,7 @@ public interface Definer<T> extends Supplier<T> {
   <A, B, R> void defineFunction(
       String name,
       String description,
-      TypeGuarantee<R> returnType,
+      ReturnTypeGuarantee<R> returnType,
       String parameter1Name,
       TypeGuarantee<A> parameter1Type,
       String parameter2Name,
@@ -147,6 +149,6 @@ public interface Definer<T> extends Supplier<T> {
    * @param returnType the return type of the signature
    * @param signer a function to construct new signers
    */
-  <T> void defineStaticSigner(
-      String name, TypeGuarantee<T> returnType, Supplier<? extends StaticSigner<T>> signer);
+  <R> void defineStaticSigner(
+      String name, ReturnTypeGuarantee<R> returnType, Supplier<? extends StaticSigner<R>> signer);
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/action/CustomActionParameter.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/action/CustomActionParameter.java
@@ -1,18 +1,13 @@
 package ca.on.oicr.gsi.shesmu.plugin.action;
 
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
-import ca.on.oicr.gsi.shesmu.plugin.types.TypeGuarantee;
 
 /** A definition for a parameter to an action */
-public abstract class CustomActionParameter<A extends Action, T> {
+public abstract class CustomActionParameter<A extends Action> {
 
   private final String name;
   private final boolean required;
   private final Imyhat type;
-
-  public CustomActionParameter(String name, boolean required, TypeGuarantee<T> type) {
-    this(name, required, type.type());
-  }
 
   public CustomActionParameter(String name, boolean required, Imyhat type) {
     super();
@@ -36,7 +31,7 @@ public abstract class CustomActionParameter<A extends Action, T> {
   }
 
   /** Store the value in an action */
-  public abstract void store(A action, T value);
+  public abstract void store(A action, Object value);
 
   /** The type of the parameter */
   public final Imyhat type() {

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/json/JsonParameter.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/json/JsonParameter.java
@@ -12,7 +12,7 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
  * property in that JSON object.
  */
 public final class JsonParameter<A extends JsonParameterisedAction>
-    extends CustomActionParameter<A, Object> {
+    extends CustomActionParameter<A> {
 
   /**
    * The name of the JSON field

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/ReturnTypeGuarantee.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/ReturnTypeGuarantee.java
@@ -1,0 +1,71 @@
+package ca.on.oicr.gsi.shesmu.plugin.types;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Set;
+
+/**
+ * Matches to make Java's type checking produce correct types in Shesmu
+ *
+ * <p>This class doesn't do anything per-se, it just allows Java type checker to produce a type that
+ * is compatible with a Shesmu {@link Imyhat} without much work on the part of the author
+ *
+ * @param <T> the Java type being exported to Shesmu
+ */
+public abstract class ReturnTypeGuarantee<T> {
+  public static final ReturnTypeGuarantee<Boolean> BOOLEAN =
+      new ReturnTypeGuarantee<Boolean>() {
+
+        @Override
+        public Imyhat type() {
+          return Imyhat.BOOLEAN;
+        }
+      };
+  public static final ReturnTypeGuarantee<Instant> DATE =
+      new ReturnTypeGuarantee<Instant>() {
+
+        @Override
+        public Imyhat type() {
+          return Imyhat.DATE;
+        }
+      };
+  public static final ReturnTypeGuarantee<Long> LONG =
+      new ReturnTypeGuarantee<Long>() {
+
+        @Override
+        public Imyhat type() {
+          return Imyhat.INTEGER;
+        }
+      };
+  public static final ReturnTypeGuarantee<Path> PATH =
+      new ReturnTypeGuarantee<Path>() {
+
+        @Override
+        public Imyhat type() {
+          return Imyhat.PATH;
+        }
+      };
+  public static final ReturnTypeGuarantee<String> STRING =
+      new ReturnTypeGuarantee<String>() {
+
+        @Override
+        public Imyhat type() {
+          return Imyhat.STRING;
+        }
+      };
+
+  public static <T> ReturnTypeGuarantee<Set<T>> list(ReturnTypeGuarantee<T> inner) {
+    final Imyhat listType = inner.type().asList();
+    return new ReturnTypeGuarantee<Set<T>>() {
+
+      @Override
+      public Imyhat type() {
+        return listType;
+      }
+    };
+  }
+
+  private ReturnTypeGuarantee() {}
+
+  public abstract Imyhat type();
+}

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/TypeGuarantee.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/TypeGuarantee.java
@@ -3,32 +3,185 @@ package ca.on.oicr.gsi.shesmu.plugin.types;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Matches to make Java's type checking produce correct types in Shesmu
  *
- * <p>This class doesn't do anything per-se, it just allows Java type checker to produce a type that
- * is compatible with a Shesmu {@link Imyhat} without much work on the part of the author
- *
  * @param <T> the Java type being exported to Shesmu
  */
 public interface TypeGuarantee<T> {
-  TypeGuarantee<Boolean> BOOLEAN = () -> Imyhat.BOOLEAN;
-  TypeGuarantee<Instant> DATE = () -> Imyhat.DATE;
-  TypeGuarantee<Long> LONG = () -> Imyhat.INTEGER;
-  TypeGuarantee<Path> PATH = () -> Imyhat.PATH;
-  TypeGuarantee<String> STRING = () -> Imyhat.STRING;
+  interface Pack2<T, U, R> {
+    R pack(T first, U second);
+  }
 
-  static <T> TypeGuarantee<Set<T>> list(TypeGuarantee<T> inner) {
+  interface Pack3<T, U, V, R> {
+    R pack(T first, U second, V third);
+  }
+
+  interface Pack4<T, U, V, W, R> {
+    R pack(T first, U second, V third, W fourth);
+  }
+
+  static <T> TypeGuarantee<List<T>> list(TypeGuarantee<T> inner) {
     final Imyhat listType = inner.type().asList();
-    return () -> listType;
+    return new TypeGuarantee<List<T>>() {
+      @Override
+      public Imyhat type() {
+        return listType;
+      }
+
+      @Override
+      public List<T> unpack(Object object) {
+        return ((Set<?>) object).stream().map(inner::unpack).collect(Collectors.toList());
+      }
+    };
+  }
+
+  static <R, T, U> TypeGuarantee<R> tuple(
+      Pack2<? super T, ? super U, ? extends R> convert,
+      TypeGuarantee<T> first,
+      TypeGuarantee<U> second) {
+    final Imyhat tupleType = Imyhat.tuple(first.type(), second.type());
+    return new TypeGuarantee<R>() {
+      @Override
+      public Imyhat type() {
+        return tupleType;
+      }
+
+      @Override
+      public R unpack(Object object) {
+        final Tuple input = (Tuple) object;
+        return convert.pack(first.unpack(input.get(0)), second.unpack(input.get(1)));
+      }
+    };
+  }
+
+  static <R, T, U, V> TypeGuarantee<R> tuple(
+      Pack3<? super T, ? super U, ? super V, ? extends R> convert,
+      TypeGuarantee<T> first,
+      TypeGuarantee<U> second,
+      TypeGuarantee<V> third) {
+    final Imyhat tupleType = Imyhat.tuple(first.type(), second.type(), third.type());
+    return new TypeGuarantee<R>() {
+      @Override
+      public Imyhat type() {
+        return tupleType;
+      }
+
+      @Override
+      public R unpack(Object object) {
+        final Tuple input = (Tuple) object;
+        return convert.pack(
+            first.unpack(input.get(0)), second.unpack(input.get(1)), third.unpack(input.get(2)));
+      }
+    };
+  }
+
+  static <R, T, U, V, W> TypeGuarantee<R> tuple(
+      Pack4<? super T, ? super U, ? super V, ? super W, ? extends R> convert,
+      TypeGuarantee<T> first,
+      TypeGuarantee<U> second,
+      TypeGuarantee<V> third,
+      TypeGuarantee<W> fourth) {
+    final Imyhat tupleType = Imyhat.tuple(first.type(), second.type(), third.type());
+    return new TypeGuarantee<R>() {
+      @Override
+      public Imyhat type() {
+        return tupleType;
+      }
+
+      @Override
+      public R unpack(Object object) {
+        final Tuple input = (Tuple) object;
+        return convert.pack(
+            first.unpack(input.get(0)),
+            second.unpack(input.get(1)),
+            third.unpack(input.get(2)),
+            fourth.unpack(input.get(3)));
+      }
+    };
   }
 
   static TypeGuarantee<Tuple> tuple(Imyhat... elements) {
     final Imyhat tupleType = Imyhat.tuple(elements);
-    return () -> tupleType;
+    return new TypeGuarantee<Tuple>() {
+      @Override
+      public Imyhat type() {
+        return tupleType;
+      }
+
+      @Override
+      public Tuple unpack(Object object) {
+        return (Tuple) object;
+      }
+    };
   }
 
+  TypeGuarantee<Boolean> BOOLEAN =
+      new TypeGuarantee<Boolean>() {
+        @Override
+        public Imyhat type() {
+          return Imyhat.BOOLEAN;
+        }
+
+        @Override
+        public Boolean unpack(Object object) {
+          return (Boolean) object;
+        }
+      };
+  TypeGuarantee<Instant> DATE =
+      new TypeGuarantee<Instant>() {
+        @Override
+        public Imyhat type() {
+          return Imyhat.DATE;
+        }
+
+        @Override
+        public Instant unpack(Object object) {
+          return (Instant) object;
+        }
+      };
+  TypeGuarantee<Long> LONG =
+      new TypeGuarantee<Long>() {
+        @Override
+        public Imyhat type() {
+          return Imyhat.INTEGER;
+        }
+
+        @Override
+        public Long unpack(Object object) {
+          return (Long) object;
+        }
+      };
+  TypeGuarantee<Path> PATH =
+      new TypeGuarantee<Path>() {
+        @Override
+        public Imyhat type() {
+          return Imyhat.PATH;
+        }
+
+        @Override
+        public Path unpack(Object object) {
+          return (Path) object;
+        }
+      };
+  TypeGuarantee<String> STRING =
+      new TypeGuarantee<String>() {
+        @Override
+        public Imyhat type() {
+          return Imyhat.STRING;
+        }
+
+        @Override
+        public String unpack(Object object) {
+          return (String) object;
+        }
+      };
+
   Imyhat type();
+
+  T unpack(Object object);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/InvokeDynamicActionParameterDescriptor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/InvokeDynamicActionParameterDescriptor.java
@@ -62,7 +62,7 @@ public final class InvokeDynamicActionParameterDescriptor implements ActionParam
               .findVirtual(
                   CustomActionParameter.class,
                   "store",
-                  MethodType.methodType(Void.TYPE, Action.class, Object.class));
+                  MethodType.methodType(void.class, Action.class, Object.class));
     } catch (NoSuchMethodException | IllegalAccessException e) {
       e.printStackTrace();
     }
@@ -188,7 +188,7 @@ public final class InvokeDynamicActionParameterDescriptor implements ActionParam
   private final Imyhat type;
 
   public InvokeDynamicActionParameterDescriptor(
-      String actionName, CustomActionParameter<?, ?> parameter) {
+      String actionName, CustomActionParameter<?> parameter) {
     this(
         actionName,
         parameter.name(),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
@@ -27,6 +27,7 @@ import ca.on.oicr.gsi.shesmu.plugin.signature.DynamicSigner;
 import ca.on.oicr.gsi.shesmu.plugin.signature.ShesmuSigner;
 import ca.on.oicr.gsi.shesmu.plugin.signature.StaticSigner;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.ReturnTypeGuarantee;
 import ca.on.oicr.gsi.shesmu.plugin.types.TypeGuarantee;
 import ca.on.oicr.gsi.shesmu.runtime.InputProvider;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
@@ -337,7 +338,7 @@ public final class PluginManager
           String description,
           Class<A> clazz,
           Supplier<A> supplier,
-          Stream<CustomActionParameter<A, ?>> parameters) {
+          Stream<CustomActionParameter<A>> parameters) {
         final MethodHandle handle =
             MH_SUPPLIER_GET.bindTo(supplier).asType(MethodType.methodType(clazz));
         actions.put(
@@ -367,7 +368,7 @@ public final class PluginManager
 
       @Override
       public <R> void defineConstant(
-          String name, String description, TypeGuarantee<R> type, R value) {
+          String name, String description, ReturnTypeGuarantee<R> type, R value) {
         constants.put(
             name,
             new ArbitraryConstantDefinition(
@@ -380,7 +381,10 @@ public final class PluginManager
 
       @Override
       public <R> void defineConstant(
-          String name, String description, TypeGuarantee<R> returnType, Supplier<R> constant) {
+          String name,
+          String description,
+          ReturnTypeGuarantee<R> returnType,
+          Supplier<R> constant) {
 
         constants.put(
             name,
@@ -394,7 +398,9 @@ public final class PluginManager
 
       @Override
       public <R> void defineDynamicSigner(
-          String name, TypeGuarantee<R> returnType, Supplier<? extends DynamicSigner<R>> signer) {
+          String name,
+          ReturnTypeGuarantee<R> returnType,
+          Supplier<? extends DynamicSigner<R>> signer) {
         signatures.put(
             name,
             new ArbitraryDynamicSignatureDefintion(
@@ -426,7 +432,7 @@ public final class PluginManager
       public <A, R> void defineFunction(
           String name,
           String description,
-          TypeGuarantee<R> returnType,
+          ReturnTypeGuarantee<R> returnType,
           String parameterDescription,
           TypeGuarantee<A> parameterType,
           Function<A, R> function) {
@@ -451,7 +457,7 @@ public final class PluginManager
       public <A, B, R> void defineFunction(
           String name,
           String description,
-          TypeGuarantee<R> returnType,
+          ReturnTypeGuarantee<R> returnType,
           String parameter1Description,
           TypeGuarantee<A> parameter1Type,
           String parameter2Description,
@@ -525,7 +531,9 @@ public final class PluginManager
 
       @Override
       public <R> void defineStaticSigner(
-          String name, TypeGuarantee<R> returnType, Supplier<? extends StaticSigner<R>> signer) {
+          String name,
+          ReturnTypeGuarantee<R> returnType,
+          Supplier<? extends StaticSigner<R>> signer) {
         signatures.put(
             name,
             new ArbitraryStaticSignatureDefintion(


### PR DESCRIPTION
Redesign the `TypeGuarantee` class to make it easier to handle deeply nested tuples (as most of the Niassa interfaces require).

This also changes Cell Ranger to use a LIMS key compatible with #272 