### PR TITLE
Attempt to perturb SFTP bug out of existence

### DIFF
--- a/plugin-sftp/pom.xml
+++ b/plugin-sftp/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.hierynomus</groupId>
       <artifactId>sshj</artifactId>
-      <version>0.24.0</version>
+      <version>0.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SftpServer.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SftpServer.java
@@ -125,7 +125,7 @@ public class SftpServer extends JsonPluginFile<Configuration> {
   }
 
   @Override
-  public void configuration(SectionRenderer renderer) throws XMLStreamException {
+  public synchronized void configuration(SectionRenderer renderer) throws XMLStreamException {
     renderer.line("Filename", fileName().toString());
     configuration.ifPresent(
         configuration -> {
@@ -184,6 +184,8 @@ public class SftpServer extends JsonPluginFile<Configuration> {
           updateMtime.accept(Instant.now());
           return new Pair<>(ActionState.SUCCEEDED, false);
         } else {
+          // The SFTP connection might be in an error state, so reset it to be sure.
+          connection.invalidate();
           throw sftpe;
         }
       }


### PR DESCRIPTION
There is a bug where the SFTP connection will get itself in a bad state and
throw errors when doing things. This is might due to some kind of
multi-threaded inteference, so ensure everything that access the connection is
synchronised. Upgrade the library in case it's a bug that's been fixed.
Finally, force the connection to be reset if it throws an exception, though
exceptions are thrown for "normal" errors (_e.g._ permissions problems).