### PR TITLE
Allow plugins to throttle an olive based

### DIFF
--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
@@ -35,8 +35,6 @@ import javax.xml.stream.XMLStreamException;
 
 public class JiraConnection extends JsonPluginFile<Configuration> {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-
   private class IssueCache extends ValueCache<Stream<Issue>> {
     public IssueCache(Path fileName) {
       super("jira-issues " + fileName.toString(), 15, MergingRecord.by(Issue::getId));
@@ -85,7 +83,6 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
   }
 
   protected static final String EXTENSION = ".jira";
-
   private static final Set<String> FIELDS =
       Stream.of(
               IssueFieldId.SUMMARY_FIELD,
@@ -98,9 +95,8 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
               IssueFieldId.LABELS_FIELD)
           .map(x -> x.id)
           .collect(Collectors.toSet());
-
   private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("YYYY-MM-dd HH:mm");
-
+  private static final ObjectMapper MAPPER = new ObjectMapper();
   private JiraRestClient client;
 
   private List<String> closeActions = Collections.emptyList();
@@ -197,6 +193,11 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
   @ShesmuAction(description = "Closes any JIRA tickets with a matching summary. Defined in {file}.")
   public ResolveTicket resolve_ticket_$() {
     return new ResolveTicket(definer);
+  }
+
+  @Override
+  public Stream<String> services() {
+    return Stream.of("jira", projectKey);
   }
 
   @ShesmuAction(description = "Opens (or re-opens) a JIRA ticket. Defined in {file}.")

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusProvenancePluginType.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusProvenancePluginType.java
@@ -4,12 +4,11 @@ import ca.on.oicr.gsi.cerberus.client.CerberusClient;
 import ca.on.oicr.gsi.provenance.model.FileProvenance;
 import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.kohsuke.MetaInfServices;
-
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
+import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(PluginFileType.class)
 public class CerberusProvenancePluginType extends BaseProvenancePluginType<CerberusClient> {
@@ -42,5 +41,10 @@ public class CerberusProvenancePluginType extends BaseProvenancePluginType<Cerbe
   @Override
   protected Stream<? extends FileProvenance> fetch(CerberusClient client) {
     return client.getFileProvenance(PROVENANCE_FILTER).stream();
+  }
+
+  @Override
+  public Stream<String> services() {
+    return Stream.of("cerberus");
   }
 }

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/PipeDevProvenancePluginType.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/PipeDevProvenancePluginType.java
@@ -3,14 +3,13 @@ package ca.on.oicr.gsi.shesmu.cerberus;
 import ca.on.oicr.gsi.provenance.DefaultProvenanceClient;
 import ca.on.oicr.gsi.provenance.ProviderLoader;
 import ca.on.oicr.gsi.provenance.model.FileProvenance;
+import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
+import ca.on.oicr.gsi.shesmu.plugin.Utils;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
-
-import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
-import ca.on.oicr.gsi.shesmu.plugin.Utils;
 import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(PluginFileType.class)
@@ -38,5 +37,10 @@ public class PipeDevProvenancePluginType extends BaseProvenancePluginType<Defaul
   @Override
   protected Stream<? extends FileProvenance> fetch(DefaultProvenanceClient client) {
     return Utils.stream(client.getFileProvenance(PROVENANCE_FILTER));
+  }
+
+  @Override
+  public Stream<String> services() {
+    return Stream.of("pinery", "niassa");
   }
 }

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
@@ -245,13 +245,13 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
         return client.getSampleProject().all().stream();
       }
     }
-  };
+  }
 
   private static Optional<String> limsAttr(
       SampleProvenance sp, String key, Consumer<String> isBad, boolean required) {
     return IUSUtils.singleton(
         sp.getSampleAttributes().get(key), reason -> isBad.accept(key + ":" + reason), required);
-  }
+  };
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final Gauge badSetMap =
@@ -295,6 +295,11 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
     final Optional<String> url = config.map(PineryConfiguration::getUrl);
     renderer.link("URL", url.orElse("about:blank"), url.orElse("Unknown"));
     renderer.line("Provider", config.map(PineryConfiguration::getProvider).orElse("Unknown"));
+  }
+
+  @Override
+  public Stream<String> services() {
+    return Stream.of("pinery");
   }
 
   @ShesmuInputSource

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFile.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFile.java
@@ -46,6 +46,17 @@ public abstract class PluginFile {
     return false;
   }
 
+  /**
+   * Stop olives that use functions and constants from this plugin when a service is throttled.
+   *
+   * <p>This does not affect actions!
+   *
+   * @return the services names needed by this plugin
+   */
+  public Stream<String> services() {
+    return Stream.empty();
+  }
+
   /** Called when a configuration file is first read. */
   public void start() {
     update();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
@@ -122,6 +122,11 @@ public final class Check extends Compiler {
                           GeneratorAdapter method, Type streamType, Stream<Target> variables) {
                         throw new UnsupportedOperationException();
                       }
+
+                      @Override
+                      public Path filename() {
+                        return null;
+                      }
                     }) //
             .collect(Collectors.toList());
     final NameLoader<InputFormatDefinition> inputFormats =

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNode.java
@@ -7,6 +7,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.Parser.Rule;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -158,6 +159,8 @@ public abstract class CollectNode {
 
   /** Add all free variable names to the set provided. */
   public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   public int column() {
     return column;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeConcatenate.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeConcatenate.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.ListNode.Ordering;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -84,6 +85,12 @@ public class CollectNodeConcatenate extends CollectNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     getter.collectFreeVariables(names, predicate);
     delimiter.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    getter.collectPlugins(pluginFileNames);
+    delimiter.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeCount.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -17,6 +18,11 @@ public class CollectNodeCount extends CollectNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     // No free variables.
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    // Do nothing.
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeList.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeList.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -45,6 +46,11 @@ public class CollectNodeList extends CollectNode {
     if (remove) {
       names.remove(name);
     }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeMatches.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeMatches.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -48,6 +49,11 @@ public final class CollectNodeMatches extends CollectNode {
     if (removeName) {
       names.remove(name);
     }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    selector.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodePartitionCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodePartitionCount.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.PartitionCount;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -52,6 +53,11 @@ public class CollectNodePartitionCount extends CollectNode {
     if (remove) {
       names.remove(name);
     }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeReduce.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeReduce.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -80,6 +81,12 @@ public class CollectNodeReduce extends CollectNode {
     if (removeAccumulator) {
       names.remove(accumulatorName);
     }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    initial.collectPlugins(pluginFileNames);
+    reducer.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeWithDefault.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeWithDefault.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -57,6 +58,12 @@ public abstract class CollectNodeWithDefault extends CollectNode {
     if (remove) {
       names.remove(name);
     }
+  }
+
+  @Override
+  public final void collectPlugins(Set<Path> pluginFileNames) {
+    alternative.collectPlugins(pluginFileNames);
+    selector.collectPlugins(pluginFileNames);
   }
 
   protected abstract void finishMethod(Renderer renderer);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNode.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -46,6 +47,8 @@ public abstract class DiscriminatorNode implements DefinedTarget {
 
   /** Add all free variable names to the set provided. */
   public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   @Override
   public int column() {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeRename.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeRename.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -24,6 +25,11 @@ public class DiscriminatorNodeRename extends DiscriminatorNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeSimple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeSimple.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.InputVariable;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -29,6 +30,11 @@ public class DiscriminatorNodeSimple extends DiscriminatorNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     // Nothing to do.
 
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    // Do nothing.
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -6,6 +6,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -629,6 +630,8 @@ public abstract class ExpressionNode {
 
   /** Add all free variable names to the set provided. */
   public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   public int column() {
     return column;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeBinary.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeBinary.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -37,6 +38,12 @@ public final class ExpressionNodeBinary extends ExpressionNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     left.collectFreeVariables(names, predicate);
     right.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    left.collectPlugins(pluginFileNames);
+    right.collectPlugins(pluginFileNames);
   }
 
   public ExpressionNode left() {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeBoolean.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeBoolean.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -19,6 +20,11 @@ public final class ExpressionNodeBoolean extends ExpressionNode {
 
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    // Do nothing.
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
     // Do nothing.
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeComparison.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeComparison.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -27,6 +28,12 @@ public class ExpressionNodeComparison extends ExpressionNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     left.collectFreeVariables(names, predicate);
     right.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    left.collectPlugins(pluginFileNames);
+    right.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeContains.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeContains.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -32,6 +33,12 @@ public class ExpressionNodeContains extends ExpressionNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     needle.collectFreeVariables(names, predicate);
     haystack.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    haystack.collectPlugins(pluginFileNames);
+    needle.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeDate.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeDate.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Set;
@@ -32,6 +33,11 @@ public class ExpressionNodeDate extends ExpressionNode {
 
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    // Do nothing.
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
     // Do nothing.
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFor.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.ListNode.Ordering;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -38,6 +39,13 @@ public class ExpressionNodeFor extends ExpressionNode {
     source.collectFreeVariables(names, predicate);
     collector.collectFreeVariables(names, predicate);
     transforms.forEach(t -> t.collectFreeVariables(names, predicate));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    source.collectPlugins(pluginFileNames);
+    transforms.forEach(transform -> transform.collectPlugins(pluginFileNames));
+    collector.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFunctionCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFunctionCall.java
@@ -74,6 +74,14 @@ public class ExpressionNodeFunctionCall extends ExpressionNode {
   }
 
   @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    if (function.filename() != null) {
+      pluginFileNames.add(function.filename());
+    }
+    arguments.forEach(arg -> arg.collectPlugins(pluginFileNames));
+  }
+
+  @Override
   public void render(Renderer renderer) {
     function.renderStart(renderer.methodGen());
     arguments.forEach(argument -> argument.render(renderer));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeInteger.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeInteger.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -19,6 +20,11 @@ public class ExpressionNodeInteger extends ExpressionNode {
 
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    // Do nothing.
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
     // Do nothing.
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeList.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeList.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -36,6 +37,11 @@ public class ExpressionNodeList extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     items.forEach(item -> item.collectFreeVariables(names, predicate));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    items.forEach(item -> item.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeLogicalNot.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeLogicalNot.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -19,6 +20,11 @@ public class ExpressionNodeLogicalNot extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     inner.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    inner.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeNegate.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeNegate.java
@@ -5,6 +5,7 @@ import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -22,6 +23,11 @@ public class ExpressionNodeNegate extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     inner.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    inner.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObject.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,11 @@ public class ExpressionNodeObject extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     fields.forEach(field -> field.second().collectFreeVariables(names, predicate));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    fields.forEach(field -> field.second().collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObjectGet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObjectGet.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -36,6 +37,11 @@ public class ExpressionNodeObjectGet extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodePathLiteral.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodePathLiteral.java
@@ -35,6 +35,11 @@ public class ExpressionNodePathLiteral extends ExpressionNode {
   }
 
   @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    // Do nothing.
+  }
+
+  @Override
   public void render(Renderer renderer) {
     renderer.methodGen().push(path);
     renderer.methodGen().getStatic(A_RUNTIME_SUPPORT, "EMPTY", A_STRING_ARRAY_TYPE);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeRegex.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeRegex.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -36,6 +37,11 @@ public class ExpressionNodeRegex extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeString.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeString.java
@@ -5,6 +5,7 @@ import static org.objectweb.asm.Type.VOID_TYPE;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -35,6 +36,11 @@ public class ExpressionNodeString extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     parts.forEach(part -> part.collectFreeVariables(names, predicate));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    parts.forEach(part -> part.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeSwitch.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeSwitch.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -44,6 +45,17 @@ public class ExpressionNodeSwitch extends ExpressionNode {
         item -> {
           item.first().collectFreeVariables(names, predicate);
           item.second().collectFreeVariables(names, predicate);
+        });
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    test.collectPlugins(pluginFileNames);
+    alternative.collectPlugins(pluginFileNames);
+    cases.forEach(
+        item -> {
+          item.first().collectPlugins(pluginFileNames);
+          item.second().collectPlugins(pluginFileNames);
         });
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTernaryIf.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTernaryIf.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -33,6 +34,13 @@ public class ExpressionNodeTernaryIf extends ExpressionNode {
     testExpression.collectFreeVariables(names, predicate);
     trueExpression.collectFreeVariables(names, predicate);
     falseExpression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    testExpression.collectPlugins(pluginFileNames);
+    trueExpression.collectPlugins(pluginFileNames);
+    falseExpression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTuple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTuple.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -33,6 +34,11 @@ public class ExpressionNodeTuple extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     items.forEach(item -> item.collectFreeVariables(names, predicate));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    items.forEach(item -> item.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTupleGet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTupleGet.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -34,6 +35,11 @@ public class ExpressionNodeTupleGet extends ExpressionNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
@@ -1,10 +1,12 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.ConstantDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputVariable;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -46,6 +48,22 @@ public class ExpressionNodeVariable extends ExpressionNode {
     if (predicate.test(target.flavour())) {
       names.add(name);
     }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    if (target instanceof ConstantDefinition) {
+      final ConstantDefinition constant = (ConstantDefinition) target;
+      if (constant.filename() != null) {
+        pluginFileNames.add(constant.filename());
+      }
+    } else if (target instanceof SignatureDefinition) {
+      final SignatureDefinition signature = (SignatureDefinition) target;
+      if (signature.filename() != null) {
+        pluginFileNames.add(signature.filename());
+      }
+    }
+    // There are many other targets that aren't from plugins, so ignore them
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.Parser.Rule;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -145,6 +146,8 @@ public abstract class GroupNode implements DefinedTarget {
   }
 
   public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   @Override
   public final int column() {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeCount.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -26,6 +27,11 @@ public final class GroupNodeCount extends GroupNode {
   @Override
   public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
     // No free variables
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    // Do nothing.
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFirst.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFirst.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -28,6 +29,11 @@ public final class GroupNodeFirst extends GroupNodeDefaultable {
   @Override
   public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(freeVariables, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeList.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeList.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -28,6 +29,11 @@ public final class GroupNodeList extends GroupNode {
   @Override
   public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(freeVariables, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeMatches.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeMatches.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -26,6 +27,11 @@ public class GroupNodeMatches extends GroupNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     condition.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    condition.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeOptima.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeOptima.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -26,6 +27,11 @@ public class GroupNodeOptima extends GroupNodeDefaultable {
   @Override
   public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(freeVariables, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodePartitionCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodePartitionCount.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.PartitionCount;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -24,6 +25,11 @@ public class GroupNodePartitionCount extends GroupNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     condition.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    condition.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeSingle.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeSingle.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -24,6 +25,11 @@ public final class GroupNodeSingle extends GroupNode {
   @Override
   public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(freeVariables, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWhere.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWhere.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -24,6 +25,11 @@ public class GroupNodeWhere extends GroupNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     condition.collectFreeVariables(names, predicate);
     sink.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    condition.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWithDefault.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWithDefault.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -25,6 +26,12 @@ public class GroupNodeWithDefault extends GroupNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     initial.collectFreeVariables(names, predicate);
     inner.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    initial.collectPlugins(pluginFileNames);
+    initial.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNode.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -41,6 +42,10 @@ public class LetArgumentNode implements Target {
 
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNode.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -132,6 +133,8 @@ public abstract class ListNode {
   }
 
   public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   public int column() {
     return column;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeBaseRange.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeBaseRange.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -23,6 +24,11 @@ public abstract class ListNodeBaseRange extends ListNode {
   @Override
   public final void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public final void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeDistinct.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeDistinct.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -20,6 +21,11 @@ public class ListNodeDistinct extends ListNode {
 
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    // Do nothing.
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
     // Do nothing.
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeFlatten.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -42,6 +43,12 @@ public class ListNodeFlatten extends ListNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     source.collectFreeVariables(names, predicate);
     transforms.forEach(t -> t.collectFreeVariables(names, predicate));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    source.collectPlugins(pluginFileNames);
+    transforms.forEach(t -> t.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeReverse.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeReverse.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -20,6 +21,11 @@ public class ListNodeReverse extends ListNode {
 
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    // Do nothing.
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
     // Do nothing.
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeSubsample.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeSubsample.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.SampleNode.Consumption;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -26,6 +27,11 @@ public class ListNodeSubsample extends ListNode {
   @Override
   public final void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     samplers.forEach(sampler -> sampler.collectFreeVariables(names, predicate));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    samplers.forEach(sampler -> sampler.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeWithExpression.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeWithExpression.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -54,6 +55,11 @@ public abstract class ListNodeWithExpression extends ListNode {
     if (remove) {
       names.remove(name);
     }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   protected abstract void finishMethod(Renderer renderer);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MonitorArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MonitorArgumentNode.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -47,6 +48,10 @@ public final class MonitorArgumentNode {
 
   public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(freeVariables, predicate);
+  }
+
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNode.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -56,6 +57,8 @@ public abstract class OliveArgumentNode {
 
   public abstract void collectFreeVariables(
       Set<String> freeVariables, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   /** Produce an error if the type of the expression is not as required */
   public abstract boolean ensureType(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNodeOptional.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNodeOptional.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -29,6 +30,12 @@ public final class OliveArgumentNodeOptional extends OliveArgumentNode {
   public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(freeVariables, predicate);
     condition.collectFreeVariables(freeVariables, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+    condition.collectPlugins(pluginFileNames);
   }
 
   /** Produce an error if the type of the expression is not as required */

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNodeProvided.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNodeProvided.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionParameterDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -25,11 +26,12 @@ public final class OliveArgumentNodeProvided extends OliveArgumentNode {
     expression.collectFreeVariables(freeVariables, predicate);
   }
 
-  /**
-   * Produce an error if the type of the expression is not as required
-   *
-   * @param targetType the required type
-   */
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+  }
+
+  /** Produce an error if the type of the expression is not as required */
   @Override
   public boolean ensureType(ActionParameterDefinition definition, Consumer<String> errorHandler) {
     this.definition = definition;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
@@ -6,6 +6,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.*;
 import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -339,6 +340,8 @@ public abstract class OliveClauseNode {
     }
     return input.raise("Expected olive clause.");
   }
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   public abstract int column();
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
@@ -7,6 +7,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,6 +31,11 @@ public class OliveClauseNodeCall extends OliveClauseNode {
     this.column = column;
     this.name = name;
     this.arguments = arguments;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    arguments.forEach(arg -> arg.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
@@ -11,6 +11,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.dumper.Dumper;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -49,6 +50,11 @@ public final class OliveClauseNodeDump extends OliveClauseNode implements Reject
   @Override
   public void collectFreeVariables(Set<String> freeVariables) {
     columns.forEach(column -> column.collectFreeVariables(freeVariables, Flavour::needsCapture));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    columns.forEach(column -> column.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -77,6 +78,12 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
     this.column = column;
     this.children = children;
     this.discriminators = discriminators;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    discriminators.forEach(discriminator -> discriminator.collectPlugins(pluginFileNames));
+    children.forEach(child -> child.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
@@ -13,6 +13,7 @@ import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperKind;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperOutput;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collectors;
@@ -64,6 +65,13 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
     this.rawInputExpressions = inputExpressions;
     this.children = children;
     this.discriminators = discriminators;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    children.forEach(child -> child.collectPlugins(pluginFileNames));
+    discriminators.forEach(discrminator -> discrminator.collectPlugins(pluginFileNames));
+    inputExpressions.forEach(expression -> expression.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -39,6 +40,12 @@ public class OliveClauseNodeJoin extends OliveClauseNode {
     this.format = format;
     this.outerKey = outerKey;
     this.innerKey = innerKey;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    outerKey.collectPlugins(pluginFileNames);
+    innerKey.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
@@ -8,6 +8,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -47,6 +48,13 @@ public final class OliveClauseNodeLeftJoin extends OliveClauseNode {
     this.outerKey = outerKey;
     this.innerKey = innerKey;
     this.children = children;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    outerKey.collectPlugins(pluginFileNames);
+    innerKey.collectPlugins(pluginFileNames);
+    children.forEach(child -> child.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,11 @@ public class OliveClauseNodeLet extends OliveClauseNode {
     this.line = line;
     this.column = column;
     this.arguments = arguments;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    arguments.forEach(arg -> arg.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
@@ -11,6 +11,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import io.prometheus.client.Gauge;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,11 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
   @Override
   public void collectFreeVariables(Set<String> freeVariables) {
     labels.forEach(arg -> arg.collectFreeVariables(freeVariables, Flavour::needsCapture));
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    labels.forEach(label -> label.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,11 @@ public class OliveClauseNodePick extends OliveClauseNode {
     this.max = max;
     this.extractor = extractor;
     this.discriminators = discriminators;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    extractor.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,12 @@ public class OliveClauseNodeReject extends OliveClauseNode {
     this.column = column;
     this.expression = expression;
     this.handlers = handlers;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+    handlers.forEach(handler -> handler.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,11 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
     this.line = line;
     this.column = column;
     this.expression = expression;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNode.java
@@ -8,6 +8,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveTable;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.ActionGenerator;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -243,6 +244,8 @@ public abstract class OliveNode {
       Predicate<String> isDefined,
       Consumer<FunctionDefinition> defineFunctions,
       Consumer<String> errorHandler);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   public abstract Stream<OliveTable> dashboard();
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveTable;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -123,6 +124,13 @@ public class OliveNodeAlert extends OliveNodeWithClauses {
       Map<String, Target> definedConstants,
       Consumer<String> errorHandler) {
     return true;
+  }
+
+  @Override
+  public void collectPluginsExtra(Set<Path> pluginFileNames) {
+    labels.forEach(arg -> arg.collectPlugins(pluginFileNames));
+    annotations.forEach(arg -> arg.collectPlugins(pluginFileNames));
+    ttl.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeConstant.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeConstant.java
@@ -6,6 +6,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.description.OliveTable;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,6 +66,11 @@ public final class OliveNodeConstant extends OliveNode implements Target {
       Consumer<FunctionDefinition> defineFunctions,
       Consumer<String> errorHandler) {
     return true;
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    body.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
@@ -7,9 +7,11 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.OliveTable;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -65,6 +67,11 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses {
     }
     definedOlives.put(name, this);
     return true;
+  }
+
+  @Override
+  public void collectPluginsExtra(Set<Path> pluginFileNames) {
+    // Nothing to do.
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeFunction.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeFunction.java
@@ -80,6 +80,11 @@ public class OliveNodeFunction extends OliveNode implements FunctionDefinition {
   }
 
   @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    body.collectPlugins(pluginFileNames);
+  }
+
+  @Override
   public Stream<OliveTable> dashboard() {
     return Stream.empty();
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
@@ -11,6 +11,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.action.Action;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,11 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
     arguments
         .stream()
         .forEach(arg -> arg.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals));
+  }
+
+  @Override
+  public void collectPluginsExtra(Set<Path> pluginFileNames) {
+    arguments.forEach(arg -> arg.collectPlugins(pluginFileNames));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeWithClauses.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeWithClauses.java
@@ -6,6 +6,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.ActionGenerator;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,6 +55,14 @@ public abstract class OliveNodeWithClauses extends OliveNode {
       Consumer<String> errorHandler) {
     return true;
   }
+
+  @Override
+  public final void collectPlugins(Set<Path> pluginFileNames) {
+    clauses.forEach(clause -> clause.collectPlugins(pluginFileNames));
+    collectPluginsExtra(pluginFileNames);
+  }
+
+  public abstract void collectPluginsExtra(Set<Path> pluginFileNames);
 
   /**
    * Generate bytecode for this stanza into the {@link ActionGenerator#run(Consumer,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
@@ -10,12 +10,9 @@ import ca.on.oicr.gsi.shesmu.compiler.description.FileTable;
 import ca.on.oicr.gsi.shesmu.plugin.ErrorConsumer;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -107,6 +104,10 @@ public class ProgramNode {
 
   public InputFormatDefinition inputFormatDefinition() {
     return inputFormatDefinition;
+  }
+
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    olives.forEach(olive -> olive.collectPlugins(pluginFileNames));
   }
 
   /** Generate bytecode for this definition */

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RejectNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RejectNode.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -15,6 +16,8 @@ import java.util.stream.Stream;
 
 public interface RejectNode {
   void collectFreeVariables(Set<String> freeVariables);
+
+  void collectPlugins(Set<Path> pluginFileNames);
 
   void render(RootBuilder builder, Renderer renderer);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNode.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -63,6 +64,8 @@ public abstract class SampleNode implements JavaStreamBuilder.RenderSubsampler {
   public SampleNode() {}
 
   public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   /**
    * Check if there will be items left to subsample

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNodeFixed.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNodeFixed.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.subsample.Fixed;
 import ca.on.oicr.gsi.shesmu.runtime.subsample.Subsampler;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -29,6 +30,11 @@ public class SampleNodeFixed extends SampleNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNodeFixedWithCondition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNodeFixedWithCondition.java
@@ -8,6 +8,7 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.subsample.FixedWithConditions;
 import ca.on.oicr.gsi.shesmu.runtime.subsample.Subsampler;
 import java.lang.invoke.LambdaMetafactory;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -79,6 +80,12 @@ public class SampleNodeFixedWithCondition extends SampleNode {
     if (remove) {
       names.remove(name);
     }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    limitExpression.collectPlugins(pluginFileNames);
+    conditionExpression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNodeSquish.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNodeSquish.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.subsample.Squish;
 import ca.on.oicr.gsi.shesmu.runtime.subsample.Subsampler;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -29,6 +30,11 @@ public class SampleNodeSquish extends SampleNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNode.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -86,6 +87,8 @@ public abstract class SourceNode {
    * @param names
    */
   public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   public int column() {
     return column;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeRange.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeRange.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.ListNode.Ordering;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -34,6 +35,12 @@ public class SourceNodeRange extends SourceNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     start.collectFreeVariables(names, predicate);
     end.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    start.collectPlugins(pluginFileNames);
+    end.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeSet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeSet.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.ListNode.Ordering;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -30,6 +31,11 @@ public class SourceNodeSet extends SourceNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeSplit.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeSplit.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.ListNode.Ordering;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -32,6 +33,11 @@ public class SourceNodeSplit extends SourceNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNode.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -92,6 +93,8 @@ public abstract class StringNode {
   }
 
   public abstract void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate);
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   public abstract boolean isPassive();
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNodeDate.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNodeDate.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -40,6 +41,11 @@ public class StringNodeDate extends StringNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNodeExpression.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNodeExpression.java
@@ -6,6 +6,7 @@ import static org.objectweb.asm.Type.LONG_TYPE;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -36,6 +37,11 @@ public class StringNodeExpression extends StringNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNodeInteger.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNodeInteger.java
@@ -7,6 +7,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -41,6 +42,11 @@ public class StringNodeInteger extends StringNode {
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNodeLiteral.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNodeLiteral.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -26,6 +27,11 @@ public class StringNodeLiteral extends StringNode {
 
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    // Do nothing.
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
     // Do nothing.
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureDefinition.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler.definitions;
 import ca.on.oicr.gsi.shesmu.compiler.Target;
 import ca.on.oicr.gsi.shesmu.compiler.TypeUtils;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -43,6 +44,8 @@ public abstract class SignatureDefinition implements Target {
    * @param variables the input variables to capture
    */
   public abstract void build(GeneratorAdapter method, Type streamType, Stream<Target> variables);
+
+  public abstract Path filename();
 
   @Override
   public final Flavour flavour() {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
@@ -318,6 +318,11 @@ public final class StandardDefinitions implements DefinitionRepository {
         new SignatureVariableForDynamicSigner("json_signature", Imyhat.STRING) {
 
           @Override
+          public Path filename() {
+            return null;
+          }
+
+          @Override
           protected void newInstance(GeneratorAdapter method) {
             method.newInstance(A_JSON_SIGNATURE_TYPE);
             method.dup();
@@ -325,6 +330,11 @@ public final class StandardDefinitions implements DefinitionRepository {
           }
         },
         new SignatureVariableForDynamicSigner("sha1_signature", Imyhat.STRING) {
+
+          @Override
+          public Path filename() {
+            return null;
+          }
 
           @Override
           protected void newInstance(GeneratorAdapter method) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignableCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignableCount.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureStorage;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.kohsuke.MetaInfServices;
 import org.objectweb.asm.Type;
@@ -19,5 +20,10 @@ public final class SignableCount extends SignatureDefinition {
   @Override
   public void build(GeneratorAdapter method, Type initialType, Stream<Target> variables) {
     method.push(variables.count());
+  }
+
+  @Override
+  public Path filename() {
+    return null;
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignatureCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignatureCount.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureStorage;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.kohsuke.MetaInfServices;
 import org.objectweb.asm.Type;
@@ -19,5 +20,10 @@ public final class SignatureCount extends SignatureDefinition {
   @Override
   public void build(GeneratorAdapter method, Type initialType, Stream<Target> variables) {
     method.push(variables.count());
+  }
+
+  @Override
+  public Path filename() {
+    return null;
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignatureNames.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignatureNames.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureStorage;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 import org.kohsuke.MetaInfServices;
@@ -37,5 +38,10 @@ public final class SignatureNames extends SignatureDefinition {
           method.invokeVirtual(A_TREE_SET_TYPE, METHOD_TREE_SET__ADD);
           method.pop();
         });
+  }
+
+  @Override
+  public Path filename() {
+    return null;
   }
 }


### PR DESCRIPTION
This allows plugins to specify services that their functions, constants, and
signatures require and then causes the olive to check if any of those are
throttled before it starts execution.

- Adds a method get the services for each plugin file
- Includes file name information in signature definitions
- Add services to our existing plugins
- Threads plugin information through the parse tree
- Adds a guard at the start of the olive that converts plugin file names to services and checks them