### PR TITLE
Switch LIMS key from tuple to object

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/BaseProvenancePluginType.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/BaseProvenancePluginType.java
@@ -113,12 +113,12 @@ public abstract class BaseProvenancePluginType<C extends AutoCloseable>
                           fp.getLastModified().toInstant(),
                           new Tuple(
                               limsKey.map(LimsKey::getId).orElse(""),
-                              limsKey.map(LimsKey::getVersion).orElse(""),
                               limsKey.map(LimsKey::getProvider).orElse(""),
                               limsKey
                                   .map(LimsKey::getLastModified)
                                   .map(ZonedDateTime::toInstant)
-                                  .orElse(Instant.EPOCH)),
+                                  .orElse(Instant.EPOCH),
+                              limsKey.map(LimsKey::getVersion).orElse("")),
                           fp.getLastModified().toInstant(),
                           fp.getStatus() == FileProvenance.Status.STALE,
                           "file_provenance");

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusAnalysisProvenanceValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusAnalysisProvenanceValue.java
@@ -61,9 +61,9 @@ public final class CerberusAnalysisProvenanceValue {
     lims =
         new Tuple(
             limsKey.getLimsKey().getId(),
-            limsKey.getLimsKey().getVersion(),
-            limsKey.getLimsKey().getVersion(),
-            limsKey.getLimsKey().getLastModified().toInstant());
+            limsKey.getLimsKey().getProvider(),
+            limsKey.getLimsKey().getLastModified().toInstant(),
+            limsKey.getLimsKey().getVersion());
     md5 = provenance.getFileMd5sum();
     metatype = provenance.getFileMetaType();
     name = provenance.getWorkflowRunName();
@@ -102,7 +102,7 @@ public final class CerberusAnalysisProvenanceValue {
     return iusAttributes;
   }
 
-  @ShesmuVariable(type = "t4sssd")
+  @ShesmuVariable(type = "o4id$sprovider$stime$dversion$s")
   public Tuple lims() {
     return lims;
   }

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusFileProvenanceValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusFileProvenanceValue.java
@@ -234,7 +234,7 @@ public final class CerberusFileProvenanceValue {
     return library_type;
   }
 
-  @ShesmuVariable(type = "t4sssd")
+  @ShesmuVariable(type = "o4id$sprovider$stime$dversion$s")
   public Tuple lims() {
     return lims;
   }

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/InputLimsKeyType.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/InputLimsKeyType.java
@@ -24,12 +24,16 @@ public enum InputLimsKeyType {
                       BamMergeEntry::new,
                       TypeGuarantee.STRING, // SWID
                       TypeGuarantee.STRING, // File name
-                      TypeGuarantee.tuple(
+                      TypeGuarantee.object(
                           SimpleLimsKey::new,
+                          "id",
                           TypeGuarantee.STRING,
+                          "provider",
                           TypeGuarantee.STRING,
-                          TypeGuarantee.STRING,
-                          TypeGuarantee.DATE), // LIMS key
+                          "time",
+                          TypeGuarantee.DATE,
+                          "version",
+                          TypeGuarantee.STRING), // LIMS key
                       TypeGuarantee.BOOLEAN // staleness
                       ))))),
   BCL2FASTQ(
@@ -39,23 +43,31 @@ public enum InputLimsKeyType {
           TypeGuarantee.tuple(
               Bcl2FastqLaneEntry::new,
               TypeGuarantee.LONG, // lane number
-              TypeGuarantee.tuple(
+              TypeGuarantee.object(
                   SimpleLimsKey::new,
+                  "id",
                   TypeGuarantee.STRING,
+                  "provider",
                   TypeGuarantee.STRING,
-                  TypeGuarantee.STRING,
-                  TypeGuarantee.DATE), // lane LIMS key
+                  "time",
+                  TypeGuarantee.DATE,
+                  "version",
+                  TypeGuarantee.STRING), // lane LIMS key
               TypeGuarantee.list(
                   TypeGuarantee.tuple(
                       Bcl2FastqSampleEntry::new,
                       TypeGuarantee.STRING, // sample barcode
                       TypeGuarantee.STRING, // sample library name
-                      TypeGuarantee.tuple(
+                      TypeGuarantee.object(
                           SimpleLimsKey::new,
+                          "id",
                           TypeGuarantee.STRING,
+                          "provider",
                           TypeGuarantee.STRING,
-                          TypeGuarantee.STRING,
-                          TypeGuarantee.DATE), // sample LIMS key
+                          "time",
+                          TypeGuarantee.DATE,
+                          "version",
+                          TypeGuarantee.STRING), // sample LIMS key
                       TypeGuarantee.STRING) // sample group id
                   )))),
   CELL_RANGER(
@@ -70,12 +82,16 @@ public enum InputLimsKeyType {
                   TypeGuarantee.LONG,
                   TypeGuarantee.STRING), // IUS
               TypeGuarantee.STRING, // library name
-              TypeGuarantee.tuple(
+              TypeGuarantee.object(
                   SimpleLimsKey::new,
+                  "id",
                   TypeGuarantee.STRING,
+                  "provider",
                   TypeGuarantee.STRING,
-                  TypeGuarantee.STRING,
-                  TypeGuarantee.DATE), // LIMS key
+                  "time",
+                  TypeGuarantee.DATE,
+                  "version",
+                  TypeGuarantee.STRING), // LIMS key
               TypeGuarantee.STRING) // group id
           )),
 
@@ -86,12 +102,16 @@ public enum InputLimsKeyType {
           TypeGuarantee.tuple(
               FilesInputFile::new,
               TypeGuarantee.STRING, // SWID
-              TypeGuarantee.tuple(
+              TypeGuarantee.object(
                   SimpleLimsKey::new,
+                  "id",
                   TypeGuarantee.STRING,
+                  "provider",
                   TypeGuarantee.STRING,
-                  TypeGuarantee.STRING,
-                  TypeGuarantee.DATE), // LIMS key
+                  "time",
+                  TypeGuarantee.DATE,
+                  "version",
+                  TypeGuarantee.STRING), // LIMS key
               TypeGuarantee.BOOLEAN))); // staleness
 
   private final CustomActionParameter<WorkflowAction> parameter;

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/SimpleLimsKey.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/SimpleLimsKey.java
@@ -12,7 +12,7 @@ public class SimpleLimsKey implements LimsKey {
   private final String provider;
   private final String version;
 
-  public SimpleLimsKey(String id, String version, String provider, Instant lastModified) {
+  public SimpleLimsKey(String id, String provider, Instant lastModified, String version) {
 
     this.id = id;
     this.version = version;

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryIUSValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryIUSValue.java
@@ -195,7 +195,7 @@ public final class PineryIUSValue {
     return library_type;
   }
 
-  @ShesmuVariable(type = "t4sssd")
+  @ShesmuVariable(type = "o4id$sprovider$stime$dversion$s")
   public Tuple lims() {
     return lims;
   }

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
@@ -144,7 +144,7 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
                         "",
                         lastModified,
                         new Tuple(
-                            lp.getLaneProvenanceId(), lp.getVersion(), provider, lastModified),
+                            lp.getLaneProvenanceId(), provider, lastModified, lp.getVersion()),
                         lp.getCreatedDate() == null
                             ? Instant.EPOCH
                             : lp.getCreatedDate().toInstant(),
@@ -211,7 +211,7 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
                         limsAttr(sp, "geo_prep_kit", badSetInRecord::add, false).orElse(""),
                         lastModified,
                         new Tuple(
-                            sp.getSampleProvenanceId(), sp.getVersion(), provider, lastModified),
+                            sp.getSampleProvenanceId(), provider, lastModified, sp.getVersion()),
                         sp.getCreatedDate() == null
                             ? Instant.EPOCH
                             : sp.getCreatedDate().toInstant(),

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/TypeGuarantee.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/TypeGuarantee.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.plugin.types;
 
+import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -7,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Matches to make Java's type checking produce correct types in Shesmu
@@ -37,6 +39,104 @@ public abstract class TypeGuarantee<T> extends GenericTypeGuarantee<T> {
       @Override
       public List<T> unpack(Object object) {
         return ((Set<?>) object).stream().map(inner::unpack).collect(Collectors.toList());
+      }
+    };
+  }
+
+  public static <R, T, U> TypeGuarantee<R> object(
+      Pack2<? super T, ? super U, ? extends R> convert,
+      String firstName,
+      TypeGuarantee<T> first,
+      String secondName,
+      TypeGuarantee<U> second) {
+    final Imyhat tupleType =
+        new Imyhat.ObjectImyhat(
+            Stream.of(new Pair<>(firstName, first.type()), new Pair<>(secondName, second.type())));
+    if (firstName.compareTo(secondName) >= 0) {
+      throw new IllegalArgumentException("Object properties must be alphabetically ordered.");
+    }
+    return new TypeGuarantee<R>() {
+      @Override
+      public Imyhat type() {
+        return tupleType;
+      }
+
+      @Override
+      public R unpack(Object object) {
+        final Tuple input = (Tuple) object;
+        return convert.pack(first.unpack(input.get(0)), second.unpack(input.get(1)));
+      }
+    };
+  }
+
+  public static <R, T, U, V> TypeGuarantee<R> object(
+      Pack3<? super T, ? super U, ? super V, ? extends R> convert,
+      String firstName,
+      TypeGuarantee<T> first,
+      String secondName,
+      TypeGuarantee<U> second,
+      String thirdName,
+      TypeGuarantee<V> third) {
+    final Imyhat tupleType =
+        new Imyhat.ObjectImyhat(
+            Stream.of(
+                new Pair<>(firstName, first.type()),
+                new Pair<>(secondName, second.type()),
+                new Pair<>(thirdName, third.type())));
+    if (firstName.compareTo(secondName) >= 0 || secondName.compareTo(thirdName) >= 0) {
+      throw new IllegalArgumentException("Object properties must be alphabetically ordered.");
+    }
+    return new TypeGuarantee<R>() {
+      @Override
+      public Imyhat type() {
+        return tupleType;
+      }
+
+      @Override
+      public R unpack(Object object) {
+        final Tuple input = (Tuple) object;
+        return convert.pack(
+            first.unpack(input.get(0)), second.unpack(input.get(1)), third.unpack(input.get(2)));
+      }
+    };
+  }
+
+  public static <R, T, U, V, W> TypeGuarantee<R> object(
+      Pack4<? super T, ? super U, ? super V, ? super W, ? extends R> convert,
+      String firstName,
+      TypeGuarantee<T> first,
+      String secondName,
+      TypeGuarantee<U> second,
+      String thirdName,
+      TypeGuarantee<V> third,
+      String fourthName,
+      TypeGuarantee<W> fourth) {
+    final Imyhat tupleType =
+        new Imyhat.ObjectImyhat(
+            Stream.of(
+                new Pair<>(firstName, first.type()),
+                new Pair<>(secondName, second.type()),
+                new Pair<>(thirdName, third.type()),
+                new Pair<>(fourthName, fourth.type())));
+    if (firstName.compareTo(secondName) >= 0
+        || secondName.compareTo(thirdName) >= 0
+        || thirdName.compareTo(fourthName) >= 0) {
+      throw new IllegalArgumentException("Object properties must be alphabetically ordered.");
+    }
+    return new TypeGuarantee<R>() {
+      @Override
+      public Imyhat type() {
+        return tupleType;
+      }
+
+      @Override
+      public R unpack(Object object) {
+        final Tuple input = (Tuple) object;
+        return convert.pack(
+            first.unpack(input.get(0)),
+            second.unpack(input.get(1)),
+            third.unpack(input.get(2)),
+            fourth.unpack(input.get(3)));
       }
     };
   }


### PR DESCRIPTION
This changes the LIMS key format to something less confusing. Currently, only the 10X olive uses this and it passes it from the provider to the workflow action, so this should not require any changes on the olive side.