### PR TITLE
Allow empty lists

### DIFF
--- a/implementation.md
+++ b/implementation.md
@@ -106,16 +106,17 @@ for Shesmu's lists, which are Java's `Set` underneath. Shesmu's tuples are
 erased to `Object` values. Although some of these JVM types may be null, Shesmu
 olives cannot handle null values.
 
-| Name      | JVM Type                      | Syntax                   | Signature  |
-|---        |---                            |---                       |---         |
-| Integer   | `long` / `J`                  | `integer`                | `i`	      |
-| Float     | `double` / `D`                | `float`                  | `f`	      |
-| String    | `java.lang.String`            | `string`                 | `s`	      |
-| Boolean   | `boolean` / `z`               | `boolean`                | `b`	      |
-| Date      | `java.time.Instant`           | `date`                   | `d`        |
-| List      | `java.lang.Set`               | `[`_inner_`]`            | `a`_inner_ |
-| Tuple     | `ca.on.oicr.gsi.shesmu.Tuple` | `{`_t1_`,`_t2_`,` ...`}` | `t` _n_ _t1_ _t2_ Where _n_ is the number of elements in the tuple. |
-| Object    | `ca.on.oicr.gsi.shesmu.Tuple` | `{`_f1_` = `_t1_`,`_f2_` = `_t2_`,` ...`}` | `o` _n_ _f1_`$`_t1_ _f2_`$`_t2_ Where _n_ is the number of elements in the object. Fields must be sorted alphabetically. |
+| Name       | JVM Type                      | Syntax                   | Signature  |
+|---         |---                            |---                       |---         |
+| Integer    | `long` / `J`                  | `integer`                | `i`        |
+| Float      | `double` / `D`                | `float`                  | `f`        |
+| String     | `java.lang.String`            | `string`                 | `s`        |
+| Boolean    | `boolean` / `z`               | `boolean`                | `b`        |
+| Date       | `java.time.Instant`           | `date`                   | `d`        |
+| List       | `java.lang.Set`               | `[`_inner_`]`            | `a`_inner_ |
+| Empty List | `java.lang.Set`               | `[]`                     | `A`        |
+| Tuple      | `ca.on.oicr.gsi.shesmu.Tuple` | `{`_t1_`,`_t2_`,` ...`}` | `t` _n_ _t1_ _t2_ Where _n_ is the number of elements in the tuple. |
+| Object     | `ca.on.oicr.gsi.shesmu.Tuple` | `{`_f1_` = `_t1_`,`_f2_` = `_t2_`,` ...`}` | `o` _n_ _f1_`$`_t1_ _f2_`$`_t2_ Where _n_ is the number of elements in the object. Fields must be sorted alphabetically. |
 
 The ASM bytecode generation library has a class `Type` that describes JVM
 types. A `Type` object can be constructed either by knowing the JVM name for a

--- a/language.md
+++ b/language.md
@@ -472,6 +472,7 @@ machine-to-machine communication.
 | Boolean    | `boolean`                                          | `b`	       |
 | Date       | `date`                                             | `d`        |
 | List       | `[`_inner_`]`                                      | `a`_inner_ |
+| Empty List | `[]`                                               | `A`        |
 | Tuple      | `{`_t1_`,`_t2_`,` ...`}`                           | `t` _n_ _t1_ _t2_ Where _n_ is the number of elements in the tuple. |
 | NamedTuple | `{`_field1_` = `_t1_`,`_field2_` = `_t2_`,` ...`}` | `o` _n_ _field1_`$`_t1_ _field2_`$`_t2_ Where _n_ is the number of elements in the tuple. |
 | Path       | `path`                                             | `p`        |

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeReduce.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeReduce.java
@@ -20,6 +20,7 @@ public class CollectNodeReduce extends CollectNode {
   private final ExpressionNode initial;
 
   private final ExpressionNode reducer;
+  Imyhat resultType = Imyhat.BAD;
   Imyhat type;
 
   public CollectNodeReduce(
@@ -96,7 +97,7 @@ public class CollectNodeReduce extends CollectNode {
 
   @Override
   public Imyhat type() {
-    return initial.type();
+    return resultType;
   }
 
   @Override
@@ -113,6 +114,8 @@ public class CollectNodeReduce extends CollectNode {
                 "%d:%d: Reducer produces type %s, but initial expression is %s.",
                 line(), column(), reducer.type().name(), initial.type().name()));
         ok = false;
+      } else {
+        resultType = reducer.type().unify(initial.type());
       }
     }
     return ok;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeWithDefault.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeWithDefault.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public abstract class CollectNodeWithDefault extends CollectNode {
   protected final ExpressionNode alternative;
   private List<String> definedNames;
+  private Imyhat returnType = Imyhat.BAD;
   protected final ExpressionNode selector;
   private final String syntax;
   private Imyhat type;
@@ -102,14 +103,14 @@ public abstract class CollectNodeWithDefault extends CollectNode {
 
   @Override
   public final Imyhat type() {
-    return alternative.type();
+    return returnType;
   }
 
   @Override
   public final boolean typeCheck(Imyhat incoming, Consumer<String> errorHandler) {
     type = incoming;
     if (selector.typeCheck(errorHandler) & alternative.typeCheck(errorHandler)) {
-      final Imyhat returnType = returnType(incoming, selector.type());
+      returnType = returnType(incoming, selector.type());
       if (returnType.isSame(alternative.type())) {
         return typeCheckExtra(errorHandler);
       } else {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -507,7 +507,7 @@ public abstract class ExpressionNode {
           final AtomicReference<List<ExpressionNode>> items = new AtomicReference<>();
           final Parser result =
               p.whitespace()
-                  .list(items::set, (cp, co) -> parse(cp.whitespace(), co).whitespace(), ',')
+                  .listEmpty(items::set, (cp, co) -> parse(cp.whitespace(), co).whitespace(), ',')
                   .whitespace()
                   .symbol("]")
                   .whitespace();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeSwitch.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeSwitch.java
@@ -24,6 +24,7 @@ public class ExpressionNodeSwitch extends ExpressionNode {
   private final List<Pair<ExpressionNode, ExpressionNode>> cases;
 
   private final ExpressionNode test;
+  private Imyhat type = Imyhat.BAD;
 
   public ExpressionNodeSwitch(
       int line,
@@ -126,7 +127,7 @@ public class ExpressionNodeSwitch extends ExpressionNode {
 
   @Override
   public Imyhat type() {
-    return alternative.type();
+    return type;
   }
 
   @Override
@@ -141,6 +142,7 @@ public class ExpressionNodeSwitch extends ExpressionNode {
                 == cases.size()
             & alternative.typeCheck(errorHandler);
     if (ok) {
+      type = alternative.type();
       ok =
           cases
                   .stream()
@@ -151,10 +153,10 @@ public class ExpressionNodeSwitch extends ExpressionNode {
                           c.first().typeError(test.type().name(), c.first().type(), errorHandler);
                           isSame = false;
                         }
-                        if (!c.second().type().isSame(alternative.type())) {
-                          c.second()
-                              .typeError(
-                                  alternative.type().name(), c.second().type(), errorHandler);
+                        if (c.second().type().isSame(type)) {
+                          type = type.unify(c.second().type());
+                        } else {
+                          c.second().typeError(type.name(), c.second().type(), errorHandler);
                           isSame = false;
                         }
                         return isSame;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTernaryIf.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTernaryIf.java
@@ -16,6 +16,7 @@ public class ExpressionNodeTernaryIf extends ExpressionNode {
   private final ExpressionNode falseExpression;
   private final ExpressionNode testExpression;
   private final ExpressionNode trueExpression;
+  private Imyhat type = Imyhat.BAD;
 
   public ExpressionNodeTernaryIf(
       int line,
@@ -75,7 +76,7 @@ public class ExpressionNodeTernaryIf extends ExpressionNode {
 
   @Override
   public Imyhat type() {
-    return trueExpression.type();
+    return type;
   }
 
   @Override
@@ -93,6 +94,8 @@ public class ExpressionNodeTernaryIf extends ExpressionNode {
       resultOk = trueExpression.type().isSame(falseExpression.type());
       if (!resultOk) {
         typeError(trueExpression.type().name(), falseExpression.type(), errorHandler);
+      } else {
+        type = trueExpression.type().unify(falseExpression.type());
       }
     }
     return testOk & resultOk;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWithDefault.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWithDefault.java
@@ -14,6 +14,7 @@ public class GroupNodeWithDefault extends GroupNode {
 
   private final ExpressionNode initial;
   private final GroupNodeDefaultable inner;
+  private Imyhat type = Imyhat.BAD;
 
   public GroupNodeWithDefault(
       int line, int column, ExpressionNode initial, GroupNodeDefaultable inner) {
@@ -62,15 +63,19 @@ public class GroupNodeWithDefault extends GroupNode {
 
   @Override
   public Imyhat type() {
-    return inner.type();
+    return type;
   }
 
   @Override
   public boolean typeCheck(Consumer<String> errorHandler) {
     boolean ok = inner.typeCheck(errorHandler) & initial.typeCheck(errorHandler);
-    if (ok && !inner.type().isSame(initial.type())) {
-      initial.typeError(inner.type().name(), initial.type(), errorHandler);
-      ok = false;
+    if (ok) {
+      if (inner.type().isSame(initial.type())) {
+        type = inner.type().unify(initial.type());
+      } else {
+        initial.typeError(inner.type().name(), initial.type(), errorHandler);
+        ok = false;
+      }
     }
     return ok;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNode.java
@@ -57,6 +57,11 @@ public abstract class ImyhatNode {
   private static Parser parse0(Parser input, Consumer<ImyhatNode> output) {
     final Parser listParser = input.symbol("[");
     if (listParser.isGood()) {
+      final Parser emptyResult = listParser.whitespace().symbol("]").whitespace();
+      if (emptyResult.isGood()) {
+        output.accept(new ImyhatNodeLiteral(Imyhat.EMPTY));
+        return emptyResult;
+      }
       final AtomicReference<ImyhatNode> inner = new AtomicReference<>();
       final Parser result =
           listParser
@@ -65,7 +70,9 @@ public abstract class ImyhatNode {
               .whitespace()
               .symbol("]")
               .whitespace();
-      output.accept(new ImyhatNodeList(inner.get()));
+      if (result.isGood()) {
+        output.accept(new ImyhatNodeList(inner.get()));
+      }
       return result;
     }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeSet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeSet.java
@@ -73,6 +73,13 @@ public class SourceNodeSet extends SourceNode {
       return false;
     }
     final Imyhat type = expression.type();
+    if (type == Imyhat.EMPTY) {
+      errorHandler.accept(
+          String.format(
+              "%d:%d: Cannot iterate over empty list. No type to check subsequent operations.",
+              line(), column()));
+      return false;
+    }
     if (type instanceof Imyhat.ListImyhat) {
       initialType = ((Imyhat.ListImyhat) type).inner();
       return true;

--- a/shesmu-server/src/test/resources/compiler/list-empty-collect.shesmu
+++ b/shesmu-server/src/test/resources/compiler/list-empty-collect.shesmu
@@ -1,0 +1,5 @@
+Input test;
+
+Olive
+ Let foo = (For x In [ "a" ]: First [x] Default [])
+ Run ok With ok =  True;

--- a/shesmu-server/src/test/resources/compiler/list-empty-group.shesmu
+++ b/shesmu-server/src/test/resources/compiler/list-empty-group.shesmu
@@ -1,0 +1,6 @@
+Input test;
+
+Olive
+ Group By accession
+   Into x = First [file_size] Default []
+ Run ok With ok = True;

--- a/shesmu-server/src/test/resources/compiler/list-empty.errors
+++ b/shesmu-server/src/test/resources/compiler/list-empty.errors
@@ -1,0 +1,1 @@
+4:28: Cannot iterate over empty list. No type to check subsequent operations.

--- a/shesmu-server/src/test/resources/compiler/list-empty.shesmu
+++ b/shesmu-server/src/test/resources/compiler/list-empty.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = (For x In [ ]: Count) == 0;

--- a/shesmu-server/src/test/resources/run/list-empty-switch.shesmu
+++ b/shesmu-server/src/test/resources/run/list-empty-switch.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = (For x In (Switch False When True Then ["a"] Else [ ]): Count) == 0;

--- a/shesmu-server/src/test/resources/run/list-empty-ternary.shesmu
+++ b/shesmu-server/src/test/resources/run/list-empty-ternary.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = (For x In (False ? ["a"] : [ ]): Count) == 0;

--- a/shesmu-server/src/test/resources/run/list-empty.shesmu
+++ b/shesmu-server/src/test/resources/run/list-empty.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = (For x In [ ["a"], [] ]: Count) == 2;


### PR DESCRIPTION
Previously, empty lists weren't allowed because the type couldn't be
determined. This adds a limited type inference to allow an empty list type that
can be merged with a non-empty list. Empty lists cannot be directly iterated.

External entities can request empty lists (though this is silly to insist) and
empty lists can be used in places where a list is requested.