### PR TITLE
Don't box values to grouper

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
@@ -166,7 +166,6 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
           final Type asmType = grouper.input(i).type().render(typeVariables).apply(TO_ASM);
           final int local = rootRenderer.methodGen().newLocal(asmType);
           inputExpressions.get(i).render(rootRenderer);
-          rootRenderer.methodGen().box(inputExpressions.get(i).type().apply(TO_ASM));
           rootRenderer.methodGen().storeLocal(local);
           grouperCaptures[i] =
               new LoadableValue() {


### PR DESCRIPTION
Parameters to grouper methods need to be boxed to go through the lambdas, but the MethodHandle type conversion does this automatically. Don't it here just generates bad bytecode.
