### PR TITLE
Do not flatten analysis provenance

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
@@ -96,50 +96,7 @@ class NiassaServer extends JsonPluginFile<Configuration> {
       if (metadata == null) {
         return Stream.empty();
       }
-      return metadata
-          .getAnalysisProvenance()
-          .stream()
-          .flatMap(
-              ap -> {
-                final Set<Tuple> iusAttributes =
-                    CerberusAnalysisProvenanceValue.attributes(ap.getIusAttributes());
-                final Set<Tuple> fileAttributes =
-                    CerberusAnalysisProvenanceValue.attributes(ap.getFileAttributes());
-                final Set<Tuple> workflowAttributes =
-                    CerberusAnalysisProvenanceValue.attributes(ap.getWorkflowAttributes());
-                final Set<Tuple> workflowRunAttributes =
-                    CerberusAnalysisProvenanceValue.attributes(ap.getWorkflowRunAttributes());
-                return ap.getIusLimsKeys() == null
-                    ? Stream.empty()
-                    : ap.getIusLimsKeys()
-                        .stream()
-                        .flatMap(
-                            ius ->
-                                ap.getWorkflowRunInputFileIds() == null
-                                    ? Stream.of(
-                                        new CerberusAnalysisProvenanceValue(
-                                            ap,
-                                            Optional.empty(),
-                                            ius,
-                                            fileAttributes,
-                                            iusAttributes,
-                                            workflowAttributes,
-                                            workflowRunAttributes,
-                                            () -> {}))
-                                    : ap.getWorkflowRunInputFileIds()
-                                        .stream()
-                                        .map(
-                                            fileId ->
-                                                new CerberusAnalysisProvenanceValue(
-                                                    ap,
-                                                    Optional.of(fileId).map(Integer::longValue),
-                                                    ius,
-                                                    fileAttributes,
-                                                    iusAttributes,
-                                                    workflowAttributes,
-                                                    workflowRunAttributes,
-                                                    () -> {})));
-              });
+      return metadata.getAnalysisProvenance().stream().map(CerberusAnalysisProvenanceValue::new);
     }
   }
 


### PR DESCRIPTION
This will roll the analysis provenance back up, in the hope of it being small enough not to cause thrashing. I'm going to add a `Flatten` olive clause to allow access to this.