### PR TITLE
Disallow empty list as a parameter type for soundness

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeAliasNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeAliasNode.java
@@ -50,7 +50,7 @@ public class TypeAliasNode {
       Function<String, Imyhat> definedTypes,
       Function<String, FunctionDefinition> definedFunctions,
       Consumer<String> errorHandler) {
-    if (ImyhatNode.isBaseType(name)) {
+    if (Imyhat.baseTypes().anyMatch(t -> t.name().equals(name))) {
       errorHandler.accept(
           String.format("%d:%d: Attempt to redefine base type “%s”.", line, column, name));
       return Imyhat.BAD;


### PR DESCRIPTION
This prevents the empty list type from being specified as a parameter since it
creates a hole in the type system:

```
Function destroy_everything([]x) x;

...
 For z In (If True Then destory_everything(["a"]) Else [1]):
  Reduce (a = 0) a + x
...
```

This will type check but explode at runtime. This is because the empty list
will unify with different inner types. The easiest solution is to prevent the
empty list as a parameter. If the empty list is returned, then it can be
confidently unified with any other type, even if it is the return of a
user-defined function.

All this applies to optional, but there is no way to write the empty optional
in a user-defined type.