### PR TITLE
Allow a flattening operation in a grouping collector

### DIFF
--- a/language.md
+++ b/language.md
@@ -117,6 +117,7 @@ and `Min` selectors can pick the highest or lowest integer or date value.
 In total, the collectors in a `Group` operation are:
 
 - `List` to collect all values into a list
+- `Flatten` to collect all values into a list for existing lists
 - `First` to collect one value; if none are collected, the group is rejected
 - `Univalued` to collect exactly one value; if none are collected, the group is
   rejected; if more than one are collected, the group is rejected. It is fine

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
@@ -40,6 +40,7 @@ public abstract class GroupNode implements DefinedTarget {
           return p;
         });
     GROUPERS.addKeyword("First", ofWithDefault(GroupNodeFirst::new));
+    GROUPERS.addKeyword("Flatten", of(GroupNodeFlatten::new));
     GROUPERS.addKeyword("List", of(GroupNodeList::new));
     GROUPERS.addKeyword("PartitionCount", of(GroupNodePartitionCount::new));
     GROUPERS.addKeyword("Univalued", of(GroupNodeUnivalued::new));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFlatten.java
@@ -1,0 +1,82 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A flatten action in a “Group” clause
+ *
+ * <p>Also usable as the variable definition for the result
+ */
+public final class GroupNodeFlatten extends GroupNode {
+
+  private final ExpressionNode expression;
+  private final String name;
+  private Imyhat innerType = Imyhat.BAD;
+
+  public GroupNodeFlatten(int line, int column, String name, ExpressionNode expression) {
+    super(line, column);
+    this.name = name;
+    this.expression = expression;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
+    expression.collectFreeVariables(freeVariables, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public void render(Regrouper regroup, RootBuilder rootBuilder) {
+    regroup.addFlatten(innerType, name(), expression::render);
+  }
+
+  @Override
+  public boolean resolve(
+      NameDefinitions defs, NameDefinitions outerDefs, Consumer<String> errorHandler) {
+    return expression.resolve(defs, errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      Map<String, OliveNodeDefinition> definedOlives,
+      Function<String, FunctionDefinition> definedFunctions,
+      Function<String, ActionDefinition> definedActions,
+      Consumer<String> errorHandler) {
+    return expression.resolveFunctions(definedFunctions, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return innerType.asList();
+  }
+
+  @Override
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    if (expression.typeCheck(errorHandler)) {
+      if (expression.type() instanceof Imyhat.ListImyhat) {
+        innerType = ((Imyhat.ListImyhat) expression.type()).inner();
+        return true;
+      } else {
+        expression.typeError("list", expression.type(), errorHandler);
+      }
+    }
+    return false;
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Regrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Regrouper.java
@@ -34,6 +34,14 @@ public interface Regrouper {
       Type fieldType, String fieldName, Consumer<Renderer> loader, Consumer<Renderer> first);
 
   /**
+   * Add a new collection of collections of values slurped during iteration
+   *
+   * @param valueType the type of the values in the collection
+   * @param fieldName the name of the variable for consumption by downstream uses
+   */
+  void addFlatten(Imyhat valueType, String fieldName, Consumer<Renderer> loader);
+
+  /**
    * Add a value that is the Boolean result of checking expressions
    *
    * @param condition the condition that must be satisfied

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
@@ -104,7 +104,7 @@ public class RunTest {
     }
   }
 
-  private class InputProviderChecker implements InputProvider {
+  private static class InputProviderChecker implements InputProvider {
     private final Set<String> usedFormats = new HashSet<>();
 
     public Stream<Object> fetch(String format) {

--- a/shesmu-server/src/test/resources/run/group-flatten.shesmu
+++ b/shesmu-server/src/test/resources/run/group-flatten.shesmu
@@ -1,0 +1,5 @@
+Input test;
+
+Olive
+ Group By workflow Into a = Flatten stuff
+ Run ok With ok = (For x In a: Count) == 4;


### PR DESCRIPTION
There's quickly getting to be multiple rounds of grouping of the same kind of data (especially what feeds `inputs`), so this allows intermediate flattening.