### PR TITLE
Fix post-Let gang typing problem

### DIFF
--- a/language.md
+++ b/language.md
@@ -691,10 +691,19 @@ The gang can then be used in the `By` of either a `Group` or `Pick` operation:
         paths = paths;
 
 The gang, in this case, `patient_tissue_prep` defines a number of fields that
-can be grouped together in `By` clause, prefixed with an `@`. The gang can
-also be converted to an underscore delimited string:
+can be grouped together in `By` clause, prefixed with an `@`.
+
+A gang can also be converted to an underscore delimited string:
 `"{@patient_tissue_prep}"`; the order of fields is defined by the input format.
-Additionally, the gang can be converted to a tuple `{@patient_tissue_prep}`.
+
+A gang can be converted to a tuple `{@patient_tissue_prep}`.
+
+A gang can also be used in a `Let` clause to preserve the contents of the gang:
+
+    Let
+      timestamp = timestamp,
+      @patient_tissue_prep,
+      project = project
 
 Note that gangs can be reused after the data has been reshaped. This is means
 it is possible to redefine the gangs in a nonsensical way.

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeGang.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeGang.java
@@ -14,9 +14,11 @@ public class DiscriminatorNodeGang extends DiscriminatorNode {
 
   private class GroupElement implements DefinedTarget, Consumer<Renderer> {
     private final Target source;
+    private final Imyhat expectedType;
 
-    private GroupElement(Target source, boolean dropIfDefault) {
+    private GroupElement(Target source, Imyhat expectedType, boolean dropIfDefault) {
       this.source = source;
+      this.expectedType = expectedType;
     }
 
     @Override
@@ -42,6 +44,17 @@ public class DiscriminatorNodeGang extends DiscriminatorNode {
     @Override
     public String name() {
       return source.name();
+    }
+
+    public boolean typeCheck(Consumer<String> errorHandler) {
+      if (expectedType.isSame(source.type())) {
+        return true;
+      }
+      errorHandler.accept(
+          String.format(
+              "%d:%d: Variable %s in gang should have type %s but got %s.",
+              line, column, source.name(), expectedType.name(), source.type()));
+      return false;
     }
 
     @Override
@@ -131,6 +144,7 @@ public class DiscriminatorNodeGang extends DiscriminatorNode {
 
   @Override
   public boolean typeCheck(Consumer<String> errorHandler) {
-    return true;
+    return outputTargets.stream().filter(e -> e.typeCheck(errorHandler)).count()
+        == outputTargets.size();
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeBaseExpression.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeBaseExpression.java
@@ -1,0 +1,85 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
+
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public abstract class LetArgumentNodeBaseExpression extends LetArgumentNode {
+  private final ExpressionNode expression;
+  private final DestructuredArgumentNode name;
+
+  public LetArgumentNodeBaseExpression(DestructuredArgumentNode name, ExpressionNode expression) {
+    super();
+    this.name = name;
+    this.expression = expression;
+    name.setFlavour(Target.Flavour.STREAM);
+  }
+
+  @Override
+  public final boolean blankCheck(Consumer<String> errorHandler) {
+    if (name.isBlank()) {
+      errorHandler.accept(
+          String.format(
+              "%d:%d: Assignment in Let discards value.", expression.line(), expression.column()));
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public final void collectFreeVariables(Set<String> names, Predicate<Target.Flavour> predicate) {
+    expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public final void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+  }
+
+  protected abstract Consumer<Renderer> render(
+      LetBuilder let, Imyhat type, Consumer<Renderer> loadLocal);
+
+  @Override
+  public final void render(LetBuilder let) {
+    final Consumer<Renderer> loadLocal =
+        let.createLocal(expression.type().apply(TO_ASM), expression::render);
+    name.render(render(let, expression.type(), loadLocal))
+        .forEach(value -> let.add(value.type(), value.name(), value));
+  }
+
+  @Override
+  public final boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
+    return expression.resolve(defs, errorHandler);
+  }
+
+  @Override
+  public final boolean resolveFunctions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return expression.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  @Override
+  public final Stream<Target> targets() {
+    return name.targets();
+  }
+
+  protected abstract boolean typeCheck(
+      int line,
+      int column,
+      Imyhat type,
+      DestructuredArgumentNode name,
+      Consumer<String> errorHandler);
+
+  @Override
+  public final boolean typeCheck(Consumer<String> errorHandler) {
+    if (!expression.typeCheck(errorHandler)) {
+      return false;
+    }
+    return typeCheck(expression.line(), expression.column(), expression.type(), name, errorHandler);
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeGang.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeGang.java
@@ -1,0 +1,139 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.GangDefinition;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public final class LetArgumentNodeGang extends LetArgumentNode {
+  private final int column;
+  private GangDefinition definition;
+  private final String gangName;
+  private final int line;
+  // This is a list of input variable to output variable
+  private List<Pair<Target, Target>> targets;
+
+  public LetArgumentNodeGang(int line, int column, String gangName) {
+    this.gangName = gangName;
+    this.line = line;
+    this.column = column;
+  }
+
+  @Override
+  public boolean blankCheck(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> names, Predicate<Target.Flavour> predicate) {
+    for (final Pair<Target, Target> target : targets) {
+      if (predicate.test(target.first().flavour())) {
+        names.add(target.first().name());
+      }
+    }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    // Do nothing
+  }
+
+  @Override
+  public boolean filters() {
+    return false;
+  }
+
+  @Override
+  public void render(LetBuilder let) {
+    for (final Pair<Target, Target> target : targets) {
+      let.add(
+          target.first().type().apply(TO_ASM),
+          target.first().name(),
+          r -> r.loadTarget(target.first()));
+    }
+  }
+
+  @Override
+  public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
+    final Optional<List<Pair<Target, Target>>> results =
+        TypeUtils.matchGang(
+            line,
+            column,
+            defs,
+            definition,
+            (inputTarget, expectedType, dropIfDefault) ->
+                new Pair<>(
+                    inputTarget,
+                    new Target() {
+                      @Override
+                      public Flavour flavour() {
+                        return Flavour.STREAM;
+                      }
+
+                      @Override
+                      public String name() {
+                        return inputTarget.name();
+                      }
+
+                      @Override
+                      public Imyhat type() {
+                        return expectedType;
+                      }
+                    }),
+            errorHandler);
+    results.ifPresent(l -> targets = l);
+    return results.isPresent();
+  }
+
+  @Override
+  public boolean resolveFunctions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    final Optional<? extends GangDefinition> gang =
+        expressionCompilerServices
+            .inputFormat()
+            .gangs()
+            .filter(g -> g.name().equals(gangName))
+            .findAny();
+    gang.ifPresent(g -> definition = g);
+    if (!gang.isPresent()) {
+      errorHandler.accept(String.format("%d:%d: Unknown gang “%s”.", line, column, gangName));
+    }
+    return gang.isPresent();
+  }
+
+  @Override
+  public Stream<Target> targets() {
+    return targets.stream().map(Pair::second);
+  }
+
+  @Override
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    return targets
+            .stream()
+            .filter(
+                p -> {
+                  if (p.first().type().isSame(p.second().type())) {
+                    return true;
+                  }
+                  errorHandler.accept(
+                      String.format(
+                          "%d:%d: Gang variable %s should have type %s but got %s.",
+                          line,
+                          column,
+                          p.first().name(),
+                          p.second().type().name(),
+                          p.first().type().name()));
+                  return false;
+                })
+            .count()
+        == targets.size();
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeOptional.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeOptional.java
@@ -9,7 +9,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
-public final class LetArgumentNodeOptional extends LetArgumentNode {
+public final class LetArgumentNodeOptional extends LetArgumentNodeBaseExpression {
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
   private static final Type A_OPTIONAL_TYPE = Type.getType(Optional.class);
   private static final Method METHOD_OPTIONAL__GET =

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeSimple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeSimple.java
@@ -3,7 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.util.function.Consumer;
 
-public final class LetArgumentNodeSimple extends LetArgumentNode {
+public final class LetArgumentNodeSimple extends LetArgumentNodeBaseExpression {
   public LetArgumentNodeSimple(DestructuredArgumentNode name, ExpressionNode expression) {
     super(name, expression);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeUnivalued.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeUnivalued.java
@@ -10,7 +10,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
-public final class LetArgumentNodeUnivalued extends LetArgumentNode {
+public final class LetArgumentNodeUnivalued extends LetArgumentNodeBaseExpression {
   private static final Type A_ITERATOR_TYPE = Type.getType(Iterator.class);
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
   private static final Type A_SET_TYPE = Type.getType(Set.class);

--- a/shesmu-server/src/test/resources/run/let-gangs.shesmu
+++ b/shesmu-server/src/test/resources/run/let-gangs.shesmu
@@ -1,0 +1,6 @@
+Input test;
+
+Olive
+ Let @useful_stuff
+ Group By @useful_stuff Into a = Count
+ Run ok With ok = a == 1;


### PR DESCRIPTION
This fixes a bug where gangs were being type checked before type checking
should have commenced. It also adds gang support to `Let` to allow copying an
entire gang to a later step.