### PR TITLE
Catch exceptions during file watch start

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/files/FileWatcher.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/files/FileWatcher.java
@@ -247,13 +247,17 @@ public abstract class FileWatcher {
     }
 
     private void start(WatchedFileListener file, Path path) {
-      file.start();
-      file.update()
-          .ifPresent(
-              timeout ->
-                  retry.offer(
-                      new RetryProcess(
-                          Instant.now().plus(timeout, ChronoUnit.MINUTES), file, path)));
+      try {
+        file.start();
+        file.update()
+            .ifPresent(
+                timeout ->
+                    retry.offer(
+                        new RetryProcess(
+                            Instant.now().plus(timeout, ChronoUnit.MINUTES), file, path)));
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
     }
   }
 


### PR DESCRIPTION
If a new bad file is placed in the directory, it can break the file watcher thread requiring a restart.