### PR TITLE
Allow empty/nothing type descriptors in boostrap method

### DIFF
--- a/shesmu-server/src/test/resources/run/empty-bsm.shesmu
+++ b/shesmu-server/src/test/resources/run/empty-bsm.shesmu
@@ -1,0 +1,5 @@
+Input test;
+
+Function x(integer a) `{x = ``, a = a}` As json; # This is what we're really testing, but we just need to generate valid bytecode
+
+Olive Run ok With ok = "{x(3)}" == "\{\"a\":3,\"x\":null}";


### PR DESCRIPTION
Empty/nothing types are used internally and should not be available to plugins.
However, the compiler may generate them and so needs to be able to parse them
from bytecode. This allows that to be possible in those limited scenarios.