### PR TITLE
Make simulation dashboard importer pluggable

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowActionRepository.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowActionRepository.java
@@ -2,6 +2,8 @@ package ca.on.oicr.gsi.shesmu.niassa;
 
 import ca.on.oicr.gsi.shesmu.plugin.Definer;
 import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.PrintStream;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
@@ -22,6 +24,21 @@ public class WorkflowActionRepository extends PluginFileType<NiassaServer> {
 
   @Override
   public void writeJavaScriptRenderer(PrintStream writer) {
+    // We're going to register a custom import converter for .niassawf files; It will need to know
+    // all of the LIMS key types, so we're going to dump them into the output file first
+    final ObjectNode types = NiassaServer.MAPPER.createObjectNode();
+    for (final InputLimsKeyType type : InputLimsKeyType.values()) {
+      types
+          .putArray(type.name())
+          .add(type.parameter().name())
+          .add(type.parameter().type().descriptor());
+    }
+    try {
+      writer.printf(
+          "const niassaLimsKeyTypes = %s;\n", NiassaServer.MAPPER.writeValueAsString(types));
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+    }
     try (final Scanner input =
         new Scanner(WorkflowActionRepository.class.getResourceAsStream("renderer.js"), "UTF-8")) {
       writer.print(input.useDelimiter("\\Z").next());

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -2188,7 +2188,7 @@ public final class Server implements ServerConfig, ActionServices {
           try (OutputStream os = t.getResponseBody();
               PrintStream writer = new PrintStream(os, false, "UTF-8")) {
             writer.println(
-                "import { blank, collapse, jsonParameters, link, objectTable, preformatted, table, text, timespan, title, visibleText } from './utils.js';\nexport const actionRender = new Map();\n");
+                "import { blank, collapse, jsonParameters, link, objectTable, preformatted, table, text, timespan, title, visibleText } from './utils.js';\nexport const actionRender = new Map();\nexport const specialImports = [];\n");
             definitionRepository.writeJavaScriptRenderer(writer);
           }
         });

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/actions/fake/FakeRemoteDefinitionInstance.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/actions/fake/FakeRemoteDefinitionInstance.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
 import java.io.PrintStream;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
+import java.util.Scanner;
 import org.kohsuke.MetaInfServices;
 
 /**
@@ -22,8 +23,11 @@ public class FakeRemoteDefinitionInstance extends PluginFileType<RemoteInstance>
 
   @Override
   public void writeJavaScriptRenderer(PrintStream writer) {
-    writer.print(
-        "actionRender.set('fake', a => [title(a, `Fake ${a.name}`)].concat(jsonParameters(a)));");
+    try (final Scanner input =
+        new Scanner(
+            FakeRemoteDefinitionInstance.class.getResourceAsStream("renderer.js"), "UTF-8")) {
+      writer.print(input.useDelimiter("\\Z").next());
+    }
   }
 
   @Override

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/core/actions/fake/renderer.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/core/actions/fake/renderer.js
@@ -1,0 +1,13 @@
+actionRender.set("fake", a =>
+  [title(a, `Fake ${a.name}`)].concat(jsonParameters(a))
+);
+
+specialImports.push(data => {
+  try {
+    const json = JSON.parse(data);
+    if (json.hasOwnProperty("name") && json.hasOwnProperty("parameters")) {
+      return { name: json.name, parameters: json.parameters, errors: [] };
+    }
+  } catch (e) {}
+  return null;
+});

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/shesmu.js
@@ -4050,7 +4050,7 @@ export function initialiseSimulationDashboard(ace, container, completeSound) {
             errorDialog.appendChild(text(error));
           }
         } else if (result.name || name) {
-          fakeActions[result.name] = result.parameters;
+          fakeActions[result.name || name] = result.parameters;
           storeFakeActions();
           updateFakeActions();
         } else {


### PR DESCRIPTION
Currently, the simulation dashboard can import actions in the format of
`/actions` and the `niassawf` format. Additional changes were necessary for new
Niassa features. This moves the import logic into the plugins and then supports
the new Niassa features:

- support `userAnnotations`
- support new `types`

This also changes the export format for actions into the `/actions` format.