### PR TITLE
Change completable future flow

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/OliveRunInfo.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/OliveRunInfo.java
@@ -6,10 +6,12 @@ import java.time.Instant;
 public class OliveRunInfo {
   private final Long inputCount;
   private final Instant lastRun;
+  private final boolean ok;
   private final Duration runtime;
   private final String status;
 
-  public OliveRunInfo(String status, Long inputCount, Instant lastRun) {
+  public OliveRunInfo(boolean ok, String status, Long inputCount, Instant lastRun) {
+    this.ok = ok;
     this.status = status;
     this.inputCount = inputCount;
     this.lastRun = lastRun;
@@ -18,6 +20,10 @@ public class OliveRunInfo {
 
   public Long inputCount() {
     return inputCount;
+  }
+
+  public boolean isOk() {
+    return ok;
   }
 
   public Instant lastRun() {


### PR DESCRIPTION
Olives are incorectly reporting as deadline exceeded even though they are fine.
This changes the flow so that the olive's execution status is written by the
process that wait for either the timeout or olive to finish will write the
status.