### PR TITLE
Lane splitting fun

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/GenericTransformer.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/GenericTransformer.java
@@ -5,7 +5,9 @@ import java.util.stream.Stream;
 public interface GenericTransformer<R> extends ImyhatTransformer<R> {
   R generic(String id);
 
-  R genericList(GenericTypeGuarantee inner);
+  R genericList(GenericTypeGuarantee<?> inner);
+
+  R genericOptional(GenericTypeGuarantee<?> inner);
 
   R genericTuple(Stream<GenericTypeGuarantee<?>> elements);
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/GenericTypeGuarantee.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/GenericTypeGuarantee.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.shesmu.plugin.types;
 
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -44,7 +45,43 @@ public abstract class GenericTypeGuarantee<T> {
 
       @Override
       public Set<T> unpack(Object object) {
-        return null;
+        return ((Set<?>) object).stream().map(inner::unpack).collect(Collectors.toSet());
+      }
+    };
+  }
+  /**
+   * Create a list containing a generic type
+   *
+   * @param inner the type of the contents of the list
+   */
+  public static <T> GenericTypeGuarantee<Optional<T>> genericOptional(
+      GenericTypeGuarantee<T> inner) {
+    return new GenericTypeGuarantee<Optional<T>>() {
+
+      @Override
+      public <R> R apply(GenericTransformer<R> transformer) {
+        return transformer.genericOptional(inner);
+      }
+
+      @Override
+      public boolean check(Map<String, Imyhat> variables, Imyhat reference) {
+        return reference instanceof Imyhat.OptionalImyhat
+            && inner.check(variables, ((Imyhat.OptionalImyhat) reference).inner());
+      }
+
+      @Override
+      public Imyhat render(Map<String, Imyhat> variables) {
+        return inner.render(variables).asOptional();
+      }
+
+      @Override
+      public String toString(Map<String, Imyhat> typeVariables) {
+        return inner.toString(typeVariables) + "?";
+      }
+
+      @Override
+      public Optional<T> unpack(Object object) {
+        return ((Optional<?>) object).map(inner::unpack);
       }
     };
   }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/ReturnTypeGuarantee.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/ReturnTypeGuarantee.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.plugin.types;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -20,6 +21,16 @@ public abstract class ReturnTypeGuarantee<T> extends GenericReturnTypeGuarantee<
       @Override
       public Imyhat type() {
         return listType;
+      }
+    };
+  }
+
+  public static <T> ReturnTypeGuarantee<Optional<T>> optional(ReturnTypeGuarantee<T> inner) {
+    final Imyhat optionalType = inner.type().asOptional();
+    return new ReturnTypeGuarantee<Optional<T>>() {
+      @Override
+      public Imyhat type() {
+        return optionalType;
       }
     };
   }
@@ -73,6 +84,8 @@ public abstract class ReturnTypeGuarantee<T> extends GenericReturnTypeGuarantee<
         }
       };
 
+  ReturnTypeGuarantee() {}
+
   @Override
   public final boolean check(Map<String, Imyhat> variables, Imyhat reference) {
     return type().isSame(reference);
@@ -87,8 +100,6 @@ public abstract class ReturnTypeGuarantee<T> extends GenericReturnTypeGuarantee<
   public final String toString(Map<String, Imyhat> typeVariables) {
     return type().name();
   }
-
-  ReturnTypeGuarantee() {}
 
   public abstract Imyhat type();
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/TypeGuarantee.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/TypeGuarantee.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,6 +44,21 @@ public abstract class TypeGuarantee<T> extends GenericTypeGuarantee<T> {
       @Override
       public List<T> unpack(Object object) {
         return ((Set<?>) object).stream().map(inner::unpack).collect(Collectors.toList());
+      }
+    };
+  }
+
+  public static <T> TypeGuarantee<Optional<T>> optional(TypeGuarantee<T> inner) {
+    final Imyhat listType = inner.type().asOptional();
+    return new TypeGuarantee<Optional<T>>() {
+      @Override
+      public Imyhat type() {
+        return listType;
+      }
+
+      @Override
+      public Optional<T> unpack(Object object) {
+        return ((Optional<?>) object).map(inner::unpack);
       }
     };
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeUtils.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeUtils.java
@@ -95,7 +95,12 @@ public class TypeUtils {
         }
 
         @Override
-        public Type genericList(GenericTypeGuarantee inner) {
+        public Type genericOptional(GenericTypeGuarantee<?> inner) {
+          return A_OPTIONAL_TYPE;
+        }
+
+        @Override
+        public Type genericList(GenericTypeGuarantee<?> inner) {
           return A_SET_TYPE;
         }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/LaneSplittingGrouperDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/LaneSplittingGrouperDefinition.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperOutput;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperOutputs;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperParameter;
+import ca.on.oicr.gsi.shesmu.plugin.types.GenericTypeGuarantee;
 import ca.on.oicr.gsi.shesmu.plugin.types.ReturnTypeGuarantee;
 import ca.on.oicr.gsi.shesmu.plugin.types.TypeGuarantee;
 import org.kohsuke.MetaInfServices;
@@ -18,7 +19,10 @@ public class LaneSplittingGrouperDefinition extends GrouperDefinition {
             TypeGuarantee.list(TypeGuarantee.list(TypeGuarantee.LONG)),
             "A description of which lanes may be merged. A list of lists of which lanes are physically connected on the flow cell. Samples must be in the lowest numbered lane in each group."),
         GrouperParameter.dynamic(
-            "is_sample", TypeGuarantee.BOOLEAN, "Whether this is a sample (rather than a lane)."),
+            "is_sample",
+            GenericTypeGuarantee.genericOptional(
+                ReturnTypeGuarantee.variable(Object.class, "𝒯").first()),
+            "A unique identifier for each sample (or a constant value for a lane). This will be used to determine if samples are common across lanes."),
         GrouperParameter.dynamic("lane", TypeGuarantee.LONG, "The lane number."),
         GrouperOutputs.of(
             GrouperOutput.fixed(

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/LaneSplittingGrouperTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/LaneSplittingGrouperTest.java
@@ -15,7 +15,10 @@ public class LaneSplittingGrouperTest {
     final Grouper<Pair<Long, String>, Set<String>> grouper =
         new LaneSplittingGrouper<>(
             i -> Collections.emptyList(),
-            i -> Character.isAlphabetic(i.second().charAt(0)),
+            i ->
+                Character.isAlphabetic(i.second().charAt(0))
+                    ? Optional.of(i.second())
+                    : Optional.empty(),
             Pair::first,
             g -> (o, i) -> o.add(i.second()));
     final Set<Integer> outputs =
@@ -37,7 +40,10 @@ public class LaneSplittingGrouperTest {
     final Grouper<Pair<Long, String>, Set<String>> grouper =
         new LaneSplittingGrouper<>(
             i -> partitions,
-            i -> Character.isAlphabetic(i.second().charAt(0)),
+            i ->
+                Character.isAlphabetic(i.second().charAt(0))
+                    ? Optional.of(i.second())
+                    : Optional.empty(),
             Pair::first,
             g -> (o, i) -> o.add(i.second()));
     final Set<Integer> outputs =
@@ -60,7 +66,10 @@ public class LaneSplittingGrouperTest {
     final Grouper<Pair<Long, String>, Set<String>> grouper =
         new LaneSplittingGrouper<>(
             i -> partitions,
-            i -> Character.isAlphabetic(i.second().charAt(0)),
+            i ->
+                Character.isAlphabetic(i.second().charAt(0))
+                    ? Optional.of(i.second())
+                    : Optional.empty(),
             Pair::first,
             g -> (o, i) -> o.add(i.second()));
     final Set<Integer> outputs =
@@ -77,13 +86,43 @@ public class LaneSplittingGrouperTest {
   }
 
   @Test
+  public void testTwoJoinedPartitionsWithDuplicates() {
+    final List<List<Long>> partitions = Collections.singletonList(Arrays.asList(1L, 2L));
+    final Grouper<Pair<Long, String>, Set<String>> grouper =
+        new LaneSplittingGrouper<>(
+            i -> partitions,
+            i ->
+                Character.isAlphabetic(i.second().charAt(0))
+                    ? Optional.of(i.second())
+                    : Optional.empty(),
+            Pair::first,
+            g -> (o, i) -> o.add(i.second()));
+    final Set<Integer> outputs =
+        grouper
+            .group(
+                Arrays.asList(
+                    new Pair<>(1L, "A"),
+                    new Pair<>(1L, "B"),
+                    new Pair<>(1L, "0"),
+                    new Pair<>(2L, "2"),
+                    new Pair<>(2L, "A"),
+                    new Pair<>(2L, "B")))
+            .map(s -> s.build(i -> new TreeSet<>()).size())
+            .collect(Collectors.toSet());
+    Assert.assertEquals(new TreeSet<>(Collections.singletonList(4)), outputs);
+  }
+
+  @Test
   public void testTwoPartitions() {
     final List<List<Long>> partitions =
         Arrays.asList(Collections.singletonList(1L), Collections.singletonList(2L));
     final Grouper<Pair<Long, String>, Set<String>> grouper =
         new LaneSplittingGrouper<>(
             i -> partitions,
-            i -> Character.isAlphabetic(i.second().charAt(0)),
+            i ->
+                Character.isAlphabetic(i.second().charAt(0))
+                    ? Optional.of(i.second())
+                    : Optional.empty(),
             Pair::first,
             g -> (o, i) -> o.add(i.second()));
     final Set<Integer> outputs =


### PR DESCRIPTION
This change is to match the way that we really enter data in MISO rather than how I thought they were initially.

The samples are assigned to all lanes in a merged flowcell rather than just the first one. This allows the duplicate lanes to be dropped if they are identical.