### PR TITLE
Allow using signatures in LeftJoin

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Target.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Target.java
@@ -57,6 +57,54 @@ public interface Target {
     }
   }
 
+  static Target softWrap(Target target) {
+    if (!target.flavour().isStream) {
+      throw new IllegalArgumentException(
+          String.format("Cannot wrap %s variable %s", target.flavour().name(), target.name()));
+    }
+    return new Target() {
+
+      @Override
+      public Flavour flavour() {
+        return target.flavour();
+      }
+
+      @Override
+      public String name() {
+        return target.name();
+      }
+
+      @Override
+      public Imyhat type() {
+        return target.type();
+      }
+    };
+  }
+
+  static Target wrap(Target target) {
+    if (!target.flavour().isStream) {
+      throw new IllegalArgumentException(
+          String.format("Cannot wrap %s variable %s", target.flavour().name(), target.name()));
+    }
+    return new Target() {
+
+      @Override
+      public Flavour flavour() {
+        return Flavour.STREAM;
+      }
+
+      @Override
+      public String name() {
+        return target.name();
+      }
+
+      @Override
+      public Imyhat type() {
+        return target.type();
+      }
+    };
+  }
+
   public static final Target BAD =
       new Target() {
 
@@ -84,28 +132,4 @@ public interface Target {
 
   /** The Shesmu type for this variable */
   Imyhat type();
-
-  static Target wrap(Target target) {
-    if (!target.flavour().isStream) {
-      throw new IllegalArgumentException(
-          String.format("Cannot wrap %s variable %s", target.flavour().name(), target.name()));
-    }
-    return new Target() {
-
-      @Override
-      public Flavour flavour() {
-        return Flavour.STREAM;
-      }
-
-      @Override
-      public String name() {
-        return target.name();
-      }
-
-      @Override
-      public Imyhat type() {
-        return target.type();
-      }
-    };
-  }
 }

--- a/shesmu-server/src/test/resources/run/leftjoin-define.shesmu
+++ b/shesmu-server/src/test/resources/run/leftjoin-define.shesmu
@@ -1,6 +1,7 @@
 Input test;
 
 Define foo()
+ Let library_size
  LeftJoin library_size To inner_test l
     ls = List l;
 

--- a/shesmu-server/src/test/resources/run/leftjoin.shesmu
+++ b/shesmu-server/src/test/resources/run/leftjoin.shesmu
@@ -1,6 +1,7 @@
 Input test;
 
 Olive
+ Let p = project
  LeftJoin True To inner_test True
     ls = List l
  Run ok With ok = (For l In ls: Count) == 2;

--- a/shesmu-server/src/test/resources/run/sign-leftjoin.shesmu
+++ b/shesmu-server/src/test/resources/run/sign-leftjoin.shesmu
@@ -1,0 +1,8 @@
+Input test;
+
+Olive
+ Where project == "the_foo_study"
+ Let p = project
+ LeftJoin p To test(project)
+  xs = List signature_names
+ Run ok With ok = For x In xs: All "project" In x;


### PR DESCRIPTION
Signatures were only allowed on the main flow of data in an olive, but since
the data in a `LeftJoin` is unmanipulated, the signatures should be valid on
that data. This came about when trying to do a self-left join in `cerberus_fp`
which needed to combine signatures from both the outer an inner parts. This
means that all `LeftJoin` clauses must be proceeded by a reshaping clause that
drops or there will be a collision; in practice, this is already true for all
olives in use.