### PR TITLE
Allow lifted field and tuple getters

### DIFF
--- a/language.md
+++ b/language.md
@@ -518,6 +518,9 @@ zero-based index of the item in the tuple. The result type will be based on the
 type of that position in the tuple. If _n_ is beyond the number of items in the
 tuple, an error occurs.
 
+The _expr_ can also be an optional of a tuple. If it is, the result will be an
+optional of the appropriate type.
+
 #### Named Tuple Access
 - _expr_ `.` _field_
 
@@ -526,6 +529,9 @@ field. The result type will be based on the type of that field in the named
 tuple or a JSON blob when accessing a JSON blob. If _field_ is not in the named
 tuple, an error occurs. If _field_ is not in the JSON blob (or applied to a
 scalar or array), the result is a JSON `null` value.
+
+The _expr_ can also be an optional of a named tuple or JSON object. If it is,
+the result will be an optional of the appropriate type.
 
 ### Terminals
 #### Date Literal

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObjectGet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObjectGet.java
@@ -6,31 +6,38 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
 public class ExpressionNodeObjectGet extends ExpressionNode {
 
+  private static final Type A_FUNCTION_TYPE = Type.getType(Function.class);
+  private static final Type A_JSON_NODE_TYPE = Type.getType(JsonNode.class);
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
+  private static final Type A_OPTIONAL_TYPE = Type.getType(Optional.class);
   private static final Type A_RUNTIME_SUPPORT_TYPE = Type.getType(RuntimeSupport.class);
   private static final Type A_TUPLE_TYPE = Type.getType(Tuple.class);
-  private static final Type A_JSON_NODE_TYPE = Type.getType(JsonNode.class);
+  private static final Method METHOD_OPTIONAL__FLAT_MAP =
+      new Method("flatMap", A_OPTIONAL_TYPE, new Type[] {A_FUNCTION_TYPE});
+  private static final Method METHOD_OPTIONAL__MAP =
+      new Method("map", A_OPTIONAL_TYPE, new Type[] {A_FUNCTION_TYPE});
   private static final Method METHOD_RUNTIME_SUPPORT_GET_JSON =
       new Method(
           "getJson", A_JSON_NODE_TYPE, new Type[] {A_JSON_NODE_TYPE, Type.getType(String.class)});
-
   private static final Method METHOD_TUPLE__GET =
       new Method("get", A_OBJECT_TYPE, new Type[] {Type.INT_TYPE});
-
   private final ExpressionNode expression;
 
   private final String field;
 
   private int index = -1;
-
+  private boolean lifted;
   private Imyhat type = Imyhat.BAD;
 
   public ExpressionNodeObjectGet(int line, int column, ExpressionNode expression, String field) {
@@ -53,13 +60,44 @@ public class ExpressionNodeObjectGet extends ExpressionNode {
   public void render(Renderer renderer) {
     expression.render(renderer);
     renderer.mark(line());
-    if (index == -1) {
-      renderer.methodGen().push(field);
-      renderer.methodGen().invokeStatic(A_RUNTIME_SUPPORT_TYPE, METHOD_RUNTIME_SUPPORT_GET_JSON);
+    if (lifted) {
+      final LambdaBuilder.LambdaType lambdaType;
+      if (index == -1) {
+        lambdaType = LambdaBuilder.function(A_JSON_NODE_TYPE, A_JSON_NODE_TYPE);
+      } else {
+        lambdaType = LambdaBuilder.function(A_OBJECT_TYPE, A_TUPLE_TYPE);
+      }
+      final LambdaBuilder lambda =
+          new LambdaBuilder(
+              renderer.root(),
+              String.format("Optional Getter %d:%d %s", line(), column(), field),
+              lambdaType);
+      final GeneratorAdapter method = lambda.methodGen();
+      method.visitCode();
+      method.loadArg(0);
+      renderLoad(method);
+      method.returnValue();
+      method.endMethod();
+      lambda.push(renderer);
+      if (type instanceof Imyhat.OptionalImyhat || type == Imyhat.NOTHING) {
+        renderer.methodGen().invokeVirtual(A_OPTIONAL_TYPE, METHOD_OPTIONAL__FLAT_MAP);
+      } else {
+        renderer.methodGen().invokeVirtual(A_OPTIONAL_TYPE, METHOD_OPTIONAL__MAP);
+      }
+
     } else {
-      renderer.methodGen().push(index);
-      renderer.methodGen().invokeVirtual(A_TUPLE_TYPE, METHOD_TUPLE__GET);
+      renderLoad(renderer.methodGen());
       renderer.methodGen().unbox(type.apply(TypeUtils.TO_ASM));
+    }
+  }
+
+  private void renderLoad(GeneratorAdapter method) {
+    if (index == -1) {
+      method.push(field);
+      method.invokeStatic(A_RUNTIME_SUPPORT_TYPE, METHOD_RUNTIME_SUPPORT_GET_JSON);
+    } else {
+      method.push(index);
+      method.invokeVirtual(A_TUPLE_TYPE, METHOD_TUPLE__GET);
     }
   }
 
@@ -76,14 +114,18 @@ public class ExpressionNodeObjectGet extends ExpressionNode {
 
   @Override
   public Imyhat type() {
-    return type;
+    return lifted ? type.asOptional() : type;
   }
 
   @Override
   public boolean typeCheck(Consumer<String> errorHandler) {
     boolean ok = expression.typeCheck(errorHandler);
     if (ok) {
-      final Imyhat expressionType = expression.type();
+      Imyhat expressionType = expression.type();
+      if (expressionType instanceof Imyhat.OptionalImyhat) {
+        lifted = true;
+        expressionType = ((Imyhat.OptionalImyhat) expressionType).inner();
+      }
       if (expressionType instanceof Imyhat.ObjectImyhat) {
         final Imyhat.ObjectImyhat objectType = (Imyhat.ObjectImyhat) expressionType;
         type = objectType.get(field);

--- a/shesmu-server/src/test/resources/run/optional-object-get-lift-flat.shesmu
+++ b/shesmu-server/src/test/resources/run/optional-object-get-lift-flat.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = ((`{ x = `1` }`).x Default 0) == 1;

--- a/shesmu-server/src/test/resources/run/optional-object-get-lift.shesmu
+++ b/shesmu-server/src/test/resources/run/optional-object-get-lift.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = ((`{ x = 1 }`).x Default 0) == 1;

--- a/shesmu-server/src/test/resources/run/optional-tuple-get-lift-flat.shesmu
+++ b/shesmu-server/src/test/resources/run/optional-tuple-get-lift-flat.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = ((`{ `1` }`)[0] Default 0) == 1;

--- a/shesmu-server/src/test/resources/run/optional-tuple-get-lift.shesmu
+++ b/shesmu-server/src/test/resources/run/optional-tuple-get-lift.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = ((`{ 1 }`)[0] Default 0) == 1;


### PR DESCRIPTION
This is meant to dovetail with the JSON configuration stuff. Since that always return an optional, it would be a pain to have to do two `OnlyIf` or `Default` expressions to get to optional values inside the structure. The idea is that you could write something like:

```
Let umi_regex = OnlyIf kit_info(kit).umi_regex
```
instead of:
```
Let kit_data = OnlyIf kit_info(kit)
Let umi_regex = OnlyIf kit_data.umi_regex
```