### PR TITLE
Allow the generic optional type to be nothing

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/GenericTypeGuarantee.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/GenericTypeGuarantee.java
@@ -65,8 +65,9 @@ public abstract class GenericTypeGuarantee<T> {
 
       @Override
       public boolean check(Map<String, Imyhat> variables, Imyhat reference) {
-        return reference instanceof Imyhat.OptionalImyhat
-            && inner.check(variables, ((Imyhat.OptionalImyhat) reference).inner());
+        return reference == Imyhat.NOTHING
+            || reference instanceof Imyhat.OptionalImyhat
+                && inner.check(variables, ((Imyhat.OptionalImyhat) reference).inner());
       }
 
       @Override


### PR DESCRIPTION
This only really applies to groupers, but if a grouper takes an optional type
parameter (in Java `Optional<T>`) and the olive only ever uses
`Optional.empty()`, leave the type variable `T` unassigned and continue on
anyway.