### PR TITLE
Improve scheduler

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -142,7 +142,7 @@ public final class Server implements ServerConfig, ActionServices {
   private static final Pattern AMPERSAND = Pattern.compile("&");
   private static final Pattern EQUAL = Pattern.compile("=");
   public static final CloseableHttpClient HTTP_CLIENT = HttpClients.createDefault();
-  private static final Map<String, Instant> INFLIGHT = new ConcurrentHashMap<>();
+  private static final Map<String, Instant> INFLIGHT = new ConcurrentSkipListMap<>();
   private static final String instanceName =
       Optional.ofNullable(System.getenv("SHESMU_INSTANCE"))
           .map("Shesmu - "::concat)


### PR DESCRIPTION
So, this is based on Mike's request. Currently, the scheduler takes all the actions, sorts them priority, and then checks each one on in sequence. This changes it in two ways:

* it creates a thread pool so that actions can run in parallel
* it takes all the actions, sorts them priority, filters out any that are currently running or have run recently, and selects the top _200 - currently running_ and throws them into the scheduler.

This is meant to make the scheduler starve low priority actions so new high priority actions can run when the system is overloaded.