### PR TITLE
Fix UI bug where action IDs were add incorrectly

### DIFF
--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/shesmu.js
@@ -2897,7 +2897,7 @@ function getStats(
                                 (item, index, array) =>
                                   item == 0 || item != array[index - 1]
                               )
-                          : [ids]
+                          : ids
                     );
                   }
                 )


### PR DESCRIPTION
`ids` is already an array. I miss my type checker.