### PR TITLE
Invalidate all workflow caches when skipping

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -487,7 +487,7 @@ public final class WorkflowAction extends Action {
           runAccession = 0;
           hasLaunched = false;
           lastState = ActionState.UNKNOWN;
-          server.get().analysisCache().invalidate(workflowAccession);
+          workflowAccessions().forEach(server.get().analysisCache()::invalidate);
           return true;
         }
     }


### PR DESCRIPTION
If there was a workflow run associated with this action, we don't actually know which workflow it was, so invalidate all of them.