### PR TITLE
Allow nesting question marks

### DIFF
--- a/language.md
+++ b/language.md
@@ -542,6 +542,10 @@ an optional type, and provides the inner (non-optional) value inside. If the
 expression has an empty optional, the entire optional creation will be the
 empty optional.
 
+These may be nested for function calls on optional values. For example:
+
+    x = `foo(x?)? + 3`
+
 ### Unary Operators
 #### Boolean Not
 - `!` _expr_

--- a/shesmu-server/src/test/resources/run/optional-nested-deeply.shesmu
+++ b/shesmu-server/src/test/resources/run/optional-nested-deeply.shesmu
@@ -1,0 +1,10 @@
+Input test;
+
+Function foo(string x) `x`;
+
+Olive
+ Run ok With ok =
+  (Begin
+    x = `project`;
+    Return `foo(x?)? == "the_foo_study"`;
+  End) Default False;


### PR DESCRIPTION
This allows reducing:

    `foo(`x?`)? + 3`

to

    `foo(x?)? + 3`

which is shorter and clearer.