### PR TITLE
Check for unused variables

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
@@ -252,6 +252,11 @@ public final class Check extends Compiler {
                               }
 
                               @Override
+                              public void read() {
+                                // Interesting. Don't care.
+                              }
+
+                              @Override
                               public Imyhat type() {
                                 return type;
                               }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNode.java
@@ -18,6 +18,13 @@ public abstract class DestructuredArgumentNode implements UndefinedVariableProvi
   private static final DestructuredArgumentNode MISSING =
       new DestructuredArgumentNode() {
         @Override
+        public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+          // Pretend like we are read because we don't want to generate errors that something was
+          // unread
+          return true;
+        }
+
+        @Override
         public WildcardCheck checkWildcard(Consumer<String> errorHandler) {
           return WildcardCheck.NONE;
         }
@@ -118,7 +125,7 @@ public abstract class DestructuredArgumentNode implements UndefinedVariableProvi
               }
               return converted;
             }
-            o.accept(new DestructuredArgumentNodeVariable(name.get()));
+            o.accept(new DestructuredArgumentNodeVariable(p.line(), p.column(), name.get()));
           }
           return result;
         });
@@ -146,6 +153,8 @@ public abstract class DestructuredArgumentNode implements UndefinedVariableProvi
       return childResult;
     }
   }
+
+  public abstract boolean checkUnusedDeclarations(Consumer<String> errorHandler);
 
   public abstract WildcardCheck checkWildcard(Consumer<String> errorHandler);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeConvertedVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeConvertedVariable.java
@@ -137,6 +137,7 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
   private Target.Flavour flavour;
   private final int line;
   private final String name;
+  private boolean read;
   private final Target target =
       new Target() {
         @Override
@@ -147,6 +148,11 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
         @Override
         public String name() {
           return name;
+        }
+
+        @Override
+        public void read() {
+          read = true;
         }
 
         @Override
@@ -166,13 +172,23 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
   }
 
   @Override
-  public boolean isBlank() {
-    return false;
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    if (read) {
+      return true;
+    } else {
+      errorHandler.accept(String.format("%d:%d: Variable “%s” is never used.", line, column, name));
+      return false;
+    }
   }
 
   @Override
   public WildcardCheck checkWildcard(Consumer<String> errorHandler) {
     return WildcardCheck.NONE;
+  }
+
+  @Override
+  public boolean isBlank() {
+    return false;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeObject.java
@@ -32,6 +32,17 @@ public class DestructuredArgumentNodeObject extends DestructuredArgumentNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    boolean ok = true;
+    for (final Pair<String, DestructuredArgumentNode> field : fields) {
+      if (!field.second().checkUnusedDeclarations(errorHandler)) {
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
+  @Override
   public WildcardCheck checkWildcard(Consumer<String> errorHandler) {
     final WildcardCheck result =
         fields

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeStar.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeStar.java
@@ -57,6 +57,11 @@ public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
     }
 
     @Override
+    public void read() {
+      read = true;
+    }
+
+    @Override
     public Imyhat type() {
       return type;
     }
@@ -68,6 +73,7 @@ public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
   private final int column;
   private final Map<String, StarTarget> fields = new TreeMap<>();
   private final int line;
+  private boolean read;
   private Imyhat.ObjectImyhat objectType;
   private Target.Flavour flavour;
 
@@ -79,6 +85,18 @@ public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
   @Override
   public boolean isBlank() {
     return false;
+  }
+
+  @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    if (read) {
+      return true;
+    } else {
+      errorHandler.accept(
+          String.format(
+              "%d:%d: No variables map back to this wildcard. It is unused", line, column));
+      return false;
+    }
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeTuple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeTuple.java
@@ -33,6 +33,17 @@ public class DestructuredArgumentNodeTuple extends DestructuredArgumentNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    boolean ok = true;
+    for (final DestructuredArgumentNode element : elements) {
+      if (!element.checkUnusedDeclarations(errorHandler)) {
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
+  @Override
   public WildcardCheck checkWildcard(Consumer<String> errorHandler) {
     final WildcardCheck result =
         elements

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeVariable.java
@@ -9,7 +9,10 @@ import org.objectweb.asm.Type;
 
 public class DestructuredArgumentNodeVariable extends DestructuredArgumentNode {
   private Target.Flavour flavour;
+  private final int line;
+  private final int column;
   private final String name;
+  private boolean read;
   private Imyhat type = Imyhat.BAD;
   private final Target target =
       new Target() {
@@ -24,13 +27,30 @@ public class DestructuredArgumentNodeVariable extends DestructuredArgumentNode {
         }
 
         @Override
+        public void read() {
+          read = true;
+        }
+
+        @Override
         public Imyhat type() {
           return type;
         }
       };
 
-  public DestructuredArgumentNodeVariable(String name) {
+  public DestructuredArgumentNodeVariable(int line, int column, String name) {
+    this.line = line;
+    this.column = column;
     this.name = name;
+  }
+
+  @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    if (read) {
+      return true;
+    } else {
+      errorHandler.accept(String.format("%d:%d: Variable “%s” is never used.", line, column, name));
+      return false;
+    }
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeGang.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeGang.java
@@ -58,6 +58,11 @@ public class DiscriminatorNodeGang extends DiscriminatorNode {
     }
 
     @Override
+    public void read() {
+      // We don't care if discriminators are read because they are implicitly read by grouping.
+    }
+
+    @Override
     public Imyhat type() {
       return source.type();
     }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeRename.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeRename.java
@@ -40,6 +40,12 @@ public class DiscriminatorNodeRename extends DiscriminatorNode {
           }
 
           @Override
+          public void read() {
+            // We don't care if discriminators are read because they are implicitly read by
+            // grouping.
+          }
+
+          @Override
           public Imyhat type() {
             return expression.type();
           }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeSimple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeSimple.java
@@ -43,6 +43,12 @@ public class DiscriminatorNodeSimple extends DiscriminatorNode {
           }
 
           @Override
+          public void read() {
+            // We don't care if discriminators are read because they are implicitly read by
+            // grouping.
+          }
+
+          @Override
           public Imyhat type() {
             return inputTarget.type();
           }
@@ -110,6 +116,7 @@ public class DiscriminatorNodeSimple extends DiscriminatorNode {
       return false;
     }
     this.inputTarget = target.get();
+    this.inputTarget.read();
     return true;
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFunctionCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFunctionCall.java
@@ -103,6 +103,7 @@ public class ExpressionNodeFunctionCall extends ExpressionNode {
       errorHandler.accept(String.format("%d:%d: Undefined function “%s”.", line(), column(), name));
       ok = false;
     }
+    function.read();
     return ok
         & arguments
                 .stream()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalOf.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalOf.java
@@ -99,6 +99,11 @@ public class ExpressionNodeOptionalOf extends ExpressionNode {
     }
 
     @Override
+    public void read() {
+      // Super. Don't care.
+    }
+
+    @Override
     public void setContext(NameDefinitions defs) {
       this.defs = Optional.of(defs);
     }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
@@ -32,6 +32,11 @@ public class ExpressionNodeVariable extends ExpressionNode {
           }
 
           @Override
+          public void read() {
+            // Gaze into the bad value and ignore that you read it.
+          }
+
+          @Override
           public Imyhat type() {
             return Imyhat.BAD;
           }
@@ -79,6 +84,7 @@ public class ExpressionNodeVariable extends ExpressionNode {
     } else {
       errorHandler.accept(String.format("%d:%d: Undefined variable “%s”.", line(), column(), name));
     }
+    target.read();
     return result.isPresent();
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
@@ -177,6 +177,8 @@ public abstract class GroupNode implements DefinedTarget {
     return Flavour.STREAM;
   }
 
+  public abstract boolean isRead();
+
   @Override
   public final int line() {
     return line;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeCount.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 public final class GroupNodeCount extends GroupNode {
 
   private final String name;
+  private boolean read;
 
   public GroupNodeCount(int line, int column, String name) {
     super(line, column);
@@ -31,8 +32,18 @@ public final class GroupNodeCount extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeDictionary.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeDictionary.java
@@ -9,8 +9,9 @@ import java.util.function.Predicate;
 public final class GroupNodeDictionary extends GroupNode {
 
   private final ExpressionNode key;
-  private final ExpressionNode value;
   private final String name;
+  private boolean read;
+  private final ExpressionNode value;
 
   public GroupNodeDictionary(
       int line, int column, String name, ExpressionNode key, ExpressionNode value) {
@@ -33,8 +34,18 @@ public final class GroupNodeDictionary extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFirst.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFirst.java
@@ -12,9 +12,9 @@ import java.util.function.Predicate;
  * <p>Also usable as the variable definition for the result
  */
 public final class GroupNodeFirst extends GroupNodeDefaultable {
-
   private final ExpressionNode expression;
   private final String name;
+  private boolean read;
 
   public GroupNodeFirst(int line, int column, String name, ExpressionNode expression) {
     super(line, column);
@@ -33,8 +33,18 @@ public final class GroupNodeFirst extends GroupNodeDefaultable {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeFlatten.java
@@ -12,10 +12,10 @@ import java.util.function.Predicate;
  * <p>Also usable as the variable definition for the result
  */
 public final class GroupNodeFlatten extends GroupNode {
-
   private final ExpressionNode expression;
-  private final String name;
   private Imyhat innerType = Imyhat.BAD;
+  private final String name;
+  private boolean read;
 
   public GroupNodeFlatten(int line, int column, String name, ExpressionNode expression) {
     super(line, column);
@@ -34,8 +34,18 @@ public final class GroupNodeFlatten extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeList.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeList.java
@@ -12,9 +12,9 @@ import java.util.function.Predicate;
  * <p>Also usable as the variable definition for the result
  */
 public final class GroupNodeList extends GroupNode {
-
   private final ExpressionNode expression;
   private final String name;
+  private boolean read;
 
   public GroupNodeList(int line, int column, String name, ExpressionNode expression) {
     super(line, column);
@@ -33,8 +33,18 @@ public final class GroupNodeList extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeMatches.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeMatches.java
@@ -7,10 +7,10 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 public class GroupNodeMatches extends GroupNode {
-
   private final ExpressionNode condition;
   private final Match matchType;
   private final String name;
+  private boolean read;
 
   public GroupNodeMatches(
       int line, int column, String name, Match matchType, ExpressionNode condition) {
@@ -31,8 +31,18 @@ public class GroupNodeMatches extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeOnlyIf.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeOnlyIf.java
@@ -14,8 +14,9 @@ import java.util.function.Predicate;
 public final class GroupNodeOnlyIf extends GroupNode {
 
   private final ExpressionNode expression;
-  private final String name;
   private Imyhat innerType = Imyhat.BAD;
+  private final String name;
+  private boolean read;
 
   public GroupNodeOnlyIf(int line, int column, String name, ExpressionNode expression) {
     super(line, column);
@@ -34,8 +35,18 @@ public final class GroupNodeOnlyIf extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeOptima.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeOptima.java
@@ -11,6 +11,7 @@ public class GroupNodeOptima extends GroupNodeDefaultable {
   private final ExpressionNode expression;
   private final boolean max;
   private final String name;
+  private boolean read;
 
   public GroupNodeOptima(
       int line, int column, String name, ExpressionNode expression, boolean max) {
@@ -31,8 +32,18 @@ public class GroupNodeOptima extends GroupNodeDefaultable {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodePartitionCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodePartitionCount.java
@@ -11,6 +11,7 @@ public class GroupNodePartitionCount extends GroupNode {
 
   private final ExpressionNode condition;
   private final String name;
+  private boolean read;
 
   public GroupNodePartitionCount(int line, int column, String name, ExpressionNode condition) {
     super(line, column);
@@ -29,8 +30,18 @@ public class GroupNodePartitionCount extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeUnivalued.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeUnivalued.java
@@ -11,6 +11,7 @@ public final class GroupNodeUnivalued extends GroupNodeDefaultable {
 
   private final ExpressionNode expression;
   private final String name;
+  private boolean read;
 
   public GroupNodeUnivalued(int line, int column, String name, ExpressionNode expression) {
     super(line, column);
@@ -29,8 +30,18 @@ public final class GroupNodeUnivalued extends GroupNodeDefaultable {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWhere.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWhere.java
@@ -29,8 +29,18 @@ public class GroupNodeWhere extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return sink.isRead();
+  }
+
+  @Override
   public String name() {
     return sink.name();
+  }
+
+  @Override
+  public void read() {
+    sink.read();
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWithDefault.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeWithDefault.java
@@ -32,8 +32,18 @@ public class GroupNodeWithDefault extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return inner.isRead();
+  }
+
+  @Override
   public String name() {
     return inner.name();
+  }
+
+  @Override
+  public void read() {
+    inner.read();
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNode.java
@@ -61,7 +61,7 @@ public abstract class LetArgumentNode implements UndefinedVariableProvider {
       if (justName.isGood()) {
         output.accept(
             new LetArgumentNodeSimple(
-                new DestructuredArgumentNodeVariable(loneName.get()),
+                new DestructuredArgumentNodeVariable(input.line(), input.column(), loneName.get()),
                 new ExpressionNodeVariable(input.line(), input.column(), loneName.get())));
         return justName;
       }
@@ -72,6 +72,8 @@ public abstract class LetArgumentNode implements UndefinedVariableProvider {
   private static final Pattern UNWRAP = Pattern.compile("(OnlyIf|Univalued|)");
 
   public abstract boolean blankCheck(Consumer<String> errorHandler);
+
+  public abstract boolean checkUnusedDeclarations(Consumer<String> errorHandler);
 
   public abstract WildcardCheck checkWildcard(Consumer<String> errorHandler);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeBaseExpression.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeBaseExpression.java
@@ -33,6 +33,11 @@ public abstract class LetArgumentNodeBaseExpression extends LetArgumentNode {
   }
 
   @Override
+  public final boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return name.checkUnusedDeclarations(errorHandler);
+  }
+
+  @Override
   public WildcardCheck checkWildcard(Consumer<String> errorHandler) {
     return name.checkWildcard(errorHandler);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
@@ -428,6 +428,8 @@ public abstract class OliveClauseNode {
         });
   }
 
+  public abstract boolean checkUnusedDeclarations(Consumer<String> errorHandler);
+
   public abstract void collectPlugins(Set<Path> pluginFileNames);
 
   public abstract int column();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseDump.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseDump.java
@@ -36,6 +36,11 @@ public abstract class OliveClauseNodeBaseDump extends OliveClauseNode implements
   protected abstract Predicate<String> captureVariable();
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   public final int column() {
     return column;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
@@ -27,6 +27,11 @@ public class OliveClauseNodeCall extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     arguments.forEach(arg -> arg.collectPlugins(pluginFileNames));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
@@ -32,6 +32,11 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return name.checkUnusedDeclarations(errorHandler);
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     expression.collectPlugins(pluginFileNames);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
@@ -50,6 +50,7 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
                             "%d:%d: Non-stream variable “%s” in “By”.", line, column, name));
                     return null;
                   }
+                  target.ifPresent(Target::read);
                   return target.orElse(null);
                 })
             .filter(Objects::nonNull)
@@ -78,6 +79,21 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
     this.children = children;
     this.discriminators = discriminators;
     this.where = where;
+  }
+
+  @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    boolean ok = true;
+    for (final GroupNode child : children) {
+      if (!child.isRead()) {
+        ok = false;
+        errorHandler.accept(
+            String.format(
+                "%d:%d: Collected result “%s” is never used.",
+                child.line(), child.column(), child.name()));
+      }
+    }
+    return ok;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
@@ -75,6 +75,21 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    boolean ok = true;
+    for (final GroupNode child : children) {
+      if (!child.isRead()) {
+        ok = false;
+        errorHandler.accept(
+            String.format(
+                "%d:%d: Collected result “%s” is never used.",
+                child.line(), child.column(), child.name()));
+      }
+    }
+    return ok;
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     children.forEach(child -> child.collectPlugins(pluginFileNames));
     discriminators.forEach(discrminator -> discrminator.collectPlugins(pluginFileNames));
@@ -336,6 +351,11 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
                           @Override
                           public String name() {
                             return outputNames.get(i);
+                          }
+
+                          @Override
+                          public void read() {
+                            // We don't care if the grouper's special outputs aren't used.
                           }
 
                           @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
@@ -37,6 +37,11 @@ public class OliveClauseNodeJoin extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     outerKey.collectPlugins(pluginFileNames);
     innerKey.collectPlugins(pluginFileNames);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
@@ -48,6 +48,21 @@ public final class OliveClauseNodeLeftJoin extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    boolean ok = true;
+    for (final GroupNode child : children) {
+      if (!child.isRead()) {
+        ok = false;
+        errorHandler.accept(
+            String.format(
+                "%d:%d: Collected result “%s” is never used.",
+                child.line(), child.column(), child.name()));
+      }
+    }
+    return ok;
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     outerKey.collectPlugins(pluginFileNames);
     innerKey.collectPlugins(pluginFileNames);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
@@ -29,6 +29,17 @@ public class OliveClauseNodeLet extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    boolean ok = true;
+    for (final LetArgumentNode argument : arguments) {
+      if (!argument.checkUnusedDeclarations(errorHandler)) {
+        ok = false;
+      }
+    }
+    return ok;
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     arguments.forEach(arg -> arg.collectPlugins(pluginFileNames));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
@@ -47,6 +47,11 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   public void collectFreeVariables(Set<String> freeVariables) {
     labels.forEach(arg -> arg.collectFreeVariables(freeVariables, Flavour::needsCapture));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
@@ -37,6 +37,11 @@ public class OliveClauseNodePick extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     extractor.collectPlugins(pluginFileNames);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
@@ -37,6 +37,11 @@ public class OliveClauseNodeReject extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     expression.collectPlugins(pluginFileNames);
     handlers.forEach(handler -> handler.collectPlugins(pluginFileNames));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
@@ -49,6 +49,11 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return name.checkUnusedDeclarations(errorHandler);
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     expression.collectPlugins(pluginFileNames);
     handlers.forEach(handler -> handler.collectPlugins(pluginFileNames));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
@@ -27,6 +27,11 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
     expression.collectPlugins(pluginFileNames);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNode.java
@@ -290,6 +290,9 @@ public abstract class OliveNode {
    */
   public abstract void build(RootBuilder builder, Map<String, OliveDefineBuilder> definitions);
 
+  /** Check that every variable that is declare is used somewhere in the program */
+  public abstract boolean checkUnusedDeclarations(Consumer<String> errorHandler);
+
   /** Check the rules that “Call” clauses must only precede “Group” clauses */
   public abstract boolean checkVariableStream(Consumer<String> errorHandler);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -105,6 +105,11 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
   }
 
   @Override
+  public boolean checkUnusedDeclarationsExtra(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   protected void collectArgumentSignableVariables() {
     labels.forEach(arg -> arg.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals));
     annotations.forEach(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
@@ -45,6 +45,19 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses {
   }
 
   @Override
+  public boolean checkUnusedDeclarationsExtra(Consumer<String> errorHandler) {
+    boolean ok = true;
+    for (final OliveParameter parameter : parameters) {
+      if (!parameter.isRead()) {
+        ok = false;
+        errorHandler.accept(
+            String.format("%d:%d: Parameter “%s” is never used.", line, column, parameter.name()));
+      }
+    }
+    return ok;
+  }
+
+  @Override
   protected void collectArgumentSignableVariables() {
     // Do nothing.
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeFunction.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeFunction.java
@@ -27,7 +27,14 @@ public class OliveNodeFunction extends OliveNode implements FunctionDefinition {
   private Method method;
   private final String name;
   private Type ownerType;
+  private boolean read;
   private final List<OliveParameter> parameters;
+
+  @Override
+  public void read() {
+
+    read = true;
+  }
 
   public OliveNodeFunction(
       int line,
@@ -53,6 +60,17 @@ public class OliveNodeFunction extends OliveNode implements FunctionDefinition {
             name,
             body.type().apply(TypeUtils.TO_ASM),
             parameters.stream().map(p -> p.type().apply(TypeUtils.TO_ASM)).toArray(Type[]::new));
+  }
+
+  @Override
+  public boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    if (read || exported) {
+      return true;
+    } else {
+      errorHandler.accept(
+          String.format("%d:%d: Function “%s” is neither used nor exported.", line, column, name));
+      return false;
+    }
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRefill.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRefill.java
@@ -97,6 +97,11 @@ public final class OliveNodeRefill extends OliveNodeWithClauses {
   }
 
   @Override
+  public boolean checkUnusedDeclarationsExtra(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   protected void collectArgumentSignableVariables() {
     arguments.forEach(
         arg -> arg.second().collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
@@ -61,6 +61,11 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
   }
 
   @Override
+  public boolean checkUnusedDeclarationsExtra(Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
   protected void collectArgumentSignableVariables() {
     arguments.forEach(
         arg -> arg.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeWithClauses.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeWithClauses.java
@@ -21,6 +21,15 @@ public abstract class OliveNodeWithClauses extends OliveNode {
     this.clauses = clauses;
   }
 
+  @Override
+  public final boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
+    return clauses.stream().filter(c -> c.checkUnusedDeclarations(errorHandler)).count()
+            == clauses.size()
+        & checkUnusedDeclarationsExtra(errorHandler);
+  }
+
+  public abstract boolean checkUnusedDeclarationsExtra(Consumer<String> errorHandler);
+
   /** Check the rules that call clauses must only precede “Group” clauses */
   @Override
   public final boolean checkVariableStream(Consumer<String> errorHandler) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveParameter.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveParameter.java
@@ -20,7 +20,7 @@ public class OliveParameter implements Target {
   }
 
   private final String name;
-
+  private boolean read;
   private Imyhat realType;
   private final ImyhatNode type;
 
@@ -34,9 +34,18 @@ public class OliveParameter implements Target {
     return Flavour.PARAMETER;
   }
 
+  public boolean isRead() {
+    return read;
+  }
+
   @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
   }
 
   public boolean resolveTypes(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
@@ -276,6 +276,11 @@ public class ProgramNode {
         ok
             && olives.stream().filter(olive -> olive.typeCheck(errorHandler)).count()
                 == olives.size();
+    // Check for unused definitions
+    ok =
+        ok
+            && olives.stream().filter(olive -> olive.checkUnusedDeclarations(errorHandler)).count()
+                == olives.size();
     return ok;
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Target.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Target.java
@@ -57,6 +57,35 @@ public interface Target {
     }
   }
 
+  public static final TargetWithContext BAD =
+      new TargetWithContext() {
+
+        @Override
+        public Flavour flavour() {
+          return Flavour.CONSTANT;
+        }
+
+        @Override
+        public String name() {
+          return "<BAD>";
+        }
+
+        @Override
+        public void read() {
+          // Ignore it
+        }
+
+        @Override
+        public void setContext(NameDefinitions defs) {
+          // Ignore it
+        }
+
+        @Override
+        public Imyhat type() {
+          return Imyhat.BAD;
+        }
+      };
+
   static Target softWrap(Target target) {
     if (!target.flavour().isStream) {
       throw new IllegalArgumentException(
@@ -72,6 +101,11 @@ public interface Target {
       @Override
       public String name() {
         return target.name();
+      }
+
+      @Override
+      public void read() {
+        target.read();
       }
 
       @Override
@@ -99,40 +133,25 @@ public interface Target {
       }
 
       @Override
+      public void read() {
+        target.read();
+      }
+
+      @Override
       public Imyhat type() {
         return target.type();
       }
     };
   }
-  public static final TargetWithContext BAD =
-      new TargetWithContext() {
-
-        @Override
-        public Flavour flavour() {
-          return Flavour.CONSTANT;
-        }
-
-        @Override
-        public String name() {
-          return "<BAD>";
-        }
-
-        @Override
-        public void setContext(NameDefinitions defs) {
-          // Ignore it
-        }
-
-        @Override
-        public Imyhat type() {
-          return Imyhat.BAD;
-        }
-      };
 
   /** What category of variables this one belongs to */
   Flavour flavour();
 
   /** The Shemsu name for this variable */
   String name();
+
+  /** Indicate that this variable is read */
+  void read();
 
   /** The Shesmu type for this variable */
   Imyhat type();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeUtils.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeUtils.java
@@ -287,6 +287,7 @@ public class TypeUtils {
                             line, column, p.name(), definition.name()));
                     return Stream.empty();
                   }
+                  source.get().read();
                   return Stream.of(constructor.apply(source.get(), p.type(), p.dropIfDefault()));
                 })
             .collect(Collectors.toList());

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
@@ -122,9 +122,9 @@ public abstract class ConstantDefinition implements Target {
   }
 
   private static final Type A_CONSTANT_LOADER_TYPE = Type.getType(ConstantLoader.class);
-  private static final Type A_OBJECT_NODE_TYPE = Type.getType(ObjectNode.class);
   private static final Type A_IMYHAT_TYPE = Type.getType(Imyhat.class);
   private static final Type A_JSON_OBJECT_TYPE = Type.getType(ObjectNode.class);
+  private static final Type A_OBJECT_NODE_TYPE = Type.getType(ObjectNode.class);
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
   private static final Type A_PACK_JSON_OBJECT_TYPE = Type.getType(PackJsonObject.class);
   private static final Type A_SET_TYPE = Type.getType(Set.class);
@@ -155,83 +155,6 @@ public abstract class ConstantDefinition implements Target {
       new Method("<init>", Type.VOID_TYPE, new Type[] {A_OBJECT_NODE_TYPE, A_STRING_TYPE});
   private static final Method SET__ADD =
       new Method("add", Type.BOOLEAN_TYPE, new Type[] {Type.getType(Object.class)});
-  private final String description;
-  private final String name;
-  private final Path path;
-  private final Imyhat type;
-  private final LoadableValue loadable =
-      new LoadableValue() {
-
-        @Override
-        public void accept(Renderer renderer) {
-          load(renderer.methodGen());
-        }
-
-        @Override
-        public String name() {
-          return name;
-        }
-
-        @Override
-        public Type type() {
-          return type.apply(TypeUtils.TO_ASM);
-        }
-      };
-
-  /**
-   * Create a new constant
-   *
-   * @param name the name of the constant, which must be valid Shesmu identifier
-   * @param type the Shemsu type of the constant
-   */
-  public ConstantDefinition(String name, Imyhat type, String description, Path path) {
-    super();
-    this.name = name;
-    this.type = type;
-    this.description = description;
-    this.path = path;
-  }
-
-  /** Convert the constant into a form that can be used during bytecode generation */
-  public final LoadableValue asLoadable() {
-    return loadable;
-  }
-
-  /** Generate a class that write the constant to JSON when called. */
-  public final ConstantLoader compile() {
-    return new ConstantCompiler().compile();
-  }
-
-  /** The documentation text for a constant. */
-  public final String description() {
-    return description;
-  }
-
-  @Override
-  public final Flavour flavour() {
-    return Flavour.CONSTANT;
-  }
-
-  /**
-   * Generate bytecode in the supplied method to load this constant on the operand stack.
-   *
-   * @param methodGen the method to load the value in
-   */
-  protected abstract void load(GeneratorAdapter methodGen);
-
-  public final Path filename() {
-    return path;
-  }
-
-  /**
-   * The name of the constant.
-   *
-   * <p>This must be a valid identifier.
-   */
-  @Override
-  public final String name() {
-    return name;
-  }
 
   /**
    * Define a boolean constant
@@ -292,6 +215,89 @@ public abstract class ConstantDefinition implements Target {
         methodGen.push(value);
       }
     };
+  }
+
+  private final String description;
+  private final String name;
+  private final Path path;
+  private final Imyhat type;
+  private final LoadableValue loadable =
+      new LoadableValue() {
+
+        @Override
+        public void accept(Renderer renderer) {
+          load(renderer.methodGen());
+        }
+
+        @Override
+        public String name() {
+          return name;
+        }
+
+        @Override
+        public Type type() {
+          return type.apply(TypeUtils.TO_ASM);
+        }
+      };
+
+  /**
+   * Create a new constant
+   *
+   * @param name the name of the constant, which must be valid Shesmu identifier
+   * @param type the Shemsu type of the constant
+   */
+  public ConstantDefinition(String name, Imyhat type, String description, Path path) {
+    super();
+    this.name = name;
+    this.type = type;
+    this.description = description;
+    this.path = path;
+  }
+
+  /** Convert the constant into a form that can be used during bytecode generation */
+  public final LoadableValue asLoadable() {
+    return loadable;
+  }
+
+  /** Generate a class that write the constant to JSON when called. */
+  public final ConstantLoader compile() {
+    return new ConstantCompiler().compile();
+  }
+
+  /** The documentation text for a constant. */
+  public final String description() {
+    return description;
+  }
+
+  public final Path filename() {
+    return path;
+  }
+
+  @Override
+  public final Flavour flavour() {
+    return Flavour.CONSTANT;
+  }
+
+  /**
+   * Generate bytecode in the supplied method to load this constant on the operand stack.
+   *
+   * @param methodGen the method to load the value in
+   */
+  protected abstract void load(GeneratorAdapter methodGen);
+
+  /**
+   * The name of the constant.
+   *
+   * <p>This must be a valid identifier.
+   */
+  @Override
+  public final String name() {
+    return name;
+  }
+
+  @Override
+  public final void read() {
+    // Grand. No one cares.
   }
 
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/FunctionDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/FunctionDefinition.java
@@ -144,6 +144,9 @@ public interface FunctionDefinition {
   /** The parameters of the function, in order */
   Stream<FunctionParameter> parameters();
 
+  /** The function was actually used in a program. */
+  default void read() {}
+
   /** Create bytecode for this function. */
   void render(GeneratorAdapter methodGen);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureDefinition.java
@@ -57,6 +57,11 @@ public abstract class SignatureDefinition implements Target {
     return name;
   }
 
+  @Override
+  public void read() {
+    // Stellar. Don't care.
+  }
+
   public final SignatureStorage storage() {
     return storage;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/AnnotatedInputFormatDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/AnnotatedInputFormatDefinition.java
@@ -437,6 +437,11 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
             }
 
             @Override
+            public void read() {
+              // Exciting! Don't care.
+            }
+
+            @Override
             public Imyhat type() {
               return type;
             }

--- a/shesmu-server/src/test/resources/compiler/action-wildcard.shesmu
+++ b/shesmu-server/src/test/resources/compiler/action-wildcard.shesmu
@@ -1,11 +1,11 @@
 Input test;
 
 
-Define standard_fastq(string s)
+Define standard_fastq()
   Where workflow == {"BamQC 2.7+", 3 }[0];
 
 Olive
-  standard_fastq("a")
+  standard_fastq()
   Group By accession Into files = List "{path}"
   Run fastqc With
     * = {memory = 4Gi},

--- a/shesmu-server/src/test/resources/compiler/basic.shesmu
+++ b/shesmu-server/src/test/resources/compiler/basic.shesmu
@@ -6,7 +6,7 @@ Define standard_execution()
 
 Define standard_fastq(string s)
   Where workflow == {"BamQC 2.7+", 3 }[0]
-  Where project == "foo"
+  Where project == "foo" && project != s
   Where str_len("{path}") == file_size;
 
 Define standard_bam()

--- a/shesmu-server/src/test/resources/compiler/just-param.shesmu
+++ b/shesmu-server/src/test/resources/compiler/just-param.shesmu
@@ -1,3 +1,3 @@
 Input test;
 
-Function foo(integer? x) x;
+Export Function foo(integer? x) x;

--- a/shesmu-server/src/test/resources/compiler/let.shesmu
+++ b/shesmu-server/src/test/resources/compiler/let.shesmu
@@ -3,5 +3,5 @@ Input test;
 Olive
   Let x = path, y = workflow
   Run optional With
-    junk = True;
+    junk = x != '/' && y != "";
   

--- a/shesmu-server/src/test/resources/compiler/list-empty-collect.errors
+++ b/shesmu-server/src/test/resources/compiler/list-empty-collect.errors
@@ -1,0 +1,1 @@
+4:6: Variable “foo” is never used.

--- a/shesmu-server/src/test/resources/compiler/list-empty-group.errors
+++ b/shesmu-server/src/test/resources/compiler/list-empty-group.errors
@@ -1,0 +1,1 @@
+5:9: Collected result “x” is never used.

--- a/shesmu-server/src/test/resources/compiler/match-with-group.shesmu
+++ b/shesmu-server/src/test/resources/compiler/match-with-group.shesmu
@@ -3,7 +3,7 @@ Input test;
 # this a comment
 Define standard_fastq(string s)
   Where workflow == { "BamQC 2.7+" ,3} [ 0 ] 
-  Where project == "foo"
+  Where project == "foo" && project != s
   Where str_len ( "{path}" )==file_size
   Group By accession, project Into files = List "{path}";
 

--- a/shesmu-server/src/test/resources/compiler/shadow-constant.errors
+++ b/shesmu-server/src/test/resources/compiler/shadow-constant.errors
@@ -1,0 +1,1 @@
+3:9: Function “x” is neither used nor exported.

--- a/shesmu-server/src/test/resources/run/group-any.shesmu
+++ b/shesmu-server/src/test/resources/run/group-any.shesmu
@@ -7,4 +7,4 @@ Olive
     x = Where library_size == 307 First path,
     y = Where library_size == 300 First path,
     z = Any library_size > 305
- Run ok With ok = z;
+ Run ok With ok = z && x != y;

--- a/shesmu-server/src/test/resources/run/group-common-where.shesmu
+++ b/shesmu-server/src/test/resources/run/group-common-where.shesmu
@@ -8,4 +8,4 @@ Olive
     x = Where library_size == 307 First path,
     y = Where library_size == 300 First path,
     z = Any library_size > 305
- Run ok With ok = z;
+ Run ok With ok = z && x != y;

--- a/shesmu-server/src/test/resources/run/group-first-default1.shesmu
+++ b/shesmu-server/src/test/resources/run/group-first-default1.shesmu
@@ -6,4 +6,4 @@ Olive
   Into
      x = Where library_size == 307 First path Default '.',
      y = Where library_size == 300 First path
- Run ok With ok = x != '.';
+ Run ok With ok = x != '.' && x != y;

--- a/shesmu-server/src/test/resources/run/group-first-default2.shesmu
+++ b/shesmu-server/src/test/resources/run/group-first-default2.shesmu
@@ -6,4 +6,4 @@ Olive
   Into
      x = Where library_size == 999 First path Default '.',
      y = Where library_size == 300 First path
- Run ok With ok = x == '.';
+ Run ok With ok = x == '.' && x != y;

--- a/shesmu-server/src/test/resources/run/group-first.shesmu
+++ b/shesmu-server/src/test/resources/run/group-first.shesmu
@@ -6,4 +6,4 @@ Olive
   Into
      x = Where library_size == 307 First path,
      y = Where library_size == 300 First path
- Run ok With ok = True;
+ Run ok With ok = x != y;

--- a/shesmu-server/src/test/resources/run/group-include_always-func-define.shesmu
+++ b/shesmu-server/src/test/resources/run/group-include_always-func-define.shesmu
@@ -13,4 +13,4 @@ Define foo()
 
 Olive
  foo()
- Run ok With ok = a == 2 && b == 1;
+ Run ok With ok = a == 2 && b == 1 && c.matched_count > 0 && c.not_matched_count > 0;

--- a/shesmu-server/src/test/resources/run/group-include_always-func.shesmu
+++ b/shesmu-server/src/test/resources/run/group-include_always-func.shesmu
@@ -10,4 +10,4 @@ Olive
     a = Count,
     b = Where is_always Count,
     c = PartitionCount is_always
- Run ok With ok = a == 2 && b == 1;
+ Run ok With ok = a == 2 && b == 1 && c.matched_count > 0 && c.not_matched_count > 0;

--- a/shesmu-server/src/test/resources/run/group-optima.shesmu
+++ b/shesmu-server/src/test/resources/run/group-optima.shesmu
@@ -7,4 +7,4 @@ Olive
     x = Where library_size == 307 First path,
     y = Where library_size == 300 First path,
     z = Max library_size
- Run ok With ok = z == 307;
+ Run ok With ok = z == 307 && x != y;

--- a/shesmu-server/src/test/resources/run/group-optima2.shesmu
+++ b/shesmu-server/src/test/resources/run/group-optima2.shesmu
@@ -7,4 +7,4 @@ Olive
     x = Where library_size == 307 First path,
     y = Where library_size == 300 First path,
     z = Max timestamp
- Run ok With ok = z == EpochSecond 500;
+ Run ok With ok = z == EpochSecond 500 && y != x;

--- a/shesmu-server/src/test/resources/run/leftjoin.shesmu
+++ b/shesmu-server/src/test/resources/run/leftjoin.shesmu
@@ -3,5 +3,5 @@ Input test;
 Olive
  Let p = project
  LeftJoin True To inner_test True
-    ls = List l
+    ls = Where p != "" List l
  Run ok With ok = (For l In ls: Count) == 2;


### PR DESCRIPTION
Background info on this:

Right now, it's possible to copy variables in a `Let` that never get used anywhere and these will make it into the signature. To reduce signature pollution, the idea is to have Shesmu reject variables that are never used.

This tries to detect variables that are never used (or make part of a grouping condition or something else that changes the behaviour of the olive) and raise an error.