### PR TITLE
Fix stack overflow when parsing paths

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Parser.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Parser.java
@@ -164,13 +164,21 @@ public abstract class Parser {
       }
       for (int i = 0; i < symbol.length(); i++) {
         if (symbol.charAt(i) != input.charAt(i)) {
+          final CharSequence got;
+          if (input.charAt(i) == '\n') {
+            got = "\\n";
+          } else if (Character.isISOControl(input.charAt(i))) {
+            got = String.format("\\U%06X", (int) input.charAt(i));
+          } else {
+            got = input.subSequence(i, i + 1);
+          }
+
           return new Broken(
               errorConsumer(),
               line(),
               column(),
               String.format(
-                  "Expected “%s”, but got %c instead of %c.",
-                  symbol, input.charAt(i), symbol.charAt(i)));
+                  "Expected “%s”, but got %s instead of %c.", symbol, got, symbol.charAt(i)));
         }
       }
       return new Good(

--- a/shesmu-server/src/test/resources/compiler/bad-path.errors
+++ b/shesmu-server/src/test/resources/compiler/bad-path.errors
@@ -1,0 +1,1 @@
+5:26: Expected “'”, but got \n instead of '.

--- a/shesmu-server/src/test/resources/compiler/bad-path.shesmu
+++ b/shesmu-server/src/test/resources/compiler/bad-path.shesmu
@@ -1,0 +1,37 @@
+Input test;
+
+Olive
+  Where `Switch reference?
+      When "hg38" Then '{
+            template_metadata = "$HG38_MAVIS_ROOT/cytoBand.txt"
+        }`
+      Else `` `
+  Run ok
+    With
+    wdl_inputs = {
+      mavis = {
+        inputBAMs = [{libraryDesign = bam_library_design, bam = bam, bamIndex = bam_index}],
+        runMavis = {
+          dvgAnnotations = `reference_info.dvg_annotations`,
+          mavisTransValidationMemory = `32000`,
+          mavisMemoryLimit = `32000`,
+          templateMetadata = `reference_info.template_metadata`,
+          minClusterPerFile = `5`,
+          mavisAnnotationMemory = `32000`,
+          mavisUninformativeFilter = `"True"`,
+          drawNonSynonymousCdnaOnly = `"False"`,
+          sleepInterval = `20`,
+          modules = `"mavis/2.2.6 {reference_info.modules}"`,
+          outputCONFIG = `"mavis_config.cfg"`,
+          annotations = `reference_info.annotations`,
+          masking = `reference_info.masking`,
+          referenceGenome = `reference_info.fasta`,
+          alignerReference = `reference_info.aligner_reference`,
+          mavisAligner = `"blat"`,
+          mavisScheduler = `"SGE"`,
+          scriptName = `"mavis_config.sh"`,
+          mavisDrawFusionOnly = `"False"`,
+          jobMemory = `12`
+        }
+     }
+   };


### PR DESCRIPTION
The test case is not very minimal, but a smaller case didn't produce the same
issue. This prevents paths from spanning multiple lines.