### PR TITLE
Provide a better implementation of a generic SSH refiller

### DIFF
--- a/plugin-sftp/README.md
+++ b/plugin-sftp/README.md
@@ -97,6 +97,9 @@ same directory):
     cat >current_data
     echo "${1}" >current_hash
 
+A more sophisticated version of this script is provided as
+`shesmu-json-refiller` if it suits your needs.
+
 ## JSON Sources
 It is possible to extract data over SSH by remotely executing a command that
 streams this data in JSON format to standard output. This data should be in the

--- a/plugin-sftp/shesmu-json-refiller
+++ b/plugin-sftp/shesmu-json-refiller
@@ -1,0 +1,67 @@
+#!/bin/sh
+#
+# Receive data provided by a Shesmu SSH refiller and save it to a file
+#
+# This does no processing to the data and therefore can be used with any format.
+
+NEW_CHECKSUM=MISSING
+HELP=false
+NAME=refiller
+TARGET_DIR=.
+
+set -eu
+
+TEMP=`getopt c:d:hn: "$@"`
+
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+
+eval set -- "$TEMP"
+
+while true ; do
+	case "$1" in
+		-c)
+			NEW_CHECKSUM="$2"
+			shift 2
+			;;
+		-d)
+			TARGET_DIR="$2"
+			shift 2
+			;;
+		-h)
+			HELP=true
+      shift
+			;;
+		-n)
+			NAME="$2"
+			shift 2
+			;;
+		--)
+			shift
+			break
+			;;
+		*) echo "Internal error!" ; exit 1 ;;
+	esac
+done
+
+if $HELP || [ $# -ne 0 ] || [ "${NEW_CHECKSUM}" = "MISSING" ]
+then
+	echo $0 '-c checksum [-d outputdir] [-n name]'
+	echo '  -c  The checksum provided by Shesmu'
+	echo '  -d  Directory to place output in (default is current directory)'
+	echo '  -h  Display help'
+	echo '  -n  The prefix of the output file (default is refiller)'
+	exit 1
+fi
+
+
+cd "${TARGET_DIR}"
+if [ -f "${NAME}.checksum" ]; then
+	EXISTING_CHECKSUM="$(cat "${NAME}.checksum")"
+	if [ "${NEW_CHECKSUM}" = "${EXISTING_CHECKSUM}" ]; then
+		echo OK
+		exit 0
+	fi
+fi
+echo UPDATE
+cat >"${NAME}.json"
+echo "${NEW_CHECKSUM}" >"${NAME}.checksum"


### PR DESCRIPTION
This is the first step in getting the JSON file for Dashi generated. This is a better version of the example refiller provided in the readme. The spec for the refiller is in the readme modified in the PR and it's also what ETL is using. Next step will for a copy of this script to go into our internal repository.