### PR TITLE
Allow `*` to cross `Require` and `Flatten` boundaries

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/NameDefinitions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/NameDefinitions.java
@@ -117,6 +117,7 @@ public class NameDefinitions {
     Optional<Target> result = Optional.ofNullable(variables.get(name));
     if (!result.isPresent()) {
       result = undefinedVariableProvider.handleUndefinedVariable(name);
+      result.ifPresent(t -> variables.put(t.name(), t));
     }
     return result;
   }
@@ -147,6 +148,10 @@ public class NameDefinitions {
 
   public Stream<Target> stream() {
     return variables.values().stream();
+  }
+
+  public UndefinedVariableProvider undefinedVariableProvider() {
+    return undefinedVariableProvider;
   }
 
   public NameDefinitions withProvider(UndefinedVariableProvider undefinedVariableProvider) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
@@ -136,13 +136,15 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
                           return false;
                         })
                     .count()
-                == 0;
+                == 0
+            & expression.resolve(defs, errorHandler)
+            & name.resolve(oliveCompilerServices, errorHandler);
     return defs.replaceStream(
-            Stream.concat(incoming.stream().map(Target::wrap), name.targets()),
-            expression.resolve(defs, errorHandler)
-                    & name.resolve(oliveCompilerServices, errorHandler)
-                && ok)
-        .withProvider(name);
+            Stream.concat(incoming.stream().map(Target::wrap), name.targets()), ok)
+        .withProvider(
+            UndefinedVariableProvider.combine(
+                name,
+                UndefinedVariableProvider.listen(defs.undefinedVariableProvider(), incoming::add)));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/UndefinedVariableProvider.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/UndefinedVariableProvider.java
@@ -1,10 +1,30 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
+/**
+ * Something that can "create" undefined variables out of thin air.
+ *
+ * <p>This is used by <tt>*</tt> to force an undefined variable to be created
+ */
 public interface UndefinedVariableProvider {
   UndefinedVariableProvider NONE = n -> Optional.empty();
 
+  /**
+   * Create a provider that delegates to another and invokes a callback with any results that are
+   * produced
+   */
+  static UndefinedVariableProvider listen(
+      UndefinedVariableProvider input, Consumer<Target> consumer) {
+    return name -> {
+      final Optional<Target> result = input.handleUndefinedVariable(name);
+      result.ifPresent(consumer);
+      return result;
+    };
+  }
+
+  /** Combine two providers in sequence */
   static UndefinedVariableProvider combine(
       UndefinedVariableProvider first, UndefinedVariableProvider second) {
     return name -> {

--- a/shesmu-server/src/test/resources/run/destructure-wildcard-clauses.shesmu
+++ b/shesmu-server/src/test/resources/run/destructure-wildcard-clauses.shesmu
@@ -1,0 +1,6 @@
+Input test;
+
+Olive
+ Flatten * In [{ a = `True`, b = 3 }]
+ Require x = a {}
+ Run ok With ok = x && b == 3;


### PR DESCRIPTION
Mike was trying to do:

    Let x
    Flatten * In x
    Require a = s1 # This is inferred to come from the *
    Where s2 # This should come from the *, but it gets eaten by the `Require`

This allows the `*` to cross the `Require` and `Flatten` boundaries if they
don't have `*` themselves