### PR TITLE
Remove restriction from having `*` in `Let`

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeBaseExpression.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeBaseExpression.java
@@ -71,26 +71,7 @@ public abstract class LetArgumentNodeBaseExpression extends LetArgumentNode {
   @Override
   public final boolean resolveFunctions(
       ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
-    boolean ok;
-    switch (name.checkWildcard(errorHandler)) {
-      case NONE:
-        ok = true;
-        break;
-      case HAS_WILDCARD:
-        errorHandler.accept(
-            String.format(
-                "%d:%d: Let argument has wildcard, but this is not allowed.",
-                expression.line(), expression.column()));
-        ok = false;
-        break;
-      case BAD:
-        ok = false;
-        break;
-      default:
-        throw new IllegalStateException("Unknown wildcard result.");
-    }
-    return ok
-        & expression.resolveDefinitions(expressionCompilerServices, errorHandler)
+    return expression.resolveDefinitions(expressionCompilerServices, errorHandler)
         & name.resolve(expressionCompilerServices, errorHandler);
   }
 

--- a/shesmu-server/src/test/resources/run/destructure-wildcard-let.shesmu
+++ b/shesmu-server/src/test/resources/run/destructure-wildcard-let.shesmu
@@ -1,0 +1,5 @@
+Input test;
+
+Olive
+ Let * = {a = True, b = 1}
+ Run ok With ok = a && b == 1;


### PR DESCRIPTION
I had a specific check to prevent this and I have no idea why, so I've removed it.