### PR TITLE
Fix requirement check on Alert clause

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -45,7 +45,7 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
 
                     @Override
                     public boolean required() {
-                      return false;
+                      return true;
                     }
 
                     @Override


### PR DESCRIPTION
There was an incorrect parameter settings which allowed `string?` to be used as
a parameter to an `Alert`. If it was empty, the alert would not be filled in
correctly resulting in a serialisation error.