### PR TITLE
Change precedence of `?` operator

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -549,12 +549,6 @@ public abstract class ExpressionNode implements Renderable {
         "%",
         binaryOperators("%", BinaryOperation.primitiveMath(Imyhat.INTEGER, GeneratorAdapter.REM)));
 
-    SUFFIX_LOOSE.addSymbol(
-        "?",
-        (p, o) -> {
-          o.accept(node -> new ExpressionNodeOptionalUnbox(p.line(), p.column(), node));
-          return p;
-        });
     SUFFIX_LOOSE.addKeyword(
         "In",
         (p, o) -> {
@@ -618,7 +612,12 @@ public abstract class ExpressionNode implements Renderable {
           }
           return result;
         });
-
+    SUFFIX_TIGHT.addSymbol(
+        "?",
+        (p, o) -> {
+          o.accept(node -> new ExpressionNodeOptionalUnbox(p.line(), p.column(), node));
+          return p;
+        });
     TERMINAL.addKeyword(
         "Date",
         (p, o) ->


### PR DESCRIPTION
This makes the `?` have higher precedence. It came about when doing:

    `"x" In foo["a"]?` Default False

which was getting interpreted as

    `("x" In foo["a"])?` Default False

when

    `"x" In (foo["a"]?)` Default False

is more intuitive.