### PR TITLE
Allow throttling workflow launch

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/MaxStatus.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/MaxStatus.java
@@ -3,5 +3,6 @@ package ca.on.oicr.gsi.shesmu.niassa;
 public enum MaxStatus {
   RUN,
   TOO_MANY_RUNNING,
+  EXTERNAL_THROTTLE,
   INVALID_SWID
 }

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
@@ -6,6 +6,7 @@ import ca.on.oicr.gsi.provenance.model.AnalysisProvenance;
 import ca.on.oicr.gsi.shesmu.cerberus.CerberusAnalysisProvenanceValue;
 import ca.on.oicr.gsi.shesmu.plugin.Definer;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionServices;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import ca.on.oicr.gsi.shesmu.plugin.action.ShesmuAction;
 import ca.on.oicr.gsi.shesmu.plugin.cache.*;
@@ -504,21 +505,27 @@ class NiassaServer extends JsonPluginFile<Configuration> {
     maxInFlightCache.invalidate(workflowRunSwid);
   }
 
-  public synchronized MaxStatus maxInFlight(String workflowName, long workflowAccession) {
+  public MaxStatus maxInFlight(
+      ActionServices services, String workflowName, long workflowAccession) {
     // Ban all jobs with invalid accessions from running
     if (workflowAccession < 1) {
       return MaxStatus.INVALID_SWID;
     }
-    return maxInFlightCache
-        .get(workflowAccession)
-        .map(
-            running -> {
-              foundRunning.labels(url(), workflowName).set(running);
-              return running >= maxInFlight.getOrDefault(workflowName, 0)
-                  ? MaxStatus.TOO_MANY_RUNNING
-                  : MaxStatus.RUN;
-            })
-        .orElse(MaxStatus.RUN);
+    if (services.isOverloaded("niassa-launch", workflowName)) {
+      return MaxStatus.EXTERNAL_THROTTLE;
+    }
+    synchronized (this) {
+      return maxInFlightCache
+          .get(workflowAccession)
+          .map(
+              running -> {
+                foundRunning.labels(url(), workflowName).set(running);
+                return running >= maxInFlight.getOrDefault(workflowName, 0)
+                    ? MaxStatus.TOO_MANY_RUNNING
+                    : MaxStatus.RUN;
+              })
+          .orElse(MaxStatus.RUN);
+    }
   }
 
   public Metadata metadata() {

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -334,7 +334,7 @@ public final class WorkflowAction extends Action {
           // Check if there are already too many copies of this workflow running; if so, wait until
           // later.
           if (!ignoreMaxInFlight) {
-            switch (server.get().maxInFlight(workflowName, workflowAccession)) {
+            switch (server.get().maxInFlight(actionServices, workflowName, workflowAccession)) {
               case RUN:
                 break;
               case TOO_MANY_RUNNING:
@@ -342,6 +342,9 @@ public final class WorkflowAction extends Action {
                     Collections.singletonList(
                         "Too many workflows running. Sit tight or increase max-in-flight setting.");
                 return ActionState.WAITING;
+              case EXTERNAL_THROTTLE:
+                this.errors = Collections.singletonList("Launching workflows has been inhibited.");
+                return ActionState.THROTTLED;
               case INVALID_SWID:
                 this.errors =
                     Collections.singletonList(


### PR DESCRIPTION
The throttling and pauses blanket apply to the actions doing anything. This
allows stopping only launching new workflow runs by creating an inhibition with
either the workflow's name or `niassa-launch`.