### PR TITLE
Allow object creation during `Group...Into`

### DIFF
--- a/language.md
+++ b/language.md
@@ -324,6 +324,12 @@ value is collected multiple times.
 
 Performs filtering before _collector_.
 
+- `{` _name1_ `=` _collector1_`,` _name2_ `=` _collector2_`,` ... `}`
+
+Performs multiple collections at once and converts the results into an object.
+This can be very useful to share a `Where` condition while collecting multiple
+pieces of information.
+
 ## Expressions
 Shesmu has the following expressions, for lowest precedence to highest precedence.
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -762,14 +762,7 @@ public abstract class ExpressionNode implements Renderable {
         (p, o) -> {
           final AtomicReference<List<String>> path = new AtomicReference<>();
           final Parser result =
-              p.list(
-                      path::set,
-                      (ip, io) -> {
-                        System.err.println(ip);
-                        return ip.dispatch(PATH, io);
-                      })
-                  .symbol("'")
-                  .whitespace();
+              p.list(path::set, (ip, io) -> ip.dispatch(PATH, io)).symbol("'").whitespace();
           if (p.isGood()) {
             o.accept(
                 new ExpressionNodePathLiteral(p.line(), p.column(), String.join("", path.get())));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeObject.java
@@ -1,0 +1,91 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class GroupNodeObject extends GroupNode {
+  private final List<GroupNode> children;
+  private final String name;
+
+  public GroupNodeObject(int line, int column, String name, List<GroupNode> children) {
+    super(line, column);
+    this.name = name;
+    this.children = children;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    for (final GroupNode child : children) {
+      child.collectFreeVariables(names, predicate);
+    }
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    for (final GroupNode child : children) {
+      child.collectPlugins(pluginFileNames);
+    }
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public void render(Regrouper regroup, RootBuilder builder) {
+    final Regrouper childGrouper =
+        regroup.addObject(
+            name, children.stream().map(child -> new Pair<>(child.name(), child.type())));
+    for (final GroupNode child : children) {
+      child.render(childGrouper, builder);
+    }
+  }
+
+  @Override
+  public boolean resolve(
+      NameDefinitions defs, NameDefinitions outerDefs, Consumer<String> errorHandler) {
+    final Map<String, Long> duplicates =
+        children.stream().collect(Collectors.groupingBy(GroupNode::name, Collectors.counting()));
+    boolean ok = true;
+    for (final Map.Entry<String, Long> duplicate : duplicates.entrySet()) {
+      if (duplicate.getValue() > 1) {
+        errorHandler.accept(
+            String.format(
+                "%d:%d: Duplicate field “%s” in object.", line(), column(), duplicate.getKey()));
+        ok = false;
+      }
+    }
+    return ok
+        & children.stream().filter(c -> c.resolve(defs, outerDefs, errorHandler)).count()
+            == children.size();
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return children
+            .stream()
+            .filter(c -> c.resolveDefinitions(expressionCompilerServices, errorHandler))
+            .count()
+        == children.size();
+  }
+
+  @Override
+  public Imyhat type() {
+    return new Imyhat.ObjectImyhat(
+        children.stream().map(child -> new Pair<>(child.name(), child.type())));
+  }
+
+  @Override
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    return children.stream().filter(c -> c.typeCheck(errorHandler)).count() == children.size();
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Regrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Regrouper.java
@@ -1,7 +1,9 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.objectweb.asm.Type;
 
 /** Build a grouping operation */
@@ -61,6 +63,13 @@ public interface Regrouper {
    * @param condition the condition that must be satisfied
    */
   void addMatches(String name, Match matchType, Consumer<Renderer> condition);
+
+  /**
+   * Create a composite object value
+   *
+   * @param fieldName the name of the object
+   */
+  Regrouper addObject(String fieldName, Stream<Pair<String, Imyhat>> fields);
 
   /**
    * Effectively flatten for optionals

--- a/shesmu-server/src/test/resources/run/group-object.shesmu
+++ b/shesmu-server/src/test/resources/run/group-object.shesmu
@@ -1,0 +1,11 @@
+Input test;
+
+Olive
+ Group By project Into
+	stuff = {
+		a = Count,
+    x = Where library_size == 307 First path,
+    y = Where library_size == 300 First path,
+    z = Any library_size > 305
+	}
+ Run ok With ok = stuff.a == 2 && stuff.z;


### PR DESCRIPTION
This allows creating an object from multiple collectors at once, mostly to
reuse complex `Where` conditions or package related pieces of information
together.