### PR TITLE
Allow turning WDL pairs into objects intead of tuples

### DIFF
--- a/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/onlinereport/Configuration.java
+++ b/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/onlinereport/Configuration.java
@@ -6,9 +6,10 @@ public class Configuration {
   private String cromwell;
   private String description;
   private String labelKey;
+  private boolean pairsAsObjects;
   private Map<String, String> parameters;
-  private String workflowName;
   private String wdl;
+  private String workflowName;
 
   public String getCromwell() {
     return cromwell;
@@ -26,12 +27,16 @@ public class Configuration {
     return parameters;
   }
 
+  public String getWdl() {
+    return wdl;
+  }
+
   public String getWorkflowName() {
     return workflowName;
   }
 
-  public String getWdl() {
-    return wdl;
+  public boolean isPairsAsObjects() {
+    return pairsAsObjects;
   }
 
   public void setCromwell(String cromwell) {
@@ -46,15 +51,19 @@ public class Configuration {
     this.labelKey = labelKey;
   }
 
+  public void setPairsAsObjects(boolean pairsAsObjects) {
+    this.pairsAsObjects = pairsAsObjects;
+  }
+
   public void setParameters(Map<String, String> parameters) {
     this.parameters = parameters;
   }
 
-  public void setWorkflowName(String workflowName) {
-    this.workflowName = workflowName;
-  }
-
   public void setWdl(String wdl) {
     this.wdl = wdl;
+  }
+
+  public void setWorkflowName(String workflowName) {
+    this.workflowName = workflowName;
   }
 }

--- a/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/onlinereport/OnlineReport.java
+++ b/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/onlinereport/OnlineReport.java
@@ -162,7 +162,8 @@ public class OnlineReport extends JsonPluginFile<Configuration> {
                         parameter ->
                             new CustomRefillerParameter<OnlineReportRefiller<I>, I>(
                                 parameter.getKey().replace(".", "_"),
-                                WdlInputType.parseString(parameter.getValue())) {
+                                WdlInputType.parseString(
+                                    parameter.getValue(), configuration.isPairsAsObjects())) {
                               private final String wdlName = parameter.getKey();
 
                               @Override

--- a/plugin-niassa+pinery/README.md
+++ b/plugin-niassa+pinery/README.md
@@ -177,9 +177,14 @@ For WDL-inside-Niassa workflows, there is a special `wdl` type:
 
     {
       "is": "wdl",
+      "pairsAsObjects": false,
       "parameters": {
          "foo.bar.baz": "Int"
        }
     }
 
 There `parameters` section is in the same format as `womtool inputs`.
+
+Normally, Shesmu will convert `Pair[` _x_`,` _y_ `]` into a tuple `{` _x_`,`
+_y_ `}`. If `"pairsAsObjects"` is set to true, then it will be converted to an
+object `{ left =` _x_`, right =` _y_ `}`.

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/IniParam.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/IniParam.java
@@ -76,7 +76,9 @@ public final class IniParam<T> {
                 node.get("delimiter").asText(),
                 Utils.stream(node.get("of")).map(this::deserialize));
           case "wdl":
-            return wdl((ObjectNode) node.get("parameters"));
+            return wdl(
+                (ObjectNode) node.get("parameters"),
+                node.has("pairsAsObjects") && node.get("pairsAsObjects").asBoolean(false));
           default:
             throw new IllegalArgumentException("Unknown INI type: " + type);
         }
@@ -92,11 +94,12 @@ public final class IniParam<T> {
       return deserialize(node);
     }
 
-    private Stringifier wdl(ObjectNode inputs) {
+    private Stringifier wdl(ObjectNode inputs, boolean pairsAsObjects) {
       final Pair<Function<ObjectNode, ImyhatConsumer>, Imyhat> handler =
           PackWdlVariables.create(
               WdlInputType.of(
                   inputs,
+                  pairsAsObjects,
                   (line, column, errorMessage) ->
                       System.err.printf("%d:%d: %s\n", line, column, errorMessage)));
       return new Stringifier() {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -1259,7 +1259,11 @@ public final class Server implements ServerConfig, ActionServices {
                 writer.writeEndElement();
                 writer.writeStartElement("option");
                 writer.writeAttribute("value", "1");
-                writer.writeCharacters("WDL Type");
+                writer.writeCharacters("WDL Type (Pairs as tuples)");
+                writer.writeEndElement();
+                writer.writeStartElement("option");
+                writer.writeAttribute("value", "2");
+                writer.writeCharacters("WDL Type (Pairs as objects)");
                 writer.writeEndElement();
                 writer.writeStartElement("option");
                 writer.writeAttribute("value", "");
@@ -2250,7 +2254,9 @@ public final class Server implements ServerConfig, ActionServices {
           if (request.getFormat() == null || request.getFormat().equals("0")) {
             type = Imyhat.parse(request.getValue());
           } else if (request.getFormat().equals("1")) {
-            type = WdlInputType.parseString(request.getValue());
+            type = WdlInputType.parseString(request.getValue(), false);
+          } else if (request.getFormat().equals("2")) {
+            type = WdlInputType.parseString(request.getValue(), true);
           } else {
             Optional<Function<String, Imyhat>> existingTypes =
                 request.getFormat().isEmpty()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeObject.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 public class GroupNodeObject extends GroupNode {
   private final List<GroupNode> children;
   private final String name;
-
+  private boolean read;
   public GroupNodeObject(int line, int column, String name, List<GroupNode> children) {
     super(line, column);
     this.name = name;
@@ -35,8 +35,18 @@ public class GroupNodeObject extends GroupNode {
   }
 
   @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public void read() {
+read = true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
@@ -254,6 +254,7 @@ public class SimulateRequest {
         return PackWdlVariables.create(
                 WdlInputType.of(
                     (ObjectNode) type,
+                    false,
                     (line, column, errorMessage) ->
                         errorHandler.accept(
                             String.format("%d:%d: %s", line, column, errorMessage))))


### PR DESCRIPTION
The existing conversion predates the existence of object syntax and is more
compact. However, to make use of the new grouping object collector, it is
easier to have the pairs as objects for some workflows. This allows a both to
be possible.