### PR TITLE
Add a caching timeout operation and use it for Niassa

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
@@ -43,7 +43,10 @@ class NiassaServer extends JsonPluginFile<Configuration> {
   private class AnalysisCache
       extends KeyValueCache<Long, Stream<AnalysisState>, Stream<AnalysisState>> {
     public AnalysisCache(Path fileName) {
-      super("niassa-analysis " + fileName.toString(), 120, ReplacingRecord::new);
+      super(
+          "niassa-analysis " + fileName.toString(),
+          120,
+          TimeoutRecord.limit(45, ReplacingRecord::new));
     }
 
     @Override
@@ -97,7 +100,10 @@ class NiassaServer extends JsonPluginFile<Configuration> {
       extends ValueCache<
           Stream<CerberusAnalysisProvenanceValue>, Stream<CerberusAnalysisProvenanceValue>> {
     public AnalysisDataCache(Path fileName) {
-      super("niassa-data-analysis " + fileName.toString(), 20, ReplacingRecord::new);
+      super(
+          "niassa-data-analysis " + fileName.toString(),
+          20,
+          TimeoutRecord.limit(45, ReplacingRecord::new));
     }
 
     @Override
@@ -116,7 +122,10 @@ class NiassaServer extends JsonPluginFile<Configuration> {
       extends KeyValueCache<
           Long, Optional<WorkflowRunEssentials>, Optional<WorkflowRunEssentials>> {
     public DirectoryAndIniCache(Path fileName) {
-      super("niassa-dir+ini " + fileName.toString(), 60 * 24 * 365, SimpleRecord::new);
+      super(
+          "niassa-dir+ini " + fileName.toString(),
+          60 * 24 * 365,
+          TimeoutRecord.limit(5, SimpleRecord::new));
     }
 
     @Override
@@ -238,7 +247,10 @@ class NiassaServer extends JsonPluginFile<Configuration> {
 
   private class MaxInFlightCache extends KeyValueCache<Long, Optional<Integer>, Optional<Integer>> {
     public MaxInFlightCache(Path fileName) {
-      super("niassa-max-in-flight " + fileName.toString(), 5, SimpleRecord::new);
+      super(
+          "niassa-max-in-flight " + fileName.toString(),
+          5,
+          TimeoutRecord.limit(5, SimpleRecord::new));
     }
 
     private int countRecords(String report) {
@@ -275,7 +287,10 @@ class NiassaServer extends JsonPluginFile<Configuration> {
   private class SkipLaneCache
       extends ValueCache<Stream<Pair<Tuple, Tuple>>, Stream<Pair<Tuple, Tuple>>> {
     public SkipLaneCache(Path fileName) {
-      super("niassa-skipped " + fileName.toString(), 20, ReplacingRecord::new);
+      super(
+          "niassa-skipped " + fileName.toString(),
+          20,
+          TimeoutRecord.limit(45, ReplacingRecord::new));
     }
 
     @Override

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/TimeoutRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/TimeoutRecord.java
@@ -1,0 +1,124 @@
+package ca.on.oicr.gsi.shesmu.plugin.cache;
+
+import ca.on.oicr.gsi.Pair;
+import io.prometheus.client.Gauge;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.Semaphore;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+/**
+ * Create a record with a timeout on the length of time for a fetch
+ *
+ * @param <V> the type of the data in from the record
+ */
+public class TimeoutRecord<V> implements Record<V> {
+  private static final Thread CLEANUP;
+  private static final Semaphore LOCK = new Semaphore(1);
+  private static final Map<Thread, Pair<Instant, String>> TIMEOUTS = new HashMap<>();
+  private static final Gauge currentTimeout =
+      Gauge.build("shesmu_cache_timeout_limit", "The timeout of this cache, in minutes.")
+          .labelNames("cache")
+          .register();
+  private static final Gauge deadlineExceeded =
+      Gauge.build(
+              "shesmu_cache_timeout_deadline_exceeded",
+              "The number of times the deadline for this cache has been hit.")
+          .labelNames("cache")
+          .register();
+
+  static {
+    CLEANUP =
+        new Thread("cache-timeout-manager") {
+          @Override
+          public void run() {
+            while (true) {
+              final Instant now = Instant.now();
+              LOCK.acquireUninterruptibly();
+              for (final Thread deadThread :
+                  TIMEOUTS
+                      .entrySet()
+                      .stream()
+                      .filter(e -> e.getValue().first().isBefore(now))
+                      .peek(e -> deadlineExceeded.labels(e.getValue().second()).inc())
+                      .map(Map.Entry::getKey)
+                      .collect(Collectors.toList())) {
+                TIMEOUTS.remove(deadThread);
+                deadThread.interrupt();
+              }
+              LOCK.release();
+              try {
+                Thread.sleep(60_000);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            }
+          }
+        };
+    CLEANUP.start();
+  }
+  /**
+   * Build a new cache record type that limits how long a cache refresh can take
+   *
+   * <p>If it exceeds the deadline, it is interrupted and treated as a cache miss
+   *
+   * @param timeout the maximum number of minutes the fetch may take
+   * @param constructor the record type to limit
+   */
+  public static <I, V> BiFunction<Owner, Updater<I>, Record<V>> limit(
+      int timeout, BiFunction<Owner, Updater<I>, Record<V>> constructor) {
+    return (owner, fetcher) ->
+        new TimeoutRecord<>(owner.name(), constructor.apply(owner, fetcher), timeout);
+  }
+
+  private final Record<V> inner;
+  private final int maxRuntime;
+  private final String name;
+
+  public TimeoutRecord(String name, Record<V> inner, int maxRuntime) {
+    this.name = name;
+    this.inner = inner;
+    this.maxRuntime = maxRuntime;
+    currentTimeout.labels(name).set(maxRuntime);
+  }
+
+  @Override
+  public int collectionSize() {
+    return inner.collectionSize();
+  }
+
+  @Override
+  public void invalidate() {
+    inner.invalidate();
+  }
+
+  @Override
+  public Instant lastUpdate() {
+    return inner.lastUpdate();
+  }
+
+  @Override
+  public V readStale() {
+    return inner.readStale();
+  }
+
+  @Override
+  public V refresh() {
+    try {
+      LOCK.acquire();
+      TIMEOUTS.put(
+          Thread.currentThread(),
+          new Pair<>(Instant.now().plus(maxRuntime, ChronoUnit.MINUTES), name));
+      LOCK.release();
+      final V result = inner.refresh();
+      LOCK.acquire();
+      TIMEOUTS.remove(Thread.currentThread());
+      LOCK.release();
+      return result;
+    } catch (InterruptedException e) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
This allows setting a maximum refresh time for cache fetches and applies it to
all the Niassa caches in an attempt to reduce the stuck-in-the-webservice
behaviour.