### PR TITLE
Handle missing counts in simulation metro diagrams

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
@@ -568,8 +568,11 @@ public class SimulateRequest {
                               counts.get(fileTable.get().format().name()),
                               fileTable.get().format(),
                               (filename, line, column, oliveLine, oliveColumn) ->
-                                  flow.get(Arrays.asList(line, column, oliveLine, oliveColumn))
-                                      .get());
+                                  Optional.of(
+                                          flow.get(
+                                              Arrays.asList(line, column, oliveLine, oliveColumn)))
+                                      .map(AtomicLong::get)
+                                      .orElse(null));
                           xmlWriter.writeEndDocument();
 
                           final ObjectNode diagram = olives.addObject();


### PR DESCRIPTION
Mike encountered cases where this information was missing from the count and
causing a null pointer exception.