### PR TITLE
Create a new action state for terminally dead actions

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -372,7 +372,7 @@ public final class WorkflowAction extends Action {
                 this.errors =
                     Collections.singletonList(
                         "The workflow SWID supplied is obviously invalid, so let's pretend is launched and everything was amazing. 🌈");
-                return ActionState.SUCCEEDED;
+                return ActionState.ZOMBIE;
               default:
                 this.errors =
                     Collections.singletonList("Unknown max status. This is an implementation bug.");

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/action/ActionState.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/action/ActionState.java
@@ -34,7 +34,15 @@ public enum ActionState {
    * capacity is available. This might be due to needing another action to complete or requiring
    * user intervention.
    */
-  WAITING(2);
+  WAITING(2),
+  /**
+   * The action is never going to complete. This is not necessarily a failed state; testing or
+   * debugging actions should be in this state.
+   *
+   * <p>This is similar to {@link #SUCCEEDED} in that the action will never be checked again, but it
+   * didn't really succeed. More reached a state of terminal stuckness.
+   */
+  ZOMBIE(1);
 
   private final int sortPriority;
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/NothingAction.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/NothingAction.java
@@ -62,7 +62,7 @@ public class NothingAction extends Action {
 
   @Override
   public ActionState perform(ActionServices services) {
-    return ActionState.SUCCEEDED;
+    return ActionState.ZOMBIE;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/actions/fake/FakeAction.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/actions/fake/FakeAction.java
@@ -81,7 +81,7 @@ public class FakeAction extends JsonParameterisedAction {
 
   @Override
   public ActionState perform(ActionServices services) {
-    return ActionState.UNKNOWN;
+    return ActionState.ZOMBIE;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -1235,6 +1235,7 @@ public final class ActionProcessor
             .filter(
                 entry ->
                     entry.getValue().lastState != ActionState.SUCCEEDED
+                        && entry.getValue().lastState != ActionState.ZOMBIE
                         && !entry.getValue().updateInProgress
                         && Duration.between(entry.getValue().lastChecked, now).toMinutes()
                             >= Math.max(10, entry.getKey().retryMinutes()))

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -250,6 +250,13 @@ a.load.danger:visited {
   background-color: #fcf5d2;
 }
 
+.state_zombie,
+.filterlist .state_zombie {
+  border: 1px solid #000;
+  background-color: #dfdfdf;
+}
+
+
 .state_failed.updating,
 .state_unknown.updating {
   background: linear-gradient(
@@ -314,6 +321,19 @@ a.load.danger:visited {
     #fcf5d2 50%,
     #fcf5d2 75%,
     #fcf1b8 75%
+  );
+  background-size: 200px 200px;
+}
+
+.state_zombie.updating {
+  background: linear-gradient(
+    -45deg,
+    #dfdfdf 25%,
+    #efefef 25%,
+    #efefef 50%,
+    #dfdfdf 50%,
+    #dfdfdf 75%,
+    #efefef 75%
   );
   background-size: 200px 200px;
 }
@@ -442,6 +462,21 @@ a.load.danger:visited {
   color: #33bcdc;
 }
 
+.action.state_zombie a:link {
+  color: #444;
+}
+
+.action.state_zombie a:visited {
+  color: #666;
+}
+
+.action.state_zombie a:hover,
+.action.state_zombie a:active
+{
+  color: #888;
+}
+
+
 .action > :first-child::before,
 .alert > :first-child::before {
   opacity: 0.5;
@@ -494,6 +529,12 @@ a.load.danger:visited {
   color: #06aed5;
 }
 
+.action.state_zombie > :first-child::before {
+  content: "Zombie 🧟";
+  color: #aaa;
+}
+
+
 .alert.expired > :first-child::before {
   content: "Expired 😴";
   color: #06aed5;
@@ -516,13 +557,16 @@ a.load.danger:visited {
 .filterlist .state_throttled,
 .filterlist .state_unknown,
 .filterlist .state_waiting,
+.filterlist .state_zombie,
 .load.state_failed,
 .load.state_inflight,
 .load.state_queued,
 .load.state_succeeded,
 .load.state_throttled,
 .load.state_unknown,
-.load.state_waiting {
+.load.state_waiting,
+.load.state_zombie
+ {
   color: #000;
 }
 

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/shesmu.js
@@ -631,7 +631,9 @@ const actionStates = {
     "The action is being rate limited by a Shesmu throttler or by an over-capacity signal.",
   UNKNOWN:
     "The actions state is not currently known either due to an exception or not having been attempted.",
-  WAITING: "The action cannot be started due to a resource being unavailable."
+  WAITING: "The action cannot be started due to a resource being unavailable.",
+  ZOMBIE:
+    "The action is never going to complete. This is not necessarily a failed state; testing or debugging actions should be in this state."
 };
 
 const timeUnits = {


### PR DESCRIPTION
This was to avoid confusion where fake actions and Niassa actions with SWID 0
are known to be bad, but not a problem.Create a new action state for terminally
dead actions