### PR TITLE
Allow setting supplemental annotations on a workflow run

### DIFF
--- a/plugin-niassa+pinery/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
+++ b/plugin-niassa+pinery/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
@@ -47,6 +47,7 @@ actionRender.set("niassa", a => [
     ["Value", x => x[1]]
   ),
   objectTable(a.annotations, "Annotations", x => x),
+  objectTable(a.supplementalAnnotations, "Supplemental Annotations", x => x),
   objectTable(a.ini, "INI from Olive", maybeJsonVisibleText),
   objectTable(
     a.discoveredIni || {},


### PR DESCRIPTION
These are a way to provide information into file provenance without affecting
matching. Mei is looking to export chunk information.