### PR TITLE
Read generic type information in action setters

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/InvokeDynamicActionParameterDescriptor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/InvokeDynamicActionParameterDescriptor.java
@@ -139,7 +139,7 @@ public final class InvokeDynamicActionParameterDescriptor implements ActionParam
                               "Setter %s in %s",
                               setter.getName(), setter.getDeclaringClass().getName()),
                           setterAnnotation.type(),
-                          setter.getParameterTypes()[0]);
+                          setter.getGenericParameterTypes()[0]);
                   parameters.add(
                       new InvokeDynamicActionParameterDescriptor(
                           actionName,


### PR DESCRIPTION
This fixes a bug where setters would not have generic type informatio used
while fields did.