### PR TITLE
Make JIRA suck marginally less

### DIFF
--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
@@ -247,7 +247,7 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
             builder.linkWithUrlSearch(
                 String.format("File %s in %s", issueTypeName, projectKey),
                 String.format(
-                    "%s/secure/CreateIssueDetails!init.jspa?pid=%d&issuetype=%d&summary=&description=%%0A%%0A",
+                    "%s/login.jsp?permissionViolation=true&page_caps=&user_role=&os_destination=%%2Fsecure%%2FCreateIssueDetails!init.jspa%%3Fpid%%3D%d%%26issuetype%%3D%d%%26summary%%3D%%26description%%3D%%250A%%250A",
                     url, projectId, issueTypeId),
                 "",
                 String.format(


### PR DESCRIPTION
If you try to create a ticket in JIRA and aren't logged in, it will let you
fill out the form and then complain that reporter is missing. This forces all
calls to JIRA to go through a login redirect, which will be a no-op if all
ready logged in. Thanks, I hate it.