### PR TITLE
Force conversion to string

### DIFF
--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/utils.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/utils.js
@@ -162,13 +162,13 @@ export function table(rows, ...headers) {
 
 export function text(t) {
   const element = document.createElement("P");
-  element.innerText = t.replace(/\n/g, "⏎");
+  element.innerText = `${t}`.replace(/\n/g, "⏎");
   return element;
 }
 
 export function strikeout(strike, t) {
   const element = document.createElement("P");
-  element.innerText = t.replace(/\n/g, "⏎");
+  element.innerText = `${t}`.replace(/\n/g, "⏎");
   if (strike) {
     element.style.textDecoration = "line-through";
   }


### PR DESCRIPTION
This is to fix a bug where numbers would trigger `replace is undefined` in the
UI.