### PR TITLE
Improve Loki logging

### DIFF
--- a/plugin-loki/src/main/java/ca/on/oicr/gsi/shesmu/loki/LokiPlugin.java
+++ b/plugin-loki/src/main/java/ca/on/oicr/gsi/shesmu/loki/LokiPlugin.java
@@ -139,11 +139,10 @@ public class LokiPlugin extends JsonPluginFile<Configuration> {
                       error.labels(fileName().toString()).set(0);
                       return;
                     }
-                    error.labels(fileName().toString()).set(1);
                     System.err.println(message);
-                    System.err.println(MAPPER.writeValueAsString(body));
                   }
                 }
+                error.labels(fileName().toString()).set(1);
               }
             } catch (final Exception e) {
               e.printStackTrace();


### PR DESCRIPTION
Make sure error variable is set in all cases when an error occurs. Do not log
the request since it generates too much console logging very quickly.