### PR TITLE
Create enhanced type descriptors

### DIFF
--- a/implementation.md
+++ b/implementation.md
@@ -113,6 +113,10 @@ The ASM bytecode generation library has a class `Type` that describes JVM
 types. A `Type` object can be constructed either by knowing the JVM name for a
 class, or by using `Type.getType(Foo.class)` where _Foo_ is the class.
 
+If you require a type as part of your configuration, `Imyhat` can be serialised
+and unserialised by Jackson with JSON-enhanced descriptors. See [types in the
+language description](language.md#types).
+
 In JSON documents, Shesmu types must be converted to the more limited types
 available. Again, there is a type erasure, so the Shesmu `Imyhat` type is
 necessary to convert a JSON document back into an interpretable format.

--- a/language.md
+++ b/language.md
@@ -31,14 +31,14 @@ After the `Input` line, various script modifiers can be added.
 
 Stop the script after _integer_ seconds. The usual integer suffixes, especially
 `minutes` and `hours` can be added here. When a script runs over its time
-budget, the Prometheus variable `shesmu_run_overtime` will be set. 
+budget, the Prometheus variable `shesmu_run_overtime` will be set.
 
 ### Frequency
 
 - `Frequency` _integer_ `;`
 
-Run the script every _integer_ seconds. The usual integer suffixes can be used, where seconds 
-is the default and others such as `minutes` and `hours` can be used. 
+Run the script every _integer_ seconds. The usual integer suffixes can be used, where seconds
+is the default and others such as `minutes` and `hours` can be used.
 
 ### Required Services
 
@@ -169,7 +169,7 @@ Discriminators come in multiple forms:
 |---                          |---                                                                                                      |
 | _name_ `=` _expr_           | Compute the value from _expr_ for teach row and use it for grouping; assign it to _name_ in the output. |
 | _name_                      | Use an existing variable _name_ for grouping and copy it to the output.                                 |
-| `@`_gang_                   | Use all variables in a gang for grouping and copy them to the output.                                   | 
+| `@`_gang_                   | Use all variables in a gang for grouping and copy them to the output.                                   |
 
 Custom groupers take parameters. Some parameters are per-row, which may use
 variables, and some are fixed, which must use constants or parameters to a
@@ -222,7 +222,7 @@ Reshapes the data by creating new variables from existing expressions. There are
 |---                                     |---                                                                                                             |
 | _name_ `=` _expr_                      | Compute the value from _expr_ and assign it to _name_.                                                         |
 | _name_                                 | Copy an existing variable _name_ without modification.                                                         |
-| `@`_gang_                              | Copy all variables in a gang without modification.                                                             | 
+| `@`_gang_                              | Copy all variables in a gang without modification.                                                             |
 | _name_ `= OnlyIf` _expr_               | Compute an optional value from _expr_; if it contains a value, assign it to _name_; if empty, discard the row. |
 | _name_ `= Univalued` _expr_            | Compute a list from _expr_; if it contains exactly one value, assign it to _name_; otherwise discard the row.  |
 | `Prefix` _name_`,` ... `With` _prefix_ | Copy all the variables, but renaming them by adding the supplied prefix. This is useful for self-joins.        |
@@ -327,7 +327,7 @@ Check if _expr_ is false for all rows. If none are collected, the result is true
 
 Take an optional value and extract it. Ignore any empty optionals. If multiple
 different values are found, reject the group. If only one unique value is
-found, use it as the result and use this value. 
+found, use it as the result and use this value.
 
 - `PartitionCount` _expr_
 
@@ -437,11 +437,11 @@ cannot be guaranteed, it will return an optional of _type_. To create a JSON
 `null` value, use `` ` ` As json ``.
 
 ### Blocks
-- `Begin`  
- _name0_ `=` _expr0_`;`  
- [ _name1_ `=` _expr1_`;`]  
- [...]  
- `Return` _expr_`;`  
+- `Begin`
+ _name0_ `=` _expr0_`;`
+ [ _name1_ `=` _expr1_`;`]
+ [...]
+ `Return` _expr_`;`
  `End`
 
 Creates local variables in _name0_ by evaluating _expr1_. These variables are
@@ -684,7 +684,7 @@ tuple is determined based on the elements.
 
 Instead of _field_` = `_expr_, a `...`_expr_ can be used and this will copy all
 the elements in _expr_, which must be an object. If some fields are to be
-excluded, use the form: `...`_expr_ `Without` _field1_ _field2_ ... 
+excluded, use the form: `...`_expr_ `Without` _field1_ _field2_ ...
 
 #### Synthetic Tuple
 - `{@`_name_`}`
@@ -852,7 +852,7 @@ Select the first _integer_ items in a sorted list while _condition_ is evaluated
 #### Squish
 - `Squish` _integer_
 
-Randomly select _integer_ items from a sorted list.  
+Randomly select _integer_ items from a sorted list.
 
 ### Collectors
 
@@ -942,6 +942,7 @@ For details on optional values, see [the Mandatory Guide to Optional
 Values](optionalguide.md).
 
 
+<a name="types">
 ## Types
 There are a small number of types in the language, listed below. Each has
 syntax as it appears in the language and a descriptor that is used for
@@ -983,6 +984,22 @@ Provides the type of an element in a tuple.
 - _type_`.`_field_
 
 Provides the type of a field in an object.
+
+Descriptors are a machine-friendly form Shesmu uses to communicate type
+information between systems. Most of this does not involve human interaction,
+but some plugin configuration files require type information in descriptor
+form. For JSON configuration files, there is a JSON-enhanced descriptor. Any
+string is treated as a normal descriptor, but composite types can be expanded
+to a more readable form:
+
+    { "is": "optional", "inner": X } // X?
+    { "is": "list", "inner": X } // [X]
+    { "is": "dictionary", "key": K, "value": V } //  K -> V
+    { "is": "object", "fields": { "f1": F1, "f2": F2 } } // { f1 = F1, f2 = F2 }
+    [ E1, E2 ] // {E1, E2}
+
+Mixing the two representations is fine (_e.g._, `["qb", "s"]` is equivalent to
+`[{"optional", "inner": "b"}, "s"]` or `t2qbs`).
 
 <a name="regexflags">
 ## Regular Expression Flags

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowConfiguration.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowConfiguration.java
@@ -20,8 +20,8 @@ public class WorkflowConfiguration {
 
   private static class UserAnnotationParameter extends CustomActionParameter<WorkflowAction> {
 
-    public UserAnnotationParameter(Entry<String, String> e) {
-      super(e.getKey(), true, Imyhat.parse(e.getValue()));
+    public UserAnnotationParameter(Entry<String, Imyhat> e) {
+      super(e.getKey(), true, e.getValue());
     }
 
     @Override
@@ -124,7 +124,7 @@ public class WorkflowConfiguration {
   private boolean relaunchFailedOnUpgrade;
   private List<String> services = Collections.emptyList();
   private InputLimsKeyProvider type;
-  private Map<String, String> userAnnotations = Collections.emptyMap();
+  private Map<String, Imyhat> userAnnotations = Collections.emptyMap();
 
   public void define(String name, Definer<NiassaServer> definer) {
     final String description =
@@ -201,7 +201,7 @@ public class WorkflowConfiguration {
     return type;
   }
 
-  public Map<String, String> getUserAnnotations() {
+  public Map<String, Imyhat> getUserAnnotations() {
     return userAnnotations;
   }
 
@@ -249,7 +249,7 @@ public class WorkflowConfiguration {
     this.type = type;
   }
 
-  public void setUserAnnotations(Map<String, String> userAnnotations) {
+  public void setUserAnnotations(Map<String, Imyhat> userAnnotations) {
     this.userAnnotations = userAnnotations;
   }
 }

--- a/plugin-sftp/README.md
+++ b/plugin-sftp/README.md
@@ -56,6 +56,9 @@ as a tuple:
       "returns": "t2si"
     }
 
+The parameter and return types are JSON-enhanced descriptors. See [types
+in the language description](../language.md#types) for details.
+
 ## Refillers
 A remote server can provide programs that will ingest data from a `Refill`
 olive. To create one, add an entry in the `"refillers"` section as follows:
@@ -70,9 +73,10 @@ olive. To create one, add an entry in the `"refillers"` section as follows:
 
 This will create `example` as a refiller available to olives. It will take
 parameters as defined in the `"parameters"` block; the value of each parameter
-is a Shesmu type descriptor. When the olive is ready, Shesmu will compute an
-order-independent hash from the data. Then, over SSH, `"command"` will be run
-with the hash (as a hexadecimal string) after it.
+is a JSON-enhanced Shesmu type descriptors (see [types in the language
+description](../language.md#types) for details).  When the olive is ready,
+Shesmu will compute an order-independent hash from the data. Then, over SSH,
+`"command"` will be run with the hash (as a hexadecimal string) after it.
 
 This program can then decide if the hash matches the last version it has
 consumed. If so, it should print: `OK` and exit 0. If it has stale data, it

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/FunctionConfig.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/FunctionConfig.java
@@ -1,22 +1,23 @@
 package ca.on.oicr.gsi.shesmu.sftp;
 
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.util.List;
 
 public final class FunctionConfig {
   private String command;
-  private List<String> parameters;
-  private String returns;
+  private List<Imyhat> parameters;
+  private Imyhat returns;
   private int ttl = 60;
 
   public String getCommand() {
     return command;
   }
 
-  public List<String> getParameters() {
+  public List<Imyhat> getParameters() {
     return parameters;
   }
 
-  public String getReturns() {
+  public Imyhat getReturns() {
     return returns;
   }
 
@@ -28,11 +29,11 @@ public final class FunctionConfig {
     this.command = command;
   }
 
-  public void setParameters(List<String> parameters) {
+  public void setParameters(List<Imyhat> parameters) {
     this.parameters = parameters;
   }
 
-  public void setReturns(String returns) {
+  public void setReturns(Imyhat returns) {
     this.returns = returns;
   }
 

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/RefillerConfig.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/RefillerConfig.java
@@ -1,16 +1,17 @@
 package ca.on.oicr.gsi.shesmu.sftp;
 
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.util.Map;
 
 public class RefillerConfig {
   private String command;
-  private Map<String, String> parameters;
+  private Map<String, Imyhat> parameters;
 
   public String getCommand() {
     return command;
   }
 
-  public Map<String, String> getParameters() {
+  public Map<String, Imyhat> getParameters() {
     return parameters;
   }
 
@@ -18,7 +19,7 @@ public class RefillerConfig {
     this.command = command;
   }
 
-  public void setParameters(Map<String, String> parameters) {
+  public void setParameters(Map<String, Imyhat> parameters) {
     this.parameters = parameters;
   }
 }

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SftpServer.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SftpServer.java
@@ -387,7 +387,7 @@ public class SftpServer extends JsonPluginFile<Configuration> {
                       .map(
                           parameter ->
                               new CustomRefillerParameter<SshRefiller<I>, I>(
-                                  parameter.getKey(), Imyhat.parse(parameter.getValue())) {
+                                  parameter.getKey(), parameter.getValue()) {
                                 @Override
                                 public void store(
                                     SshRefiller<I> refiller, Function<I, Object> function) {
@@ -411,9 +411,8 @@ public class SftpServer extends JsonPluginFile<Configuration> {
     }
     definer.clearFunctions();
     for (final Map.Entry<String, FunctionConfig> entry : configuration.getFunctions().entrySet()) {
-      final Imyhat returns = Imyhat.parse(entry.getValue().getReturns());
-      final Imyhat[] parameters =
-          entry.getValue().getParameters().stream().map(Imyhat::parse).toArray(Imyhat[]::new);
+      final Imyhat returns = entry.getValue().getReturns();
+      final Imyhat[] parameters = entry.getValue().getParameters().stream().toArray(Imyhat[]::new);
       final KeyValueCache<Tuple, Optional<Object>, Optional<Object>> cache =
           new KeyValueCache<Tuple, Optional<Object>, Optional<Object>>(
               String.format("sftp-function %s %s", fileName(), entry.getKey()),

--- a/plugin-tsv/README.md
+++ b/plugin-tsv/README.md
@@ -136,6 +136,9 @@ empty optional. If `"missingUsesDefaults"` is true, then, the values in
 `"defaults"` will be provided instead. This requires that *all* values in the
 `"types"` have a default value (or are optional).
 
+The types are JSON-enhanced descriptors. See [types in the language
+description](../language.md#types) for details.
+
 ## Refillable Dictionary
 This is a mechanism for inter-olive communication. It allows one olive to fill
 a dictionary and others to read values out of it. In a file ending in
@@ -156,3 +159,7 @@ keys, one is selected arbitrarily. The dictionary is updated atomically, so
 olives reading the dictionary will have the complete set of data; however, it
 may be updated during an olive's run, so multiple accesses can produce
 different results.
+
+The types are JSON-enhanced descriptors. See [types in the language
+description](../language.md#types) for details.
+

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/json/Configuration.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/json/Configuration.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.json;
 
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Collections;
 import java.util.Map;
@@ -7,14 +8,14 @@ import java.util.Map;
 public class Configuration {
   private Map<String, JsonNode> defaults = Collections.emptyMap();
   private boolean missingUsesDefaults;
-  private Map<String, String> types;
+  private Map<String, Imyhat> types;
   private Map<String, Map<String, JsonNode>> values;
 
   public Map<String, JsonNode> getDefaults() {
     return defaults;
   }
 
-  public Map<String, String> getTypes() {
+  public Map<String, Imyhat> getTypes() {
     return types;
   }
 
@@ -34,7 +35,7 @@ public class Configuration {
     this.missingUsesDefaults = missingUsesDefaults;
   }
 
-  public void setTypes(Map<String, String> types) {
+  public void setTypes(Map<String, Imyhat> types) {
     this.types = types;
   }
 

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/json/StructuredConfigFile.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/json/StructuredConfigFile.java
@@ -39,11 +39,7 @@ public class StructuredConfigFile extends JsonPluginFile<Configuration> {
   protected Optional<Integer> update(Configuration value) {
     final Imyhat.ObjectImyhat type =
         new Imyhat.ObjectImyhat(
-            value
-                .getTypes()
-                .entrySet()
-                .stream()
-                .map(e -> new Pair<>(e.getKey(), Imyhat.parse(e.getValue()))));
+            value.getTypes().entrySet().stream().map(e -> new Pair<>(e.getKey(), e.getValue())));
     final Set<String> badRecords = new TreeSet<>();
     final Map<String, Optional<Tuple>> values =
         value

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/redict/Configuration.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/redict/Configuration.java
@@ -1,22 +1,24 @@
 package ca.on.oicr.gsi.shesmu.redict;
 
-public class Configuration {
-  private String key;
-  private String value;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 
-  public String getKey() {
+public class Configuration {
+  private Imyhat key;
+  private Imyhat value;
+
+  public Imyhat getKey() {
     return key;
   }
 
-  public String getValue() {
+  public Imyhat getValue() {
     return value;
   }
 
-  public void setKey(String key) {
+  public void setKey(Imyhat key) {
     this.key = key;
   }
 
-  public void setValue(String value) {
+  public void setValue(Imyhat value) {
     this.value = value;
   }
 }

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/redict/RefillableDictionary.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/redict/RefillableDictionary.java
@@ -54,9 +54,7 @@ public class RefillableDictionary extends JsonPluginFile<Configuration> {
 
   @Override
   protected Optional<Integer> update(Configuration configuration) {
-    final Imyhat key = Imyhat.parse(configuration.getKey());
-    final Imyhat value = Imyhat.parse(configuration.getValue());
-    if (key.isBad() || value.isBad()) {
+    if (configuration.getKey().isBad() || configuration.getValue().isBad()) {
       return Optional.empty();
     }
 
@@ -65,7 +63,7 @@ public class RefillableDictionary extends JsonPluginFile<Configuration> {
     definer.defineConstantBySupplier(
         name(),
         "Dictionary of values collected from refiller.",
-        Imyhat.dictionary(key, value),
+        Imyhat.dictionary(configuration.getKey(), configuration.getValue()),
         dictionary::get);
     definer.defineRefiller(
         name(),
@@ -82,14 +80,16 @@ public class RefillableDictionary extends JsonPluginFile<Configuration> {
               @Override
               public Stream<CustomRefillerParameter<DictionaryRefiller<I>, I>> parameters() {
                 return Stream.of(
-                    new CustomRefillerParameter<DictionaryRefiller<I>, I>("key", key) {
+                    new CustomRefillerParameter<DictionaryRefiller<I>, I>(
+                        "key", configuration.getKey()) {
                       @Override
                       public void store(
                           DictionaryRefiller<I> refiller, Function<I, Object> function) {
                         refiller.key = function;
                       }
                     },
-                    new CustomRefillerParameter<DictionaryRefiller<I>, I>("value", value) {
+                    new CustomRefillerParameter<DictionaryRefiller<I>, I>(
+                        "value", configuration.getValue()) {
                       @Override
                       public void store(
                           DictionaryRefiller<I> refiller, Function<I, Object> function) {

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
@@ -4,6 +4,8 @@ import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import java.io.IOException;
@@ -35,6 +37,8 @@ import java.util.stream.Stream;
  * <p>Java's {@link Class} are unsuitable for this purpose because generic erasure has happened.
  * Shesmu types also have an interchange string format, called a descriptor.
  */
+@JsonDeserialize(using = ImyhatDeserializer.class)
+@JsonSerialize(using = ImyhatSerializer.class)
 public abstract class Imyhat {
   /** A subclass of types for base types */
   public abstract static class BaseImyhat extends Imyhat {

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/ImyhatDeserializer.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/ImyhatDeserializer.java
@@ -1,0 +1,53 @@
+package ca.on.oicr.gsi.shesmu.plugin.types;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.Utils;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.ObjectImyhat;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+
+public class ImyhatDeserializer extends JsonDeserializer<Imyhat> {
+
+  private Imyhat deserialize(JsonNode node) {
+    if (node.isTextual()) {
+      return Imyhat.parse(node.asText());
+    }
+    if (node.isArray()) {
+      final Imyhat[] elements = new Imyhat[node.size()];
+      for (int i = 0; i < elements.length; i++) {
+        elements[i] = deserialize(node.get(i));
+      }
+      return Imyhat.tuple(elements);
+    }
+    if (node.isObject()) {
+      final String type = node.get("is").asText();
+      switch (type) {
+        case "optional":
+          return deserialize(node.get("inner")).asOptional();
+        case "list":
+          return deserialize(node.get("inner")).asList();
+        case "dictionary":
+          return Imyhat.dictionary(deserialize(node.get("key")), deserialize(node.get("value")));
+        case "object":
+          return new ObjectImyhat(
+              Utils.stream(((ObjectNode) node.get("fields")).fields())
+                  .map(e -> new Pair<>(e.getKey(), deserialize(e.getValue()))));
+        default:
+          throw new IllegalArgumentException("Unknown type: " + type);
+      }
+    }
+    throw new IllegalArgumentException("Cannot parse type: " + node.getNodeType());
+  }
+
+  @Override
+  public Imyhat deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    final ObjectCodec oc = parser.getCodec();
+    final JsonNode node = oc.readTree(parser);
+    return deserialize(node);
+  }
+}

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/ImyhatSerializer.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/ImyhatSerializer.java
@@ -1,0 +1,141 @@
+package ca.on.oicr.gsi.shesmu.plugin.types;
+
+import ca.on.oicr.gsi.Pair;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ImyhatSerializer extends JsonSerializer<Imyhat> {
+  private interface Generator {
+    void generate(JsonGenerator generator) throws IOException;
+  }
+
+  private static Generator field(String name, Generator value) {
+    return g -> {
+      g.writeFieldName(name);
+      value.generate(g);
+    };
+  }
+
+  private static Generator just(Imyhat imyhat) {
+    return g -> g.writeString(imyhat.descriptor());
+  }
+
+  @Override
+  public void serialize(
+      Imyhat imyhat, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+    imyhat
+        .apply(
+            new ImyhatTransformer<Generator>() {
+              @Override
+              public Generator bool() {
+                return just(Imyhat.BOOLEAN);
+              }
+
+              @Override
+              public Generator date() {
+                return just(Imyhat.DATE);
+              }
+
+              @Override
+              public Generator floating() {
+                return just(Imyhat.FLOAT);
+              }
+
+              @Override
+              public Generator integer() {
+                return just(Imyhat.INTEGER);
+              }
+
+              @Override
+              public Generator json() {
+                return just(Imyhat.JSON);
+              }
+
+              @Override
+              public Generator list(Imyhat inner) {
+                return single(inner, "list", Imyhat.EMPTY);
+              }
+
+              @Override
+              public Generator map(Imyhat key, Imyhat value) {
+                final Generator keyGenerator = key.apply(this);
+                final Generator valueGenerator = value.apply(this);
+                return g -> {
+                  g.writeStartObject();
+                  g.writeStringField("is", "dictionary");
+                  g.writeFieldName("key");
+                  keyGenerator.generate(g);
+                  g.writeFieldName("value");
+                  valueGenerator.generate(g);
+                  g.writeEndObject();
+                };
+              }
+
+              @Override
+              public Generator object(Stream<Pair<String, Imyhat>> contents) {
+                final List<Generator> fields =
+                    contents
+                        .map(p -> field(p.first(), p.second().apply(this)))
+                        .collect(Collectors.toList());
+                return g -> {
+                  g.writeStartObject();
+                  g.writeStringField("is", "object");
+                  g.writeFieldName("fields");
+                  g.writeStartObject();
+                  for (final Generator field : fields) {
+                    field.generate(g);
+                  }
+                  g.writeEndObject();
+                  g.writeEndObject();
+                };
+              }
+
+              @Override
+              public Generator optional(Imyhat inner) {
+                return single(inner, "optional", Imyhat.NOTHING);
+              }
+
+              @Override
+              public Generator path() {
+                return just(Imyhat.PATH);
+              }
+
+              private Generator single(Imyhat inner, String name, Imyhat whenNull) {
+                if (inner == null) return just(whenNull);
+                final Generator generator = inner.apply(this);
+                return g -> {
+                  g.writeStartObject();
+                  g.writeStringField("is", name);
+                  g.writeFieldName("inner");
+                  generator.generate(g);
+                  g.writeEndObject();
+                };
+              }
+
+              @Override
+              public Generator string() {
+                return just(Imyhat.STRING);
+              }
+
+              @Override
+              public Generator tuple(Stream<Imyhat> contents) {
+                final List<Generator> elements =
+                    contents.map(e -> e.apply(this)).collect(Collectors.toList());
+                return g -> {
+                  g.writeStartArray();
+                  for (final Generator element : elements) {
+                    element.generate(g);
+                  }
+                  g.writeEndArray();
+                };
+              }
+            })
+        .generate(jsonGenerator);
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -1292,6 +1292,10 @@ public final class Server implements ServerConfig, ActionServices {
                 writer.writeCharacters("Descriptor");
                 writer.writeEndElement();
                 writer.writeStartElement("option");
+                writer.writeAttribute("value", "3");
+                writer.writeCharacters("JSON-enhanced Descriptor");
+                writer.writeEndElement();
+                writer.writeStartElement("option");
                 writer.writeAttribute("value", "1");
                 writer.writeCharacters("WDL Type (Pairs as tuples)");
                 writer.writeEndElement();
@@ -1358,6 +1362,17 @@ public final class Server implements ServerConfig, ActionServices {
                 writer.writeStartElement("td");
                 writer.writeStartElement("span");
                 writer.writeAttribute("id", "descriptorType");
+                writer.writeEndElement();
+                writer.writeEndElement();
+                writer.writeEndElement();
+
+                writer.writeStartElement("tr");
+                writer.writeStartElement("td");
+                writer.writeCharacters("JSON-enhanced Descriptor");
+                writer.writeEndElement();
+                writer.writeStartElement("td");
+                writer.writeStartElement("span");
+                writer.writeAttribute("id", "jsonDescriptorType");
                 writer.writeEndElement();
                 writer.writeEndElement();
                 writer.writeEndElement();
@@ -2310,6 +2325,8 @@ public final class Server implements ServerConfig, ActionServices {
             type = WdlInputType.parseString(request.getValue(), false);
           } else if (request.getFormat().equals("2")) {
             type = WdlInputType.parseString(request.getValue(), true);
+          } else if (request.getFormat().equals("3")) {
+            type = RuntimeSupport.MAPPER.readValue(request.getValue(), Imyhat.class);
           } else {
             Optional<Function<String, Imyhat>> existingTypes =
                 request.getFormat().isEmpty()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/TypeParseResponse.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/TypeParseResponse.java
@@ -6,12 +6,14 @@ import ca.on.oicr.gsi.shesmu.plugin.wdl.WdlInputType;
 public class TypeParseResponse {
   private String descriptor;
   private String humanName;
+  private Imyhat jsonDescriptor;
   private String wdlType;
 
   public TypeParseResponse(Imyhat input) {
     humanName = input.name();
     descriptor = input.descriptor();
     wdlType = input.apply(WdlInputType.TO_WDL_TYPE);
+    jsonDescriptor = input;
   }
 
   public String getDescriptor() {
@@ -20,6 +22,10 @@ public class TypeParseResponse {
 
   public String getHumanName() {
     return humanName;
+  }
+
+  public Imyhat getJsonDescriptor() {
+    return jsonDescriptor;
   }
 
   public String getWdlType() {
@@ -32,6 +38,10 @@ public class TypeParseResponse {
 
   public void setHumanName(String humanName) {
     this.humanName = humanName;
+  }
+
+  public void setJsonDescriptor(Imyhat jsonDescriptor) {
+    this.jsonDescriptor = jsonDescriptor;
   }
 
   public void setWdlType(String wdlType) {

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/shesmu.js
@@ -196,6 +196,7 @@ export function parseType() {
       document.getElementById("humanType").innerText = data.humanName;
       document.getElementById("descriptorType").innerText = data.descriptor;
       document.getElementById("wdlType").innerText = data.wdlType;
+      document.getElementById("jsonDescriptorType").innerText = JSON.stringify(data.jsonDescriptor);
     }
   );
 }


### PR DESCRIPTION
For simple types, the type descriptors are manageable, but for complex types,
they are very difficult for a human to parse or edit. This creates an
intermediate form of type descriptor for where humans need to enter types into
JSON configuration that breaks complex types into JSON objects that are easier
to read and edit.