### PR TITLE
Allow converting WDL-friendly pair types

### DIFF
--- a/language.md
+++ b/language.md
@@ -575,6 +575,15 @@ Compute the logical complement of the expression, which must be a boolean.
 
 Computes the arithmetic additive inverse of the expression, which must be an integer.
 
+#### WDL Pair Conversion
+- `ConvertWdlPair` _expr_
+
+WDL has a pair type, `Pair[X, Y]`, which can be represented in Shesmu two ways:
+as a tuple, `{X, Y}`; or as an object, `{left = X, right = Y}`. The tuple form
+better matches how pairs are written in WDL, while the object better matches
+how pairs are encoded as JSON. This function converts between the two
+representations.
+
 #### Optional Creation
 - `` ` `` _expr_ `` ` ``
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -574,6 +574,7 @@ public abstract class ExpressionNode implements Renderable {
 
     UNARY.addSymbol("!", just(ExpressionNodeLogicalNot::new));
     UNARY.addSymbol("-", just(ExpressionNodeNegate::new));
+    UNARY.addKeyword("ConvertWdlPair", just(ExpressionNodeWdlPair::new));
 
     SUFFIX_TIGHT.addSymbol(
         "[",
@@ -901,11 +902,11 @@ public abstract class ExpressionNode implements Renderable {
 
   public abstract void collectPlugins(Set<Path> pluginFileNames);
 
-  public int column() {
+  public final int column() {
     return column;
   }
 
-  public int line() {
+  public final int line() {
     return line;
   }
 
@@ -935,7 +936,7 @@ public abstract class ExpressionNode implements Renderable {
    * @param acceptable the allowed type
    * @param found the type provided
    */
-  protected void typeError(Imyhat acceptable, Imyhat found, Consumer<String> errorHandler) {
+  protected final void typeError(Imyhat acceptable, Imyhat found, Consumer<String> errorHandler) {
     generateTypeError(line(), column(), "", acceptable, found, errorHandler);
   }
 
@@ -945,7 +946,7 @@ public abstract class ExpressionNode implements Renderable {
    * @param acceptable the allowed type
    * @param found the type provided
    */
-  protected void typeError(String acceptable, Imyhat found, Consumer<String> errorHandler) {
+  protected final void typeError(String acceptable, Imyhat found, Consumer<String> errorHandler) {
     errorHandler.accept(
         String.format(
             "%d:%d: Expected %s, but got %s.", line(), column(), acceptable, found.name()));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeWdlPair.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeWdlPair.java
@@ -1,0 +1,99 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.ObjectImyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.TupleImyhat;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class ExpressionNodeWdlPair extends ExpressionNode {
+
+  private final ExpressionNode inner;
+  private Imyhat type = Imyhat.BAD;
+
+  public ExpressionNodeWdlPair(int line, int column, ExpressionNode inner) {
+    super(line, column);
+    this.inner = inner;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    inner.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    inner.collectPlugins(pluginFileNames);
+  }
+
+  @Override
+  public void render(Renderer renderer) {
+    inner.render(renderer);
+
+    // Whether in the object or tuple form, Shemu's internal representation is a Tuple object and
+    // since the fields are in the correct order, there is no need to do anything with the object.
+    // This is zero cost.
+  }
+
+  @Override
+  public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
+    return inner.resolve(defs, errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return inner.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return type;
+  }
+
+  @Override
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    if (inner.typeCheck(errorHandler)) {
+      if (inner.type() instanceof TupleImyhat) {
+        final TupleImyhat tuple = (TupleImyhat) inner.type();
+        if (tuple.count() == 2) {
+          type =
+              new ObjectImyhat(
+                  Stream.of(new Pair<>("left", tuple.get(0)), new Pair<>("right", tuple.get(1))));
+          return true;
+        }
+        typeError("tuple of two items", inner.type(), errorHandler);
+      } else if (inner.type() instanceof ObjectImyhat) {
+        final ObjectImyhat object = (ObjectImyhat) inner.type();
+        final long count = object.fields().count();
+        final Optional<Imyhat> left =
+            object
+                .fields()
+                .filter(e -> e.getKey().equals("left"))
+                .map(e -> e.getValue().first())
+                .findFirst();
+        final Optional<Imyhat> right =
+            object
+                .fields()
+                .filter(e -> e.getKey().equals("right"))
+                .map(e -> e.getValue().first())
+                .findFirst();
+        if (count == 2 && left.isPresent() && right.isPresent()) {
+          type = Imyhat.tuple(left.get(), right.get());
+          return true;
+        }
+        typeError("object with only left and right", inner.type(), errorHandler);
+      } else {
+        typeError(
+            "tuple of two items or object with only left and right", inner.type(), errorHandler);
+      }
+    }
+    return false;
+  }
+}

--- a/shesmu-server/src/test/resources/run/wdlpair.shesmu
+++ b/shesmu-server/src/test/resources/run/wdlpair.shesmu
@@ -1,0 +1,3 @@
+Input test;
+
+Olive Run ok With ok = (ConvertWdlPair {0, "hi"} == {left = 0, right = "hi"}) && (ConvertWdlPair {left = 0, right = "hi"} == {0, "hi"});


### PR DESCRIPTION
This allows converting between a two-element tuple and an object with `left`
and `right` for ease of interacting with both WDL representations.