### PR TITLE
Invalidate analysis cache after scheduling

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -617,6 +617,7 @@ public final class WorkflowAction extends Action {
           // Zap the cache so any other workflows will see this workflow running and won't exceed
           // our budget
           server.get().invalidateMaxInFlight(workflowAccession);
+          server.get().analysisCache().invalidate(workflowAccession);
           final WorkflowRunAttribute attribute = new WorkflowRunAttribute();
           attribute.setTag(MAJOR_OLIVE_VERSION);
           attribute.setValue(Long.toString(majorOliveVersion));


### PR DESCRIPTION
This is a possible fix to duplicate action launching to ensure that fresh
records are seen immediately by other actions.