### PR TITLE
Increase threads for olives

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
@@ -404,7 +404,7 @@ public class CompiledGenerator implements DefinitionRepository {
   private final ScheduledExecutorService executor;
   private Optional<AutoUpdatingDirectory<Script>> scripts = Optional.empty();
   private final ExecutorService workExecutor =
-      Executors.newFixedThreadPool(Math.max(1, Runtime.getRuntime().availableProcessors() - 1));
+      Executors.newFixedThreadPool(Math.max(1, 4 * Runtime.getRuntime().availableProcessors() - 1));
 
   public CompiledGenerator(
       ScheduledExecutorService executor, DefinitionRepository definitionRepository) {


### PR DESCRIPTION
This was originally set low because olives are generally CPU-bound so having
more threads that processors wouldn't improve throughput. Now, a number of
olives, particularly SSH refillers are I/O-bound, so it makes sense to provide
more threads.