### PR TITLE
Add support to convert between Shesmu types and JSON schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.10.4</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.9.9</version>
+        <version>2.11.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jsonSchema</artifactId>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>ca.on.oicr.gsi</groupId>

--- a/shesmu-pluginapi/pom.xml
+++ b/shesmu-pluginapi/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jsonSchema</artifactId>
+    </dependency>
+    <dependency>
       <groupId>ca.on.oicr.gsi</groupId>
       <artifactId>server-utils</artifactId>
     </dependency>

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/jsonschema/ImyhatJsonFormatVisitor.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/jsonschema/ImyhatJsonFormatVisitor.java
@@ -1,0 +1,170 @@
+package ca.on.oicr.gsi.shesmu.plugin.jsonschema;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.ObjectImyhat;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonAnyFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonArrayFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonBooleanFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitable;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonMapFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNullFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNumberFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonStringFormatVisitor;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+public class ImyhatJsonFormatVisitor implements JsonFormatVisitorWrapper {
+  private final Consumer<Imyhat> output;
+
+  public ImyhatJsonFormatVisitor(Consumer<Imyhat> output) {
+    this.output = output;
+  }
+
+  @Override
+  public JsonObjectFormatVisitor expectObjectFormat(JavaType javaType) throws JsonMappingException {
+    return new JsonObjectFormatVisitor.Base() {
+      private final Map<String, Imyhat> fields = new TreeMap<>();
+
+      @Override
+      public void property(String name, JsonFormatVisitable handler, JavaType propertyTypeHint)
+          throws JsonMappingException {
+        handler.acceptJsonFormatVisitor(
+            new ImyhatJsonFormatVisitor(
+                t -> {
+                  fields.put(name, t);
+                  emit();
+                }),
+            propertyTypeHint);
+      }
+
+      private void emit() {
+        // This visitor design does't let us know when it's done, so we regenerate and send the
+        // result to our caller for every new field.
+        output.accept(
+            new ObjectImyhat(
+                fields.entrySet().stream().map(e -> new Pair<>(e.getKey(), e.getValue()))));
+      }
+
+      @Override
+      public void optionalProperty(
+          String name, JsonFormatVisitable handler, JavaType propertyTypeHint)
+          throws JsonMappingException {
+        handler.acceptJsonFormatVisitor(
+            new ImyhatJsonFormatVisitor(
+                t -> {
+                  fields.put(name, t.asOptional());
+                  emit();
+                }),
+            propertyTypeHint);
+      }
+    };
+  }
+
+  @Override
+  public JsonArrayFormatVisitor expectArrayFormat(JavaType javaType) throws JsonMappingException {
+    return new JsonArrayFormatVisitor.Base() {
+      @Override
+      public void itemsFormat(JsonFormatVisitable handler, JavaType elementType)
+          throws JsonMappingException {
+        handler.acceptJsonFormatVisitor(
+            new ImyhatJsonFormatVisitor(inner -> output.accept(inner.asList())), elementType);
+      }
+    };
+  }
+
+  @Override
+  public JsonStringFormatVisitor expectStringFormat(JavaType javaType) throws JsonMappingException {
+    output.accept(Imyhat.STRING);
+    return new JsonStringFormatVisitor.Base();
+  }
+
+  @Override
+  public JsonNumberFormatVisitor expectNumberFormat(JavaType javaType) throws JsonMappingException {
+    output.accept(Imyhat.FLOAT);
+    return new JsonNumberFormatVisitor.Base();
+  }
+
+  @Override
+  public JsonIntegerFormatVisitor expectIntegerFormat(JavaType javaType)
+      throws JsonMappingException {
+    output.accept(Imyhat.INTEGER);
+    return new JsonIntegerFormatVisitor.Base();
+  }
+
+  @Override
+  public JsonBooleanFormatVisitor expectBooleanFormat(JavaType javaType)
+      throws JsonMappingException {
+    output.accept(Imyhat.BOOLEAN);
+    return new JsonBooleanFormatVisitor.Base();
+  }
+
+  @Override
+  public JsonNullFormatVisitor expectNullFormat(JavaType javaType) throws JsonMappingException {
+    output.accept(Imyhat.NOTHING);
+    return new JsonNullFormatVisitor.Base();
+  }
+
+  @Override
+  public JsonAnyFormatVisitor expectAnyFormat(JavaType javaType) throws JsonMappingException {
+    output.accept(Imyhat.JSON);
+    return new JsonAnyFormatVisitor.Base();
+  }
+
+  @Override
+  public JsonMapFormatVisitor expectMapFormat(JavaType javaType) throws JsonMappingException {
+    return new JsonMapFormatVisitor.Base() {
+      private Imyhat key;
+      private Imyhat value;
+
+      private void emit() {
+        if (key != null && value != null) {
+          output.accept(Imyhat.dictionary(key, value));
+        }
+      }
+
+      @Override
+      public void keyFormat(JsonFormatVisitable jsonFormatVisitable, JavaType javaType)
+          throws JsonMappingException {
+        jsonFormatVisitable.acceptJsonFormatVisitor(
+            new ImyhatJsonFormatVisitor(
+                k -> {
+                  key = k;
+                  emit();
+                }),
+            javaType);
+      }
+
+      @Override
+      public void valueFormat(JsonFormatVisitable jsonFormatVisitable, JavaType javaType)
+          throws JsonMappingException {
+        jsonFormatVisitable.acceptJsonFormatVisitor(
+            new ImyhatJsonFormatVisitor(
+                v -> {
+                  value = v;
+                  emit();
+                }),
+            javaType);
+      }
+    };
+  }
+
+  private SerializerProvider provider;
+
+  @Override
+  public SerializerProvider getProvider() {
+    return provider;
+  }
+
+  @Override
+  public void setProvider(SerializerProvider serializerProvider) {
+    this.provider = serializerProvider;
+  }
+}

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/jsonschema/JsonSchemaConverter.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/jsonschema/JsonSchemaConverter.java
@@ -1,0 +1,106 @@
+package ca.on.oicr.gsi.shesmu.plugin.jsonschema;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.ImyhatTransformer;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.AnySchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema.ArrayItems;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema.SingleItems;
+import com.fasterxml.jackson.module.jsonSchema.types.IntegerSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.NullSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.NumberSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema.SchemaAdditionalProperties;
+import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
+import java.util.stream.Stream;
+
+final class JsonSchemaConverter implements ImyhatTransformer<JsonSchema> {
+
+  @Override
+  public JsonSchema bool() {
+    return new StringSchema();
+  }
+
+  @Override
+  public JsonSchema date() {
+    final IntegerSchema schema = new IntegerSchema();
+    schema.setFormat(JsonValueFormat.DATE_TIME);
+    return schema;
+  }
+
+  @Override
+  public JsonSchema floating() {
+    return new NumberSchema();
+  }
+
+  @Override
+  public JsonSchema integer() {
+    return new IntegerSchema();
+  }
+
+  @Override
+  public JsonSchema json() {
+    return new AnySchema();
+  }
+
+  @Override
+  public JsonSchema list(Imyhat inner) {
+    final ArraySchema schema = new ArraySchema();
+    schema.setItemsSchema(inner.apply(this));
+    return schema;
+  }
+
+  @Override
+  public JsonSchema map(Imyhat key, Imyhat value) {
+    if (key.isSame(Imyhat.STRING)) {
+      final ObjectSchema object = new ObjectSchema();
+      object.setAdditionalProperties(new SchemaAdditionalProperties(value.apply(this)));
+      return object;
+    } else {
+      final ArraySchema inner = new ArraySchema();
+      inner.setItems(new ArrayItems(new JsonSchema[] {key.apply(this), value.apply(this)}));
+      final ArraySchema schema = new ArraySchema();
+      schema.setItems(new SingleItems(inner));
+      return schema;
+    }
+  }
+
+  @Override
+  public JsonSchema object(Stream<Pair<String, Imyhat>> contents) {
+    final ObjectSchema object = new ObjectSchema();
+    object.rejectAdditionalProperties();
+    contents.forEach(field -> object.putProperty(field.first(), field.second().apply(this)));
+    return object;
+  }
+
+  @Override
+  public JsonSchema optional(Imyhat inner) {
+    if (inner == null) {
+      return new NullSchema();
+    } else {
+      final JsonSchema schema = inner.apply(this);
+      schema.setRequired(false);
+      return schema;
+    }
+  }
+
+  @Override
+  public JsonSchema path() {
+    return new StringSchema();
+  }
+
+  @Override
+  public JsonSchema string() {
+    return new StringSchema();
+  }
+
+  @Override
+  public JsonSchema tuple(Stream<Imyhat> contents) {
+    final ArraySchema schema = new ArraySchema();
+    schema.setItems(new ArrayItems(contents.map(e -> e.apply(this)).toArray(JsonSchema[]::new)));
+    return schema;
+  }
+}

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/jsonschema/JsonSchemaUtils.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/jsonschema/JsonSchemaUtils.java
@@ -1,0 +1,132 @@
+package ca.on.oicr.gsi.shesmu.plugin.jsonschema;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.ObjectImyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.ImyhatTransformer;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema.ArrayItems;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema.NoAdditionalProperties;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema.SchemaAdditionalProperties;
+import com.fasterxml.jackson.module.jsonSchema.types.ReferenceSchema;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/** Allow converting between Shemu's type system and JSON Schema/Jackson's type schema */
+public final class JsonSchemaUtils {
+
+  /** Convert a Shesmu type to a JSON schema */
+  public static final ImyhatTransformer<JsonSchema> TO_SCHEMA = new JsonSchemaConverter();
+
+  /**
+   * Convert a Jackson type to a Shesmu type
+   *
+   * @param mapper the object mapper to resolve format information
+   * @param type the type to be resolved
+   * @return the resulting type; it may be the bad type if errors were encountered
+   * @throws JsonMappingException if a class was encountered which Jackson could not explore
+   *     properly due to the configuration of the mapper
+   */
+  public static Imyhat convert(ObjectMapper mapper, JavaType type) throws JsonMappingException {
+    final AtomicReference<Imyhat> result = new AtomicReference<>(Imyhat.BAD);
+    mapper.acceptJsonFormatVisitor(type, new ImyhatJsonFormatVisitor(result::set));
+    return result.get();
+  }
+
+  /**
+   * Convert a JSON schema to a Shesmu type
+   *
+   * @param schema the JSON schema to convert
+   * @param inferDictionaries if true, schemas that resemble <tt>[[X, Y]]</tt> will be converted to
+   *     <tt>X -> Y</tt>. This is how dictionaries with non-string keys are serialised by default in
+   *     Shesmu.
+   * @param resolver a function to handle <tt>$ref</tt> nodes in the schema; if null, referenes will
+   *     be resolved to the bad type
+   */
+  public static Imyhat convert(
+      JsonSchema schema, boolean inferDictionaries, Function<String, Imyhat> resolver) {
+    if (schema == null) {
+      return Imyhat.BAD;
+    } else if (schema.isNullSchema()) {
+      return Imyhat.NOTHING;
+    } else if (schema.isAnySchema()) {
+      return optional(schema, Imyhat.JSON);
+    } else if (schema.isArraySchema()) {
+      final ArraySchema arraySchema = schema.asArraySchema();
+      if (arraySchema.getItems().isArrayItems()) {
+        final ArrayItems arrayItems = arraySchema.getItems().asArrayItems();
+        return optional(
+            schema,
+            Imyhat.tuple(
+                Stream.of(arrayItems.getJsonSchemas())
+                    .map(schema1 -> convert(schema1, inferDictionaries, resolver))
+                    .toArray(Imyhat[]::new)));
+      } else if (arraySchema.getItems().isSingleItems()) {
+        final JsonSchema inner = arraySchema.getItems().asSingleItems().getSchema();
+        if (inferDictionaries
+            && inner.isArraySchema()
+            && inner.getRequired()
+            && inner.asArraySchema().getItems().isArrayItems()
+            && inner.asArraySchema().getItems().asArrayItems().getJsonSchemas().length == 2) {
+          final JsonSchema[] types =
+              inner.asArraySchema().getItems().asArrayItems().getJsonSchemas();
+          return optional(
+              schema,
+              Imyhat.dictionary(
+                  convert(types[0], true, resolver), convert(types[1], true, resolver)));
+        }
+        return optional(schema, convert(inner, inferDictionaries, resolver).asList());
+      }
+    } else if (schema.isBooleanSchema()) {
+      return optional(schema, Imyhat.BOOLEAN);
+    } else if (schema.isIntegerSchema()) {
+      return optional(schema, Imyhat.INTEGER);
+    } else if (schema.isObjectSchema()) {
+      final ObjectSchema objectSchema = schema.asObjectSchema();
+      if (objectSchema.getPatternProperties().isEmpty()
+          && (objectSchema.getAdditionalProperties() == null
+              || objectSchema.getAdditionalProperties() instanceof NoAdditionalProperties)) {
+        return optional(
+            objectSchema,
+            new ObjectImyhat(
+                objectSchema
+                    .getProperties()
+                    .entrySet()
+                    .stream()
+                    .map(
+                        e ->
+                            new Pair<>(
+                                e.getKey(), convert(e.getValue(), inferDictionaries, resolver)))));
+      } else if (objectSchema.getProperties().isEmpty()
+          && objectSchema.getPatternProperties().isEmpty()
+          && objectSchema.getAdditionalProperties() instanceof SchemaAdditionalProperties) {
+        return optional(
+            objectSchema,
+            Imyhat.dictionary(
+                Imyhat.STRING,
+                convert(
+                    ((SchemaAdditionalProperties) objectSchema.getAdditionalProperties())
+                        .getJsonSchema(),
+                    inferDictionaries,
+                    resolver)));
+      }
+    } else if (schema.isStringSchema()) {
+      return optional(schema, Imyhat.STRING);
+    } else if (resolver != null && schema instanceof ReferenceSchema) {
+      return optional(schema, resolver.apply(schema.get$ref()));
+    }
+    return Imyhat.BAD;
+  }
+
+  private static Imyhat optional(JsonSchema schema, Imyhat type) {
+    return schema.getRequired() ? type : type.asOptional();
+  }
+
+  private JsonSchemaUtils() {}
+}

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/jsonschema/package-info.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/jsonschema/package-info.java
@@ -1,0 +1,2 @@
+/** Utilities for interacting with JSON Schema, the type system used by NextFlow */
+package ca.on.oicr.gsi.shesmu.plugin.jsonschema;


### PR DESCRIPTION
Nextflow has adopted JSON schema as their parameter description format. This
add support to convert between Shemu's internal type representation and JSON
schema.