### PR TITLE
Rebuild trigger

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
@@ -72,95 +72,6 @@ public abstract class Imyhat {
     }
   }
 
-  public static final class ListImyhat extends Imyhat {
-    private final Imyhat inner;
-
-    private ListImyhat(Imyhat inner) {
-      this.inner = inner;
-    }
-
-    @Override
-    public void accept(ImyhatConsumer dispatcher, Object value) {
-      @SuppressWarnings("unchecked")
-      final Set<Object> values = (Set<Object>) value;
-      dispatcher.accept(values.stream(), inner);
-    }
-
-    @Override
-    public <R> R apply(ImyhatFunction<R> dispatcher, Object value) {
-      @SuppressWarnings("unchecked")
-      final Set<Object> values = (Set<Object>) value;
-      return dispatcher.apply(values.stream(), inner);
-    }
-
-    @Override
-    public <R> R apply(ImyhatTransformer<R> transformer) {
-      return transformer.list(inner);
-    }
-
-    @Override
-    public Comparator<?> comparator() {
-      @SuppressWarnings("unchecked")
-      final Comparator<Object> innerComparator = (Comparator<Object>) inner.comparator();
-      return (Set<?> a, Set<?> b) -> {
-        final Iterator<?> aIt = a.iterator();
-        final Iterator<?> bIt = b.iterator();
-        while (aIt.hasNext() && bIt.hasNext()) {
-          final int result = innerComparator.compare(aIt.next(), bIt.next());
-          if (result != 0) {
-            return result;
-          }
-        }
-        return Boolean.compare(aIt.hasNext(), bIt.hasNext());
-      };
-    }
-
-    @Override
-    public String descriptor() {
-      return "a" + inner.descriptor();
-    }
-
-    public Imyhat inner() {
-      return inner;
-    }
-
-    @Override
-    public boolean isBad() {
-      return inner.isBad();
-    }
-
-    @Override
-    public boolean isOrderable() {
-      return false;
-    }
-
-    @Override
-    public boolean isSame(Imyhat other) {
-      if (other instanceof ListImyhat) {
-        return inner.isSame(((ListImyhat) other).inner);
-      }
-      return other == EMPTY;
-    }
-
-    @Override
-    public Class<?> javaType() {
-      return Set.class;
-    }
-
-    @Override
-    public String name() {
-      return "[" + inner.name() + "]";
-    }
-
-    @Override
-    public Imyhat unify(Imyhat other) {
-      if (other == EMPTY) {
-        return this;
-      }
-      return new ListImyhat(inner.unify(((ListImyhat) other).inner));
-    }
-  }
-
   public static final class DictionaryImyhat extends Imyhat {
     private final Imyhat key;
     private final Imyhat value;
@@ -216,6 +127,23 @@ public abstract class Imyhat {
     }
 
     @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      DictionaryImyhat that = (DictionaryImyhat) o;
+      return key.equals(that.key) && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(key, value);
+    }
+
+    @Override
     public boolean isBad() {
       return key.isBad() || value.isBad();
     }
@@ -256,6 +184,112 @@ public abstract class Imyhat {
 
     public Imyhat value() {
       return value;
+    }
+  }
+
+  public static final class ListImyhat extends Imyhat {
+    private final Imyhat inner;
+
+    private ListImyhat(Imyhat inner) {
+      this.inner = inner;
+    }
+
+    @Override
+    public void accept(ImyhatConsumer dispatcher, Object value) {
+      @SuppressWarnings("unchecked")
+      final Set<Object> values = (Set<Object>) value;
+      dispatcher.accept(values.stream(), inner);
+    }
+
+    @Override
+    public <R> R apply(ImyhatFunction<R> dispatcher, Object value) {
+      @SuppressWarnings("unchecked")
+      final Set<Object> values = (Set<Object>) value;
+      return dispatcher.apply(values.stream(), inner);
+    }
+
+    @Override
+    public <R> R apply(ImyhatTransformer<R> transformer) {
+      return transformer.list(inner);
+    }
+
+    @Override
+    public Comparator<?> comparator() {
+      @SuppressWarnings("unchecked")
+      final Comparator<Object> innerComparator = (Comparator<Object>) inner.comparator();
+      return (Set<?> a, Set<?> b) -> {
+        final Iterator<?> aIt = a.iterator();
+        final Iterator<?> bIt = b.iterator();
+        while (aIt.hasNext() && bIt.hasNext()) {
+          final int result = innerComparator.compare(aIt.next(), bIt.next());
+          if (result != 0) {
+            return result;
+          }
+        }
+        return Boolean.compare(aIt.hasNext(), bIt.hasNext());
+      };
+    }
+
+    @Override
+    public String descriptor() {
+      return "a" + inner.descriptor();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ListImyhat that = (ListImyhat) o;
+      return inner.equals(that.inner);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(inner);
+    }
+
+    public Imyhat inner() {
+      return inner;
+    }
+
+    @Override
+    public boolean isBad() {
+      return inner.isBad();
+    }
+
+    @Override
+    public boolean isOrderable() {
+      return false;
+    }
+
+    @Override
+    public boolean isSame(Imyhat other) {
+      if (other instanceof ListImyhat) {
+        return inner.isSame(((ListImyhat) other).inner);
+      }
+      return other == EMPTY;
+    }
+
+    @Override
+    public Class<?> javaType() {
+      return Set.class;
+    }
+
+    @Override
+    public String name() {
+      return "[" + inner.name() + "]";
+    }
+
+    @Override
+    public Imyhat unify(Imyhat other) {
+      if (other == EMPTY) {
+        return this;
+      }
+      return new ListImyhat(inner.unify(((ListImyhat) other).inner));
     }
   }
 
@@ -335,12 +369,29 @@ public abstract class Imyhat {
               .collect(Collectors.joining());
     }
 
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ObjectImyhat that = (ObjectImyhat) o;
+      return fields.equals(that.fields);
+    }
+
     public Stream<Map.Entry<String, Pair<Imyhat, Integer>>> fields() {
       return fields.entrySet().stream();
     }
 
     public Imyhat get(String field) {
       return fields.getOrDefault(field, new Pair<>(BAD, 0)).first();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(fields);
     }
 
     public int index(String field) {
@@ -449,6 +500,23 @@ public abstract class Imyhat {
       return "q" + inner.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      OptionalImyhat that = (OptionalImyhat) o;
+      return inner.equals(that.inner);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(inner);
+    }
+
     public Imyhat inner() {
       return inner;
     }
@@ -545,8 +613,25 @@ public abstract class Imyhat {
           .collect(Collectors.joining("", "t" + types.length, ""));
     }
 
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TupleImyhat that = (TupleImyhat) o;
+      return Arrays.equals(types, that.types);
+    }
+
     public Imyhat get(int index) {
       return index >= 0 && index < types.length ? types[index] : BAD;
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(types);
     }
 
     public Stream<Imyhat> inner() {
@@ -1274,16 +1359,16 @@ public abstract class Imyhat {
     }
   }
 
+  public static DictionaryImyhat dictionary(Imyhat key, Imyhat value) {
+    return new DictionaryImyhat(key, value);
+  }
+
   /** Parse a name which must be one of the base types (no lists or tuples) */
   public static BaseImyhat forName(String s) {
     return baseTypes()
         .filter(t -> t.name().equals(s))
         .findAny()
         .orElseThrow(() -> new IllegalArgumentException(String.format("No such base type %s.", s)));
-  }
-
-  public static DictionaryImyhat dictionary(Imyhat key, Imyhat value) {
-    return new DictionaryImyhat(key, value);
   }
 
   public static Optional<? extends Imyhat> of(Type c) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
@@ -97,7 +97,7 @@ public final class Check extends Compiler {
                         null) {
 
                       @Override
-                      protected void load(GeneratorAdapter methodGen) {
+                      public void load(GeneratorAdapter methodGen) {
                         throw new UnsupportedOperationException();
                       }
                     }) //

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
@@ -107,7 +107,7 @@ public abstract class ConstantDefinition implements Target {
     }
 
     @Override
-    protected final void load(GeneratorAdapter methodGen) {
+    public final void load(GeneratorAdapter methodGen) {
       Renderer.loadImyhatInMethod(methodGen, type().descriptor());
       methodGen.invokeVirtual(A_IMYHAT_TYPE, METHOD_IMYHAT__NEW_SET);
       for (final T value : values) {
@@ -165,7 +165,7 @@ public abstract class ConstantDefinition implements Target {
     return new ConstantDefinition(name, Imyhat.BOOLEAN, description, null) {
 
       @Override
-      protected void load(GeneratorAdapter methodGen) {
+      public void load(GeneratorAdapter methodGen) {
         methodGen.push(value);
       }
     };
@@ -180,7 +180,7 @@ public abstract class ConstantDefinition implements Target {
     return new ConstantDefinition(name, Imyhat.DATE, description, null) {
 
       @Override
-      protected void load(GeneratorAdapter methodGen) {
+      public void load(GeneratorAdapter methodGen) {
         methodGen.push(value.toEpochMilli());
         methodGen.invokeStatic(type().apply(TypeUtils.TO_ASM), INSTANT_CTOR);
       }
@@ -196,7 +196,7 @@ public abstract class ConstantDefinition implements Target {
     return new ConstantDefinition(name, Imyhat.INTEGER, description, null) {
 
       @Override
-      protected void load(GeneratorAdapter methodGen) {
+      public void load(GeneratorAdapter methodGen) {
         methodGen.push(value);
       }
     };
@@ -211,7 +211,7 @@ public abstract class ConstantDefinition implements Target {
     return new ConstantDefinition(name, Imyhat.STRING, description, null) {
 
       @Override
-      protected void load(GeneratorAdapter methodGen) {
+      public void load(GeneratorAdapter methodGen) {
         methodGen.push(value);
       }
     };
@@ -283,7 +283,7 @@ public abstract class ConstantDefinition implements Target {
    *
    * @param methodGen the method to load the value in
    */
-  protected abstract void load(GeneratorAdapter methodGen);
+  public abstract void load(GeneratorAdapter methodGen);
 
   /**
    * The name of the constant.

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
@@ -481,7 +481,7 @@ public final class StandardDefinitions implements DefinitionRepository {
             null) {
 
           @Override
-          protected void load(GeneratorAdapter methodGen) {
+          public void load(GeneratorAdapter methodGen) {
             methodGen.invokeStatic(A_INSTANT_TYPE, METHOD_INSTANT__NOW);
           }
         }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ImportVerifier.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ImportVerifier.java
@@ -1,0 +1,202 @@
+package ca.on.oicr.gsi.shesmu.server;
+
+import ca.on.oicr.gsi.shesmu.compiler.RefillerDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.RefillerParameterDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionParameterDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.ConstantDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
+import ca.on.oicr.gsi.shesmu.plugin.functions.FunctionParameter;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/** An import reference that can check if it is still valid */
+public interface ImportVerifier {
+
+  class ActionVerifier implements ImportVerifier {
+    private final String name;
+    private final Map<String, Imyhat> parameters;
+
+    public ActionVerifier(ActionDefinition definition) {
+      name = definition.name();
+      parameters =
+          definition
+              .parameters()
+              .collect(
+                  Collectors.toMap(
+                      ActionParameterDefinition::name, ActionParameterDefinition::type));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ActionVerifier that = (ActionVerifier) o;
+      return name.equals(that.name) && parameters.equals(that.parameters);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, parameters);
+    }
+
+    @Override
+    public boolean stillMatches(DefinitionRepository repository) {
+      return repository
+          .actions()
+          .anyMatch(
+              a ->
+                  a.name().equals(name)
+                      && a.parameters()
+                          .collect(
+                              Collectors.toMap(
+                                  ActionParameterDefinition::name, ActionParameterDefinition::type))
+                          .entrySet()
+                          .containsAll(parameters.entrySet()));
+    }
+  }
+
+  class ConstantVerifier implements ImportVerifier {
+
+    private final String name;
+    private final Imyhat type;
+
+    public ConstantVerifier(ConstantDefinition definition) {
+      name = definition.name();
+      type = definition.type();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ConstantVerifier that = (ConstantVerifier) o;
+      return name.equals(that.name) && type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, type);
+    }
+
+    @Override
+    public boolean stillMatches(DefinitionRepository repository) {
+      return repository.constants().anyMatch(c -> c.name().equals(name) && c.type().isSame(type));
+    }
+  }
+
+  class FunctionVerifier implements ImportVerifier {
+
+    private final String name;
+    private final List<Imyhat> parameters;
+    private final Imyhat returnType;
+
+    public FunctionVerifier(FunctionDefinition definition) {
+      name = definition.name();
+      returnType = definition.returnType();
+      parameters =
+          definition.parameters().map(FunctionParameter::type).collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      FunctionVerifier that = (FunctionVerifier) o;
+      return name.equals(that.name)
+          && returnType.equals(that.returnType)
+          && parameters.equals(that.parameters);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, returnType, parameters);
+    }
+
+    @Override
+    public boolean stillMatches(DefinitionRepository repository) {
+      return repository
+          .functions()
+          .anyMatch(
+              f ->
+                  f.name().equals(name)
+                      && f.returnType().isSame(returnType)
+                      && f.parameters()
+                          .map(FunctionParameter::type)
+                          .collect(Collectors.toList())
+                          .equals(parameters));
+    }
+  }
+
+  class RefillerVerifier implements ImportVerifier {
+    private final String name;
+    private final Map<String, Imyhat> parameters;
+
+    public RefillerVerifier(RefillerDefinition definition) {
+      name = definition.name();
+      parameters =
+          definition
+              .parameters()
+              .collect(
+                  Collectors.toMap(
+                      RefillerParameterDefinition::name, RefillerParameterDefinition::type));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      RefillerVerifier that = (RefillerVerifier) o;
+      return name.equals(that.name) && parameters.equals(that.parameters);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, parameters);
+    }
+
+    @Override
+    public boolean stillMatches(DefinitionRepository repository) {
+      return repository
+          .refillers()
+          .anyMatch(
+              a ->
+                  a.name().equals(name)
+                      && a.parameters()
+                          .collect(
+                              Collectors.toMap(
+                                  RefillerParameterDefinition::name,
+                                  RefillerParameterDefinition::type))
+                          .entrySet()
+                          .containsAll(parameters.entrySet()));
+    }
+  }
+
+  /**
+   * Check if an import is still available in the definition repository provided
+   *
+   * @param repository the repository to check
+   * @return true if the repository contains a compatible definition
+   */
+  boolean stillMatches(DefinitionRepository repository);
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
@@ -425,7 +425,8 @@ public class SimulateRequest {
                       .forEach(info.putArray("parameters")::add);
                 }
               },
-              fileTable::set);
+              fileTable::set,
+              importVerifier -> {});
       compiler.errors().forEach(errors::add);
       if (fileTable.get() != null) {
         response.put("bytecode", fileTable.get().bytecode());

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
@@ -131,7 +131,7 @@ public final class PluginManager
       }
 
       @Override
-      protected void load(GeneratorAdapter methodGen) {
+      public void load(GeneratorAdapter methodGen) {
         methodGen.invokeDynamic(
             fixedName,
             Type.getMethodDescriptor(type().apply(TypeUtils.TO_ASM)),
@@ -1100,7 +1100,7 @@ public final class PluginManager
                       path) {
 
                     @Override
-                    protected void load(GeneratorAdapter methodGen) {
+                    public void load(GeneratorAdapter methodGen) {
                       invoker.write(methodGen, path.toString());
                     }
                   });

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
@@ -509,7 +509,8 @@ public class RunTest {
                       // Do nothing
                     }
                   },
-                  dashboard::set)
+                  dashboard::set,
+                  importVerifier -> {})
               .orElse(ActionGenerator.NULL);
       compiler.errors().forEach(System.err::println);
       final ActionChecker checker = new ActionChecker();


### PR DESCRIPTION
This has become more of a problem with the use of `.jsonconfig` files. When the data associated with a function, constant, refiller, or action changes, Shesmu uses a `MethodHandle` to dynamically replace the contents of the olive. However, this only works if the type hasn't changed. These changes detect breaking changes in the imports and trigger recompilation of the olive.