### PR TITLE
Replace braces in Require and Reject

### DIFF
--- a/language.md
+++ b/language.md
@@ -246,7 +246,7 @@ largest or smallest value of _expr_ to pass and discards the rest.
 
 This does not reshape the data.
 
-- `Reject` _cond_ `{` _reject1_[`,` _reject2_[`,` ...]] `}`
+- `Reject` _cond_ `OnReject` _reject1_[ _reject2_[ ...]] `Resume`
 
 Filter rows from the input. If _cond_ is false, the row will be kept; if true,
 it will be discarded. This is the opposite of `Where`. Rows which are rejected
@@ -255,7 +255,7 @@ an `Alert` terminal.
 
 This does not reshape the data.
 
-- `Require` _name_ `=` _expr_ `{` _reject1_[`,` _reject2_[`,` ...]] `}`
+- `Require` _name_ `=` _expr_ `OnReject` _reject1_[ _reject2_[ ...]] `Resume`
 
 Evaluate _expr_, which must return an optional. If the result is empty, the row
 will be discarded; if the optional has a value, this value will be assigned to

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
@@ -281,12 +281,11 @@ public abstract class OliveClauseNode {
                   .whitespace()
                   .then(ExpressionNode::parse, clause::set)
                   .whitespace()
-                  .symbol("{")
+                  .keyword("OnReject")
                   .whitespace()
-                  .listEmpty(
-                      handlers::set, (rp, ro) -> rp.whitespace().dispatch(REJECT_CLAUSES, ro), ',')
+                  .list(handlers::set, (rp, ro) -> rp.whitespace().dispatch(REJECT_CLAUSES, ro))
                   .whitespace()
-                  .symbol("}")
+                  .keyword("Resume")
                   .whitespace();
 
           if (result.isGood()) {
@@ -311,12 +310,11 @@ public abstract class OliveClauseNode {
                   .whitespace()
                   .then(ExpressionNode::parse, expression::set)
                   .whitespace()
-                  .symbol("{")
+                  .keyword("OnReject")
                   .whitespace()
-                  .listEmpty(
-                      handlers::set, (rp, ro) -> rp.whitespace().dispatch(REJECT_CLAUSES, ro), ',')
+                  .list(handlers::set, (rp, ro) -> rp.whitespace().dispatch(REJECT_CLAUSES, ro))
                   .whitespace()
-                  .symbol("}")
+                  .keyword("Resume")
                   .whitespace();
 
           if (result.isGood()) {

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
@@ -20,7 +20,7 @@ ace.define(
       var keywordMapper = (this.$keywords = this.createKeywordMapper(
         {
           "keyword.control":
-            "Alert|All|Annotations|Any|Argument|As|Begin|By|Count|Default|Define|Description|Dict|Distinct|Dump|Else|End|EpochMilli|EpochSecond|Export|First|Fixed|FixedConcat|Flatten|For|Frequency|From|Function|Group|If|In|Into|Input|Join|Labels|LeftJoin|Let|LexicalConcat|Limit|List|Location|Max|Min|Monitor|None|Olive|OnlyIf|PartitionCount|Prefix|Pick|Reduce|Refill|Reject|Require|Return|Reverse|RequiredServices|Run|Univalued|Skip|Sort|Splitting|Squish|Subsample|Switch|Tag|Then|Timeout|To|TypeAlias|Using|When|Where|While|With|Without|Zipping",
+            "Alert|All|Annotations|Any|Argument|As|Begin|By|Count|Default|Define|Description|Dict|Distinct|Dump|Else|End|EpochMilli|EpochSecond|Export|First|Fixed|FixedConcat|Flatten|For|Frequency|From|Function|Group|If|In|Into|Input|Join|Labels|LeftJoin|Let|LexicalConcat|Limit|List|Location|Max|Min|Monitor|None|Olive|OnlyIf|OnReject|PartitionCount|Prefix|Pick|Reduce|Refill|Reject|Require|Return|Reverse|RequiredServices|Run|Univalued|Skip|Sort|Splitting|Squish|Subsample|Switch|Tag|Then|Timeout|To|TypeAlias|Using|When|Where|While|With|Without|Zipping",
           "storage.type": "boolean|date|float|integer|json|path|string",
           "keyword.operator": "`|~|:|<=?|>=?|==|\\|\\||-|!=?|/|\\*|&&|\\?",
           "constant.language":

--- a/shesmu-server/src/test/resources/run/destructure-wildcard-clauses.shesmu
+++ b/shesmu-server/src/test/resources/run/destructure-wildcard-clauses.shesmu
@@ -2,5 +2,5 @@ Input test;
 
 Olive
  Flatten * In [{ a = `True`, b = 3 }]
- Require x = a {}
+ Require x = a OnReject Dump a To aaa Resume
  Run ok With ok = x && b == 3;

--- a/shesmu-server/src/test/resources/run/reject-alert.shesmu
+++ b/shesmu-server/src/test/resources/run/reject-alert.shesmu
@@ -4,7 +4,7 @@ Olive
  Description "something, something"
  Tag foo
  Tag bar
- Reject path != '/foo1' {
+ Reject path != '/foo1' OnReject
    Alert alertname = "Badness", value = "true" For 5mins
- }
+ Resume
  Run ok With ok = path == '/foo1';

--- a/shesmu-server/src/test/resources/run/reject.shesmu
+++ b/shesmu-server/src/test/resources/run/reject.shesmu
@@ -4,7 +4,7 @@ Olive
  Description "something, something"
  Tag foo
  Tag bar
- Reject path != '/foo1' {
+ Reject path != '/foo1' OnReject
    Dump workflow To somefile
- }
+ Resume
  Run ok With ok = path == '/foo1';

--- a/shesmu-server/src/test/resources/run/require.shesmu
+++ b/shesmu-server/src/test/resources/run/require.shesmu
@@ -4,7 +4,7 @@ Olive
  Description "something, something"
  Tag foo
  Tag bar
- Require x = If path == '/foo1' Then `"hi"` Else `` {
+ Require x = If path == '/foo1' Then `"hi"` Else `` OnReject
    Dump workflow To somefile
- }
+ Resume
  Run ok With ok = x == "hi";

--- a/tutorial.md
+++ b/tutorial.md
@@ -399,13 +399,14 @@ monitoring or dumping. The `Reject` clause does this:
 
     Olive
       Where workflow == "BamQC 2.7+"
-      Reject file_size == 0 {
+      Reject file_size == 0
+       OnReject
          Monitor bad_bam_qc_results
                  "The number of bad BamQC results in production"
-                 {},
-         Dump ius, path To junk_bamqc_results,
+                 {}
+         Dump ius, path To junk_bamqc_results
          Alert alertname = "BadFile", path = "{path}" For 30mins
-      }
+       Resume
       Run fastqc With
         memory = 4Gi,
         input = path;

--- a/vim/syntax.vim
+++ b/vim/syntax.vim
@@ -62,6 +62,7 @@ syn keyword shesmuKeyword Monitor
 syn keyword shesmuKeyword None
 syn keyword shesmuKeyword Olive
 syn keyword shesmuKeyword OnlyIf
+syn keyword shesmuKeyword OnReject
 syn keyword shesmuKeyword PartitionCount
 syn keyword shesmuKeyword Pick
 syn keyword shesmuKeyword Prefix


### PR DESCRIPTION
Since `{}` are used almost exclusively for objects and tuples, this completes
that exclusivity that by removing them for `Require` and `Reject` clauses in
favour of words.

Closes #706