### PR TITLE
Add a LexicalConcat as a grouping clause

### DIFF
--- a/language.md
+++ b/language.md
@@ -307,6 +307,11 @@ Collect all values into a list from existing lists (duplicates are removed).
 
 Collects the results into a dictionary. Duplicate values are resolved arbitrarily.
 
+- `LexicalConcat` _expr_ `With` _delimiter_
+
+Concatenate all values, which must be strings, into a single string separated
+by _delimiter_, which must also be a string.
+
 - `List` _expr_
 
 Collect all values into a list (duplicates are removed).

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
@@ -40,6 +40,27 @@ public abstract class GroupNode implements DefinedTarget {
     GROUPERS.addKeyword("Flatten", of(GroupNodeFlatten::new));
     GROUPERS.addKeyword("OnlyIf", of(GroupNodeOnlyIf::new));
     GROUPERS.addKeyword("List", of(GroupNodeList::new));
+    GROUPERS.addKeyword(
+        "LexicalConcat",
+        (p, o) -> {
+          final AtomicReference<ExpressionNode> expression = new AtomicReference<>();
+          final AtomicReference<ExpressionNode> delimiter = new AtomicReference<>();
+          final Parser result =
+              p.whitespace()
+                  .then(ExpressionNode::parse0, expression::set)
+                  .whitespace()
+                  .keyword("With")
+                  .whitespace()
+                  .then(ExpressionNode::parse0, delimiter::set)
+                  .whitespace();
+          if (result.isGood()) {
+            o.accept(
+                (line, column, name) ->
+                    new GroupNodeLexicalConcat(
+                        line, column, name, expression.get(), delimiter.get()));
+          }
+          return result;
+        });
     GROUPERS.addKeyword("PartitionCount", of(GroupNodePartitionCount::new));
     GROUPERS.addKeyword("Univalued", ofWithDefault(GroupNodeUnivalued::new));
     GROUPERS.addKeyword(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeLexicalConcat.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeLexicalConcat.java
@@ -1,0 +1,93 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * A collection action in a “Group” clause
+ *
+ * <p>Also usable as the variable definition for the result
+ */
+public final class GroupNodeLexicalConcat extends GroupNode {
+  private final ExpressionNode expression;
+  private final ExpressionNode delimiter;
+  private final String name;
+  private boolean read;
+
+  public GroupNodeLexicalConcat(
+      int line, int column, String name, ExpressionNode expression, ExpressionNode delimiter) {
+    super(line, column);
+    this.name = name;
+    this.expression = expression;
+    this.delimiter = delimiter;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
+    delimiter.collectFreeVariables(freeVariables, predicate);
+    expression.collectFreeVariables(freeVariables, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    delimiter.collectPlugins(pluginFileNames);
+    expression.collectPlugins(pluginFileNames);
+  }
+
+  @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
+  }
+
+  @Override
+  public void render(Regrouper regroup, RootBuilder rootBuilder) {
+    regroup.addLexicalConcat(name(), expression::render, delimiter::render);
+  }
+
+  @Override
+  public boolean resolve(
+      NameDefinitions defs, NameDefinitions outerDefs, Consumer<String> errorHandler) {
+    return expression.resolve(defs, errorHandler) & delimiter.resolve(outerDefs, errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return expression.resolveDefinitions(expressionCompilerServices, errorHandler)
+        & delimiter.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return Imyhat.STRING;
+  }
+
+  @Override
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    boolean ok = true;
+    for (final ExpressionNode e : new ExpressionNode[] {expression, delimiter}) {
+      if (e.typeCheck(errorHandler)) {
+        if (!e.type().isSame(Imyhat.STRING)) {
+          e.typeError(Imyhat.STRING, e.type(), errorHandler);
+          ok = false;
+        }
+      } else {
+        ok = false;
+      }
+    }
+    return ok;
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RegroupVariablesBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RegroupVariablesBuilder.java
@@ -67,6 +67,12 @@ public final class RegroupVariablesBuilder implements Regrouper {
     }
 
     @Override
+    public void addLexicalConcat(
+        String fieldName, Consumer<Renderer> loader, Consumer<Renderer> delimiterLoader) {
+      elements.add(new LexicalConcat(prefix + fieldName, loader, delimiterLoader));
+    }
+
+    @Override
     public final void addMatches(String name, Match matchType, Consumer<Renderer> condition) {
       elements.add(new Matches(prefix + name, matchType, condition));
     }
@@ -624,6 +630,89 @@ public final class RegroupVariablesBuilder implements Regrouper {
     @Override
     protected void collect() {
       collectRenderer.methodGen().invokeInterface(A_SET_TYPE, METHOD_SET__ADD_ALL);
+    }
+  }
+
+  private class LexicalConcat extends Element {
+
+    private final Consumer<Renderer> delimiter;
+    private final String fieldName;
+    private final Consumer<Renderer> loader;
+
+    public LexicalConcat(
+        String fieldName, Consumer<Renderer> loader, Consumer<Renderer> delimiter) {
+      this.fieldName = fieldName;
+      this.loader = loader;
+      this.delimiter = delimiter;
+      classVisitor
+          .visitField(Opcodes.ACC_PUBLIC, fieldName, A_SET_TYPE.getDescriptor(), null, null)
+          .visitEnd();
+      classVisitor
+          .visitField(
+              Opcodes.ACC_PUBLIC, fieldName + "$delim", A_STRING_TYPE.getDescriptor(), null, null)
+          .visitEnd();
+      final GeneratorAdapter getMethod =
+          new GeneratorAdapter(
+              Opcodes.ACC_PUBLIC,
+              new Method(fieldName, A_STRING_TYPE, new Type[] {}),
+              null,
+              null,
+              classVisitor);
+      getMethod.visitCode();
+      getMethod.loadThis();
+      getMethod.getField(self, fieldName + "$delim", A_STRING_TYPE);
+      getMethod.loadThis();
+      getMethod.getField(self, fieldName, A_SET_TYPE);
+      getMethod.invokeStatic(A_STRING_TYPE, METHOD_STRING__JOIN);
+      getMethod.returnValue();
+      getMethod.endMethod();
+    }
+
+    @Override
+    public void buildCollect() {
+      collectRenderer.methodGen().loadArg(collectedSelfArgument);
+      collectRenderer.methodGen().getField(self, fieldName, A_SET_TYPE);
+      loader.accept(collectRenderer);
+      collectRenderer.methodGen().invokeInterface(A_SET_TYPE, METHOD_SET__ADD);
+      collectRenderer.methodGen().pop();
+    }
+
+    @Override
+    public int buildConstructor(GeneratorAdapter ctor, int index) {
+      ctor.loadThis();
+      ctor.loadArg(index);
+      ctor.putField(self, fieldName + "$delim", A_STRING_TYPE);
+      ctor.loadThis();
+      ctor.newInstance(A_TREE_SET_TYPE);
+      ctor.dup();
+      ctor.invokeConstructor(A_TREE_SET_TYPE, CTOR_DEFAULT);
+      ctor.putField(self, fieldName, A_SET_TYPE);
+      return index + 1;
+    }
+
+    @Override
+    public void buildEquals(GeneratorAdapter methodGen, int otherLocal, Label end) {
+      // LexicalConcat with default are not included in equality.
+    }
+
+    @Override
+    public void buildHashCode(GeneratorAdapter method) {
+      // LexicalConcat with are not included in hash code.
+    }
+
+    @Override
+    public Stream<Type> constructorType() {
+      return Stream.of(A_STRING_TYPE);
+    }
+
+    @Override
+    public void failIfBad(GeneratorAdapter okMethod) {
+      // LexicalConcat with default is always ok
+    }
+
+    @Override
+    public void loadConstructorArgument() {
+      delimiter.accept(newRenderer);
     }
   }
 
@@ -1258,6 +1347,8 @@ public final class RegroupVariablesBuilder implements Regrouper {
   private static final Type A_OPTIONAL_TYPE = Type.getType(Optional.class);
   private static final Type A_PARTITION_COUNT_TYPE = Type.getType(PartitionCount.class);
   private static final Type A_SET_TYPE = Type.getType(Set.class);
+  private static final Type A_STRING_TYPE = Type.getType(String.class);
+  private static final Type A_TREE_SET_TYPE = Type.getType(TreeSet.class);
   private static final Type A_TUPLE_TYPE = Type.getType(Tuple.class);
   private static final Type A_UNIVALUED_GROUP_ACCUMULATOR_TYPE =
       Type.getType(UnivaluedGroupAccumulator.class);
@@ -1285,6 +1376,11 @@ public final class RegroupVariablesBuilder implements Regrouper {
       new Method("add", BOOLEAN_TYPE, new Type[] {A_OBJECT_TYPE});
   private static final Method METHOD_SET__ADD_ALL =
       new Method("addAll", BOOLEAN_TYPE, new Type[] {Type.getType(Collection.class)});
+  private static final Method METHOD_STRING__JOIN =
+      new Method(
+          "join",
+          A_STRING_TYPE,
+          new Type[] {Type.getType(CharSequence.class), Type.getType(Iterable.class)});
   private static final Method METHOD_UNIVALUED_GROUP_ACCUMULATOR__ADD =
       new Method("add", VOID_TYPE, new Type[] {A_OBJECT_TYPE});
   private static final Method METHOD_UNIVALUED_GROUP_ACCUMULATOR__CTOR =
@@ -1357,6 +1453,12 @@ public final class RegroupVariablesBuilder implements Regrouper {
 
   public void addKey(Type fieldType, String fieldName, Consumer<Renderer> loader) {
     elements.add(new Discriminator(fieldType, fieldName, loader));
+  }
+
+  @Override
+  public void addLexicalConcat(
+      String fieldName, Consumer<Renderer> loader, Consumer<Renderer> delimiterLoader) {
+    elements.add(new LexicalConcat(fieldName, loader, delimiterLoader));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Regrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Regrouper.java
@@ -58,6 +58,14 @@ public interface Regrouper {
   void addFlatten(Imyhat valueType, String fieldName, Consumer<Renderer> loader);
 
   /**
+   * Create a lexically concatenated string
+   *
+   * @param fieldName the name of the variable for consumption by downstream uses
+   */
+  void addLexicalConcat(
+      String fieldName, Consumer<Renderer> loader, Consumer<Renderer> delimiterLoader);
+
+  /**
    * Add a value that is the Boolean result of checking expressions
    *
    * @param condition the condition that must be satisfied

--- a/shesmu-server/src/test/resources/run/group-lexicalconcat.shesmu
+++ b/shesmu-server/src/test/resources/run/group-lexicalconcat.shesmu
@@ -1,0 +1,8 @@
+Input test;
+
+Olive
+ Group
+  By project
+  Into
+    library_sizes = LexicalConcat "{library_size}" With ","
+ Run ok With ok = library_sizes == "300,307";


### PR DESCRIPTION
There are a few olives where we group into a list and then concatenate the
list. Fixed concatenation is not allowed because the input is unsorted.