### PR TITLE
Add a `Sum` collector to `Group` and `For`

### DIFF
--- a/language.md
+++ b/language.md
@@ -336,6 +336,11 @@ times it was _false_. The resulting value will be an object with two fields:
 `matched_count` with the number of rows that satisfied the condition and
 `not_matched_count` with the number that failed the provided condition
 
+- `Sum` _expr_
+
+Compute the sum of the resulting value from _expr_, which must be an integer or
+floating point number.
+
 - `Univalued` _expr_
 
 Collect exactly one value; if none are collected, the group is rejected; if
@@ -936,6 +941,12 @@ Performs a reduction operation on all the items in the list. _a_ is the
 accumulator, which will be returned, which is initially set to _initialexpr_.
 For every item, _expr_ is evaluated with _a_ set to the previously returned
 value.
+
+#### Sum
+- `Sum` _expr_
+
+Evaluates _expr_ for every item and compute the sum of all the results. _expr_
+must return an integer or a floating-point number.
 
 #### Univalued
 - `Univalued` _expr_

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNode.java
@@ -63,6 +63,16 @@ public abstract class CollectNode {
           return result;
         });
     DISPATCH.addKeyword(
+        "Sum",
+        (p, o) -> {
+          final AtomicReference<ExpressionNode> expression = new AtomicReference<>();
+          final Parser result = p.whitespace().then(ExpressionNode::parse0, expression::set);
+          if (result.isGood()) {
+            o.accept(new CollectNodeSum(p.line(), p.column(), expression.get()));
+          }
+          return result;
+        });
+    DISPATCH.addKeyword(
         "Count",
         (p, o) -> {
           o.accept(new CollectNodeCount(p.line(), p.column()));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeSum.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeSum.java
@@ -1,0 +1,90 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class CollectNodeSum extends CollectNode {
+
+  private List<String> definedNames;
+  private final ExpressionNode expression;
+
+  public CollectNodeSum(int line, int column, ExpressionNode expression) {
+    super(line, column);
+    this.expression = expression;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    final List<String> remove =
+        definedNames.stream().filter(name -> !names.contains(name)).collect(Collectors.toList());
+    expression.collectFreeVariables(names, predicate);
+    names.removeAll(remove);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+  }
+
+  @Override
+  public void render(JavaStreamBuilder builder, LoadableConstructor name) {
+    final Set<String> freeVariables = new HashSet<>();
+    expression.collectFreeVariables(freeVariables, Flavour::needsCapture);
+    final PrimitiveStream primitive =
+        expression.type().isSame(Imyhat.INTEGER) ? PrimitiveStream.LONG : PrimitiveStream.DOUBLE;
+    final Renderer renderer =
+        builder.mapToPrimitive(
+            line(),
+            column(),
+            name,
+            primitive,
+            builder
+                .renderer()
+                .allValues()
+                .filter(v -> freeVariables.contains(v.name()))
+                .toArray(LoadableValue[]::new));
+    renderer.methodGen().visitCode();
+    expression.render(renderer);
+    renderer.methodGen().returnValue();
+    renderer.methodGen().visitMaxs(0, 0);
+    renderer.methodGen().visitEnd();
+    builder.sum(primitive);
+  }
+
+  @Override
+  public boolean resolve(
+      DestructuredArgumentNode name, NameDefinitions defs, Consumer<String> errorHandler) {
+    final boolean ok = expression.resolve(defs.bind(name), errorHandler);
+    definedNames = name.targets().map(Target::name).collect(Collectors.toList());
+    return ok;
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return expression.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return expression.type();
+  }
+
+  @Override
+  public boolean typeCheck(Imyhat incoming, Consumer<String> errorHandler) {
+    if (expression.typeCheck(errorHandler)) {
+      if (expression.type().isSame(Imyhat.INTEGER) || expression.type().isSame(Imyhat.FLOAT)) {
+        return true;
+      }
+      expression.typeError("integer or float", expression.type(), errorHandler);
+    }
+    return false;
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNode.java
@@ -41,6 +41,7 @@ public abstract class GroupNode implements DefinedTarget {
     GROUPERS.addKeyword("OnlyIf", of(GroupNodeOnlyIf::new));
     GROUPERS.addKeyword("List", of(GroupNodeList::new));
     GROUPERS.addKeyword("PartitionCount", of(GroupNodePartitionCount::new));
+    GROUPERS.addKeyword("Sum", of(GroupNodeSum::new));
     GROUPERS.addKeyword("Univalued", ofWithDefault(GroupNodeUnivalued::new));
     GROUPERS.addKeyword(
         "Max",

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeSum.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/GroupNodeSum.java
@@ -1,0 +1,82 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * A sum action in a “Group” clause
+ *
+ * <p>Also usable as the variable definition for the result
+ */
+public final class GroupNodeSum extends GroupNode {
+  private final ExpressionNode expression;
+  private final String name;
+  private boolean read;
+
+  public GroupNodeSum(int line, int column, String name, ExpressionNode expression) {
+    super(line, column);
+    this.name = name;
+    this.expression = expression;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> freeVariables, Predicate<Flavour> predicate) {
+    expression.collectFreeVariables(freeVariables, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+  }
+
+  @Override
+  public boolean isRead() {
+    return read;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public void read() {
+    read = true;
+  }
+
+  @Override
+  public void render(Regrouper regroup, RootBuilder rootBuilder) {
+    regroup.addSum(expression.type(), name(), expression::render);
+  }
+
+  @Override
+  public boolean resolve(
+      NameDefinitions defs, NameDefinitions outerDefs, Consumer<String> errorHandler) {
+    return expression.resolve(defs, errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return expression.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return expression.type();
+  }
+
+  @Override
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    if (expression.typeCheck(errorHandler)) {
+      if (expression.type().isSame(Imyhat.INTEGER) || expression.type().isSame(Imyhat.FLOAT)) {
+        return true;
+      }
+      expression.typeError("integer or float", expression.type(), errorHandler);
+    }
+    return false;
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LambdaBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LambdaBuilder.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
 import static org.objectweb.asm.Type.*;
 
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
@@ -46,7 +47,9 @@ public final class LambdaBuilder {
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
   private static final Type A_PREDICATE_TYPE = Type.getType(Predicate.class);
   private static final Type A_SUPPLIER_TYPE = Type.getType(Supplier.class);
+  private static final Type A_TO_DOUBLE_FUNCTION_TYPE = Type.getType(ToDoubleFunction.class);
   private static final Type A_TO_INT_FUNCTION_TYPE = Type.getType(ToIntFunction.class);
+  private static final Type A_TO_LONG_FUNCTION_TYPE = Type.getType(ToLongFunction.class);
   private static final Type A_TRIGROUPER_TYPE = Type.getType(TriGrouper.class);
   private static final Handle LAMBDA_METAFACTORY_BSM =
       new Handle(
@@ -86,8 +89,7 @@ public final class LambdaBuilder {
           case ERASED:
             return Stream.of(A_OBJECT_TYPE, A_OBJECT_TYPE);
           case REAL:
-            return Stream.of(
-                parameter1Type.apply(TypeUtils.TO_ASM), parameter2Type.apply(TypeUtils.TO_ASM));
+            return Stream.of(parameter1Type.apply(TO_ASM), parameter2Type.apply(TO_ASM));
           default:
             throw new UnsupportedOperationException();
         }
@@ -215,8 +217,7 @@ public final class LambdaBuilder {
                 parameter1Type.apply(TypeUtils.TO_BOXED_ASM),
                 parameter2Type.apply(TypeUtils.TO_BOXED_ASM));
           case REAL:
-            return Stream.of(
-                parameter1Type.apply(TypeUtils.TO_ASM), parameter2Type.apply(TypeUtils.TO_ASM));
+            return Stream.of(parameter1Type.apply(TO_ASM), parameter2Type.apply(TO_ASM));
           case ERASED:
             return Stream.of(A_OBJECT_TYPE, A_OBJECT_TYPE);
           default:
@@ -235,7 +236,7 @@ public final class LambdaBuilder {
           case BOXED:
             return returnType.apply(TypeUtils.TO_BOXED_ASM);
           case REAL:
-            return returnType.apply(TypeUtils.TO_ASM);
+            return returnType.apply(TO_ASM);
           case ERASED:
             return A_OBJECT_TYPE;
           default:
@@ -266,7 +267,7 @@ public final class LambdaBuilder {
           case BOXED:
             return Stream.of(parameter1Type, parameter2Type.apply(TypeUtils.TO_BOXED_ASM));
           case REAL:
-            return Stream.of(parameter1Type, parameter2Type.apply(TypeUtils.TO_ASM));
+            return Stream.of(parameter1Type, parameter2Type.apply(TO_ASM));
           case ERASED:
             return Stream.of(A_OBJECT_TYPE, A_OBJECT_TYPE);
           default:
@@ -441,7 +442,7 @@ public final class LambdaBuilder {
           case ERASED:
             return Stream.of(A_OBJECT_TYPE);
           case REAL:
-            return Stream.of(parameterType.apply(TypeUtils.TO_ASM));
+            return Stream.of(parameterType.apply(TO_ASM));
           default:
             throw new UnsupportedOperationException();
         }
@@ -460,7 +461,7 @@ public final class LambdaBuilder {
           case ERASED:
             return A_OBJECT_TYPE;
           case REAL:
-            return returnType.apply(TypeUtils.TO_ASM);
+            return returnType.apply(TO_ASM);
           default:
             throw new UnsupportedOperationException();
         }
@@ -508,7 +509,7 @@ public final class LambdaBuilder {
           case ERASED:
             return A_OBJECT_TYPE;
           case REAL:
-            return returnType.apply(TypeUtils.TO_ASM);
+            return returnType.apply(TO_ASM);
           default:
             throw new UnsupportedOperationException();
         }
@@ -536,7 +537,7 @@ public final class LambdaBuilder {
           case BOXED:
             return Stream.of(parameterType.apply(TypeUtils.TO_BOXED_ASM));
           case REAL:
-            return Stream.of(parameterType.apply(TypeUtils.TO_ASM));
+            return Stream.of(parameterType.apply(TO_ASM));
           case ERASED:
             return Stream.of(A_OBJECT_TYPE);
           default:
@@ -633,7 +634,7 @@ public final class LambdaBuilder {
           case ERASED:
             return Stream.of(A_OBJECT_TYPE);
           case REAL:
-            return Stream.of(parameterType.apply(TypeUtils.TO_ASM));
+            return Stream.of(parameterType.apply(TO_ASM));
           default:
             throw new UnsupportedOperationException();
         }
@@ -863,10 +864,48 @@ public final class LambdaBuilder {
           case ERASED:
             return A_OBJECT_TYPE;
           case REAL:
-            return returnType.apply(TypeUtils.TO_ASM);
+            return returnType.apply(TO_ASM);
           default:
             throw new UnsupportedOperationException();
         }
+      }
+    };
+  }
+
+  public static LambdaType toDoubleFunction(Imyhat parameterType) {
+    return new LambdaType() {
+
+      @Override
+      public Type interfaceType() {
+        return A_TO_DOUBLE_FUNCTION_TYPE;
+      }
+
+      @Override
+      public String methodName() {
+        return "applyAsDouble";
+      }
+
+      @Override
+      public Stream<Type> parameterTypes(AccessMode accessMode) {
+        switch (accessMode) {
+          case BOXED:
+          case REAL:
+            return Stream.of(parameterType.apply(TO_ASM));
+          case ERASED:
+            return Stream.of(A_OBJECT_TYPE);
+          default:
+            throw new UnsupportedOperationException();
+        }
+      }
+
+      @Override
+      public int parameters() {
+        return 1;
+      }
+
+      @Override
+      public Type returnType(AccessMode accessMode) {
+        return DOUBLE_TYPE;
       }
     };
   }
@@ -906,6 +945,44 @@ public final class LambdaBuilder {
       @Override
       public Type returnType(AccessMode accessMode) {
         return INT_TYPE;
+      }
+    };
+  }
+
+  public static LambdaType toLongFunction(Imyhat parameterType) {
+    return new LambdaType() {
+
+      @Override
+      public Type interfaceType() {
+        return A_TO_LONG_FUNCTION_TYPE;
+      }
+
+      @Override
+      public String methodName() {
+        return "applyAsLong";
+      }
+
+      @Override
+      public Stream<Type> parameterTypes(AccessMode accessMode) {
+        switch (accessMode) {
+          case BOXED:
+          case REAL:
+            return Stream.of(parameterType.apply(TO_ASM));
+          case ERASED:
+            return Stream.of(A_OBJECT_TYPE);
+          default:
+            throw new UnsupportedOperationException();
+        }
+      }
+
+      @Override
+      public int parameters() {
+        return 1;
+      }
+
+      @Override
+      public Type returnType(AccessMode accessMode) {
+        return LONG_TYPE;
       }
     };
   }
@@ -999,6 +1076,10 @@ public final class LambdaBuilder {
                     streamType == null ? Stream.empty() : Stream.of(streamType)),
                 Arrays.stream(capturedVariables).map(LoadableValue::type))
             .toArray(Type[]::new);
+  }
+
+  public LambdaType lambda() {
+    return lambda;
   }
 
   /** Get the method that was generated */

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeFlatten.java
@@ -90,7 +90,6 @@ public class ListNodeFlatten extends ListNode {
                 (a, b) -> {
                   throw new UnsupportedOperationException();
                 });
-    flattenBuilder.finish();
     renderer.methodGen().returnValue();
     renderer.methodGen().visitMaxs(0, 0);
     renderer.methodGen().visitEnd();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PrimitiveStream.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PrimitiveStream.java
@@ -1,0 +1,46 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.LambdaBuilder.LambdaType;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.stream.DoubleStream;
+import java.util.stream.LongStream;
+import org.objectweb.asm.Type;
+
+public enum PrimitiveStream {
+  DOUBLE("mapToDouble", Type.getType(DoubleStream.class), Type.DOUBLE_TYPE) {
+    @Override
+    public LambdaType lambdaOf(Imyhat input) {
+      return LambdaBuilder.toDoubleFunction(input);
+    }
+  },
+  LONG("mapToLong", Type.getType(LongStream.class), Type.LONG_TYPE) {
+    @Override
+    public LambdaType lambdaOf(Imyhat input) {
+      return LambdaBuilder.toLongFunction(input);
+    }
+  };
+
+  private final String methodName;
+  private final Type outputStreamType;
+  private final Type resultType;
+
+  PrimitiveStream(String methodName, Type outputStreamType, Type resultType) {
+    this.methodName = methodName;
+    this.outputStreamType = outputStreamType;
+    this.resultType = resultType;
+  }
+
+  public abstract LambdaType lambdaOf(Imyhat input);
+
+  public String methodName() {
+    return methodName;
+  }
+
+  public Type outputStreamType() {
+    return outputStreamType;
+  }
+
+  public Type resultType() {
+    return resultType;
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RegroupVariablesBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RegroupVariablesBuilder.java
@@ -105,6 +105,11 @@ public final class RegroupVariablesBuilder implements Regrouper {
     }
 
     @Override
+    public void addSum(Imyhat valueType, String fieldName, Consumer<Renderer> loader) {
+      elements.add(new Sum(valueType, prefix + fieldName, loader));
+    }
+
+    @Override
     public final void addUnivalued(Imyhat valueType, String fieldName, Consumer<Renderer> loader) {
       elements.add(new Univalued(valueType, prefix + fieldName, loader));
     }
@@ -1074,6 +1079,63 @@ public final class RegroupVariablesBuilder implements Regrouper {
     }
   }
 
+  private class Sum extends Element {
+    private final String fieldName;
+    private final Consumer<Renderer> loader;
+    private final Type type;
+
+    private Sum(Imyhat valueType, String fieldName, Consumer<Renderer> loader) {
+      super();
+      this.type = valueType.apply(TO_ASM);
+      this.fieldName = fieldName;
+      this.loader = loader;
+      classVisitor
+          .visitField(Opcodes.ACC_PUBLIC, fieldName, type.getDescriptor(), null, null)
+          .visitEnd();
+      buildGetter(type, fieldName);
+    }
+
+    @Override
+    public void buildCollect() {
+      collectRenderer.methodGen().loadArg(collectedSelfArgument);
+      collectRenderer.methodGen().loadArg(collectedSelfArgument);
+      collectRenderer.methodGen().getField(self, fieldName, type);
+      loader.accept(collectRenderer);
+      collectRenderer.methodGen().math(GeneratorAdapter.ADD, type);
+      collectRenderer.methodGen().putField(self, fieldName, type);
+    }
+
+    @Override
+    public int buildConstructor(GeneratorAdapter ctor, int index) {
+      return index;
+    }
+
+    @Override
+    public void buildEquals(GeneratorAdapter methodGen, int otherLocal, Label end) {
+      // Sum are not included in equality.
+    }
+
+    @Override
+    public void buildHashCode(GeneratorAdapter hashMethod) {
+      // Sum are not included in the hash.
+    }
+
+    @Override
+    public Stream<Type> constructorType() {
+      return Stream.empty();
+    }
+
+    @Override
+    public void failIfBad(GeneratorAdapter okMethod) {
+      // Sum cannot fail
+    }
+
+    @Override
+    public void loadConstructorArgument() {
+      // No argument to constructor.
+    }
+  }
+
   private class Univalued extends Element {
     private final String fieldName;
     private final Consumer<Renderer> loader;
@@ -1394,6 +1456,11 @@ public final class RegroupVariablesBuilder implements Regrouper {
   @Override
   public void addPartitionCount(String fieldName, Consumer<Renderer> condition) {
     elements.add(new PartitionCounter(fieldName, condition));
+  }
+
+  @Override
+  public void addSum(Imyhat valueType, String fieldName, Consumer<Renderer> loader) {
+    elements.add(new Sum(valueType, fieldName, loader));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Regrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Regrouper.java
@@ -106,6 +106,14 @@ public interface Regrouper {
   void addPartitionCount(String fieldName, Consumer<Renderer> condition);
 
   /**
+   * Add a new sum of values slurped during iteration
+   *
+   * @param valueType the type of the values (either float or integer)
+   * @param fieldName the name of the variable for consumption by downstream uses
+   */
+  void addSum(Imyhat valueType, String fieldName, Consumer<Renderer> loader);
+
+  /**
    * Create a collection that should only ever have one item in it
    *
    * <p>The row will be rejected if it has zero or 2 or more items.

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
@@ -20,7 +20,7 @@ ace.define(
       var keywordMapper = (this.$keywords = this.createKeywordMapper(
         {
           "keyword.control":
-            "Alert|All|Annotations|Any|Argument|As|Begin|By|Count|Default|Define|Description|Dict|Distinct|Dump|Else|End|EpochMilli|EpochSecond|Export|First|Fixed|FixedConcat|Flatten|For|Frequency|From|Function|Group|If|In|Into|Input|Join|Labels|LeftJoin|Let|LexicalConcat|Limit|List|Location|Max|Min|Monitor|None|Olive|OnlyIf|OnReject|PartitionCount|Prefix|Pick|Reduce|Refill|Reject|Require|Return|Reverse|RequiredServices|Run|Univalued|Skip|Sort|Splitting|Squish|Subsample|Switch|Tag|Then|Timeout|To|TypeAlias|Using|When|Where|While|With|Without|Zipping",
+            "Alert|All|Annotations|Any|Argument|As|Begin|By|Count|Default|Define|Description|Dict|Distinct|Dump|Else|End|EpochMilli|EpochSecond|Export|First|Fixed|FixedConcat|Flatten|For|Frequency|From|Function|Group|If|In|Into|Input|Join|Labels|LeftJoin|Let|LexicalConcat|Limit|List|Location|Max|Min|Monitor|None|Olive|OnlyIf|OnReject|PartitionCount|Prefix|Pick|Reduce|Refill|Reject|Require|Return|Reverse|RequiredServices|Run|Univalued|Skip|Sort|Splitting|Squish|Subsample|Sum|Switch|Tag|Then|Timeout|To|TypeAlias|Using|When|Where|While|With|Without|Zipping",
           "storage.type": "boolean|date|float|integer|json|path|string",
           "keyword.operator": "`|~|:|<=?|>=?|==|\\|\\||-|!=?|/|\\*|&&|\\?",
           "constant.language":

--- a/shesmu-server/src/test/resources/run/group-sum.shesmu
+++ b/shesmu-server/src/test/resources/run/group-sum.shesmu
@@ -1,0 +1,9 @@
+Input test;
+
+Olive
+ Group
+  By project
+  Into
+    x = Sum library_size,
+    y = Sum library_size * 1.0
+ Run ok With ok = x == 607 && y == 607.0;

--- a/shesmu-server/src/test/resources/run/list-sum-float.shesmu
+++ b/shesmu-server/src/test/resources/run/list-sum-float.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = (For x In [ 1.0, 2.0 ]: Sum x) == 3.0;

--- a/shesmu-server/src/test/resources/run/list-sum-int.shesmu
+++ b/shesmu-server/src/test/resources/run/list-sum-int.shesmu
@@ -1,0 +1,4 @@
+Input test;
+
+Olive
+ Run ok With ok = (For x In [ 1, 2 ]: Sum x) == 3;

--- a/vim/syntax.vim
+++ b/vim/syntax.vim
@@ -80,6 +80,7 @@ syn keyword shesmuKeyword Sort
 syn keyword shesmuKeyword Splitting
 syn keyword shesmuKeyword Squish
 syn keyword shesmuKeyword Subsample
+syn keyword shesmuKeyword Sum
 syn keyword shesmuKeyword Switch
 syn keyword shesmuKeyword Tag
 syn keyword shesmuKeyword Then


### PR DESCRIPTION
Add a summing collector type that adds all the discovered results together for
integer and floating-point numbers.

No current use cases, but it seems reasonable to add before 1.0