### PR TITLE
Fix action ID parsing in text queries

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilter.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilter.java
@@ -238,7 +238,8 @@ public abstract class ActionFilter {
                   o.accept(
                       errorHandler -> {
                         final ActionFilterIds filter = new ActionFilterIds();
-                        filter.setIds(Collections.singletonList(m.group(0).toUpperCase()));
+                        filter.setIds(
+                            Collections.singletonList("shesmu:" + m.group(0).toUpperCase()));
                         return Optional.of(filter);
                       });
                 },


### PR DESCRIPTION
The implementation incorrectly strips `shesmu:` from action IDs, but this is
necessary for matching.