### PR TITLE
Export underlying scheduler job IDs from Cromwell

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CromwellCall.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CromwellCall.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CromwellCall {
   private int attempt;
+  private String backend;
   private String callRoot;
+  private String jobId;
   private String shardIndex;
   private String stderr;
   private String stdout;
@@ -14,8 +16,16 @@ public class CromwellCall {
     return attempt;
   }
 
+  public String getBackend() {
+    return backend;
+  }
+
   public String getCallRoot() {
     return callRoot;
+  }
+
+  public String getJobId() {
+    return jobId;
   }
 
   public String getShardIndex() {
@@ -34,8 +44,16 @@ public class CromwellCall {
     this.attempt = attempt;
   }
 
+  public void setBackend(String backend) {
+    this.backend = backend;
+  }
+
   public void setCallRoot(String callRoot) {
     this.callRoot = callRoot;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
   }
 
   public void setShardIndex(String shardIndex) {

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -910,6 +910,8 @@ public final class WorkflowAction extends Action {
                           final ObjectNode logEntry = cromwellLogs.addObject();
                           logEntry.put("task", task);
                           logEntry.put("attempt", log.getAttempt());
+                          logEntry.put("backend", log.getBackend());
+                          logEntry.put("jobId", log.getJobId());
                           logEntry.put("shardIndex", log.getShardIndex());
                           logEntry.put("stderr", log.getStderr());
                           logEntry.put("stdout", log.getStdout());

--- a/plugin-niassa+pinery/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
+++ b/plugin-niassa+pinery/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
@@ -126,6 +126,8 @@ actionRender.set("niassa", a => [
       ["Task", x => x.task],
       ["Attempt", x => x.attempt],
       ["Scatter", x => (x.shardIndex < 0 ? "N/A" : x.shardIndex)],
+      ["Backend", x => x.backend || "Unknown"],
+      ["Job ID", x => x.jobId || "Unknown"],
       ["Standard Error", x => (x.stderr ? breakSlashes(x.stderr) : "N/A")],
       ["Standard Output", x => (x.stdout ? breakSlashes(x.stdout) : "N/A")]
     )


### PR DESCRIPTION
This display the Univa job IDs for Cromwell tasks, to make tracing problems
easier.