### PR TITLE
Fix LIMS key locking

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
@@ -233,16 +233,17 @@ class NiassaServer extends JsonPluginFile<Configuration> {
             // should block each other, so just provider + ID
             final Pair<String, String> limsKeyId =
                 new Pair<>(limsKey.getProvider(), limsKey.getId());
-            if (lockedLimsKeys.containsKey(limsKeyId) || stale.contains(limsKeyId)) {
+
+            if (lockedLimsKeys.containsKey(limsKeyId)) {
               // Duplicate LIMS keys in input. This is bad and will probably fail elsewhere, but we
               // can lock it successfully.
               logger.log(
                   limsKey,
-                  "There's an olive that has produced multiple LIMS keys with multiple %s/%s and that's a bug.");
+                  "There's an olive that has produced multiple LIMS keys with the same provider/id and that's a bug");
               continue;
             }
             // Add this lims key to the set of active locks. Add returns true if it was newly added
-            if (this.activeLimsKeys.add(limsKeyId)) {
+            if (!stale.contains(limsKeyId) && this.activeLimsKeys.add(limsKeyId)) {
               // Track that we added this LIMS key and therefore own it
               lockedLimsKeys.put(limsKeyId, limsKey);
             } else {


### PR DESCRIPTION
The checking of LIMS keys that have been previously locked was in the wrong
branch which resulted in an incorrect error and a failure to lock properly.