### PR TITLE
Fix bad bytecode using signatures after `Flatten`

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
@@ -46,6 +46,8 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
     return column;
   }
 
+  private boolean copySignatures;
+
   @Override
   public Stream<OliveClauseRow> dashboard() {
     final Set<String> inputs = new TreeSet<>();
@@ -72,6 +74,7 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
       OliveNode.ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
     if (state == OliveNode.ClauseStreamOrder.PURE) {
       expression.collectFreeVariables(signableNames, Target.Flavour.STREAM_SIGNABLE::equals);
+      copySignatures = true;
       // Okay, we're going to lie here. Flatten does modify the stream but we're going to say that
       // it doesn't for an important reason: signatures. We want the variables that cross flatten to
       // still be part of the signature since flatten only adds new (non-signable) variables. For
@@ -100,6 +103,7 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
             line,
             column,
             unrollType,
+            copySignatures,
             oliveBuilder
                 .loadableValues()
                 .filter(v -> freeVariables.contains(v.name()))

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
@@ -28,10 +28,13 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
   private static final Method METHOD_RUNTIME_SUPPORT__STEAM_OPTIONAL =
       new Method("stream", Type.getType(Stream.class), new Type[] {A_OPTIONAL_TYPE});
   private final int column;
-  private final DestructuredArgumentNode name;
+  private boolean copySignatures;
   private final ExpressionNode expression;
   private final List<RejectNode> handlers;
+  private List<Target> incoming;
   private final int line;
+  private final DestructuredArgumentNode name;
+  private Imyhat type = Imyhat.BAD;
 
   public OliveClauseNodeRequire(
       int line,
@@ -97,6 +100,7 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
       ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
     if (state == ClauseStreamOrder.PURE) {
       expression.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals);
+      copySignatures = true;
     }
     // All though we technically manipulate the stream, we're only adding, so we can pretend the
     // stream is still pure.
@@ -107,8 +111,6 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
   public int line() {
     return line;
   }
-
-  private List<Target> incoming;
 
   @Override
   public void render(
@@ -123,6 +125,7 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
             line,
             column,
             type,
+            copySignatures,
             Stream.concat(
                     Stream.of(
                         new LoadableValue() {
@@ -217,8 +220,6 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
             == handlers.size()
         & name.checkWildcard(errorHandler) != WildcardCheck.BAD;
   }
-
-  private Imyhat type = Imyhat.BAD;
 
   @Override
   public boolean typeCheck(Consumer<String> errorHandler) {

--- a/shesmu-server/src/test/resources/run/flatten-signature.shesmu
+++ b/shesmu-server/src/test/resources/run/flatten-signature.shesmu
@@ -1,0 +1,7 @@
+Version 1;
+Input test;
+
+Olive
+ Where project == "the_foo_study"
+ Flatten x In stuff
+ Run ok With ok = "project" In signature_names && x != "";


### PR DESCRIPTION
The `Flatten` (and `Require`) operation works by creating a proxy class with
two fields: the original value and the unrolled value and creating delegate
methods to the original value. Signatures do not exist as real methods on the
input data, so an incorrect delegate was created. This expands each signature
to a real value at the time of proxy construction and stores it as a field in
the proxy.