### PR TITLE
Circumvent strange Mac Chrome bug

### DIFF
--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -764,7 +764,6 @@ table.errors {
 
 .vertical {
   writing-mode: vertical-rl;
-  transform: rotate(180deg);
 }
 
 .active {


### PR DESCRIPTION
Chrome on Mac hates the `writing-mode: vertical-tr` property.

Chrome Version 83.0.4103.116 (Official Build) (64-bit)  on Mac 10.14.6:
![Screen Shot 2020-06-26 at 10 16 07 AM](https://user-images.githubusercontent.com/1746206/85869445-ad15fc80-b799-11ea-915c-2b5f74dabbce.png)

By turning off rotate(180deg), it's at least readable on Chrome:

Firefox with fix:
![Screen Shot 2020-06-26 at 10 36 15 AM](https://user-images.githubusercontent.com/1746206/85869497-c028cc80-b799-11ea-850d-218292bb5230.png)

Chrome with fix:
![Screen Shot 2020-06-26 at 10 35 26 AM](https://user-images.githubusercontent.com/1746206/85869504-c1f29000-b799-11ea-9fc1-5cad4a62cf83.png)

