### PR TITLE
Change signature handling in `Define` olives

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
@@ -47,6 +47,9 @@ public class ExpressionNodeVariable extends ExpressionNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     if (predicate.test(target.flavour())) {
       names.add(name);
+      // We also need to get an accessor when in a Define olive and we need to lift the accessor
+      // along the way; in a other olives, this will just get ignored.
+      names.add(BaseOliveBuilder.SIGNER_ACCESSOR_NAME);
     }
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Renderer.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Renderer.java
@@ -101,7 +101,12 @@ public class Renderer {
 
   /** Find a known variable by name and load it on the stack. */
   public void emitNamed(String name) {
-    loadables.get(name).accept(this);
+    final LoadableValue value = loadables.get(name);
+    if (value == null) {
+      throw new IllegalStateException(
+          String.format("Attempt to emit “%s”, but this is an unknown name in this context", name));
+    }
+    value.accept(this);
   }
 
   public void emitSigner(SignatureDefinition name) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/SignatureAccessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/SignatureAccessor.java
@@ -1,0 +1,29 @@
+package ca.on.oicr.gsi.shesmu.runtime;
+
+/**
+ * An interface for getting signature values
+ *
+ * <p>This is used by <tt>Define</tt> olives to access signatures which their callers must provide.
+ */
+public interface SignatureAccessor {
+
+  /**
+   * Get a signature
+   *
+   * @param name the name of the signature
+   * @param value the stream value; the type of the object is not really know and should only be
+   *     access via method handles
+   * @return the signature result; the type is known to the compiler and the callee will unbox it
+   *     appropriately
+   */
+  Object dynamicSignature(String name, Object value);
+
+  /**
+   * Get a signature
+   *
+   * @param name the name of the signature
+   * @return the signature result; the type is known to the compiler and the callee will unbox it
+   *     appropriately
+   */
+  Object staticSignature(String name);
+}


### PR DESCRIPTION
The changes signatures in `Define` olives to be passed as a single
`SignatureAccessor` object rather than individually and to copy this into
lambdas rather than storing this information in a field. The reason for this is
as a prerequisite to make `Export Define` possible. If a `Define` olive is
exported, so two different scripts might call it simultaneously, so it cannot
store state in a shared place. Further more, since signatures can be redefined
by plugins, putting the signatures in the method will make incompatible method
signatures if new signatures are found.