### PR TITLE
Rename JSON config function

### DIFF
--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/json/StructuredConfigFile.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/json/StructuredConfigFile.java
@@ -115,7 +115,7 @@ public class StructuredConfigFile extends JsonPluginFile<Configuration> {
     this.badRecords = badRecords;
     definer.clearFunctions();
     definer.defineFunction(
-        this.name(),
+        "get",
         "JSON configuration from " + fileName(),
         type.asOptional(),
         args -> values.getOrDefault(args[0], missingResult),


### PR DESCRIPTION
It should be `config::foo::get` not `config::foo::foo`.