### PR TITLE
Fix Signer Accessor not being lifted into lambdas

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
@@ -47,8 +47,10 @@ public class ExpressionNodeVariable extends ExpressionNode {
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     if (predicate.test(target.flavour())) {
       names.add(name);
-      // We also need to get an accessor when in a Define olive and we need to lift the accessor
-      // along the way; in a other olives, this will just get ignored.
+    }
+    // We also need to get an accessor when in a Define olive and we need to lift the accessor
+    // along the way; in a other olives, this will just get ignored.
+    if (predicate.test(Flavour.CONSTANT)) {
       names.add(BaseOliveBuilder.SIGNER_ACCESSOR_NAME);
     }
   }

--- a/shesmu-server/src/test/resources/run/sign5.shesmu
+++ b/shesmu-server/src/test/resources/run/sign5.shesmu
@@ -1,0 +1,9 @@
+Version 1;
+Input test;
+
+Define foo(string s)
+ Where s == project && (For x In [1]: All std::signature::sha1 != "");
+
+Olive
+ foo("the_foo_study")
+ Run ok With ok = std::signature::count == 2 && "project" In std::signature::names && library_size > 0 && "library_size" In std::signature::names;


### PR DESCRIPTION
The lifting of the accessor and the variable itself follow different rules. The
accessor should always be lifted, but the variable itself is not lifted.