### PR TITLE
Ignore unknown properties in static actions

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/StaticAction.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/StaticAction.java
@@ -1,9 +1,11 @@
 package ca.on.oicr.gsi.shesmu.server;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StaticAction {
   private String name;
   private ObjectNode parameters;


### PR DESCRIPTION
This silences a problem where the simulation output includes `type`, which
prevents loading that output as a static action. This property contains no
useful information in this context, so it can be discarded.