### PR TITLE
Fix action permalinks

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -30,6 +30,7 @@ import {
   inputText,
   checkRandomPermutation,
   checkRandomSequence,
+  makeUrl,
 } from "./html.js";
 import {
   StatefulModel,
@@ -239,9 +240,10 @@ export function actionDisplay(
                   css,
                   paragraph(
                     link(
-                      `actiondash?filters=${encodeURIComponent(
-                        JSON.stringify({ id: [action.actionId] })
-                      )}&saved=All%20Actions`,
+                      makeUrl("actiondash", {
+                        filters: { id: [action.actionId] },
+                        saved: "All Actions",
+                      }),
                       action.actionId
                     ),
                     button(

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -850,14 +850,7 @@ export function historyState<T extends { [name: string]: any }>(
         window.history.pushState(
           { ...input },
           title(input),
-          window.location.pathname +
-            "?" +
-            Object.entries(input)
-              .map(
-                ([key, value]) =>
-                  key + "=" + encodeURIComponent(JSON.stringify(value))
-              )
-              .join("&")
+          makeUrl(window.location.pathname, input)
         );
       }
     },
@@ -1020,6 +1013,25 @@ export function link(
   element.href = url;
   element.title = title || "";
   return element;
+}
+/**
+ * Create a URL with query parameters
+ * @param url the base URL
+ * @param parameters the parameters to supply; they will be JSON-encoded
+ */
+export function makeUrl(
+  url: string,
+  parameters: { [name: string]: any }
+): string {
+  return (
+    url +
+    "?" +
+    Object.entries(parameters)
+      .map(
+        ([key, value]) => key + "=" + encodeURIComponent(JSON.stringify(value))
+      )
+      .join("&")
+  );
 }
 /**
  * Display some monospaced text.


### PR DESCRIPTION
This fixes action permalinks causing a cryptic error. The encoding of the base
search in the action dashboard has changed from a raw string to a JSON-encoded
one. This updates the permalinks to match.