### PR TITLE
Allow exporting and sharing Define olives

### DIFF
--- a/language.md
+++ b/language.md
@@ -123,7 +123,7 @@ possible types are defined below. If
 `olive::`_script_`::`_name_.
 
 
-- `Define` _name_`(`[_type1_ _arg1_[`,` ...]]`)` _clauses_ `;`
+- [`Export`] `Define` _name_`(`[_type1_ _arg1_[`,` ...]]`)` _clauses_ `;`
 
 Create a new define olive. This is a section of olive that can be reused among
 different olives in the file. It is intended for when olives share similar

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -56,10 +56,10 @@ import { helpArea } from "./help.js";
 /**
  * An exported definition from a simulated script
  */
-type Export = ExportConstant | ExportFunction;
+type Export = ExportConstant | ExportDefine | ExportFunction;
 
 /**
- * A constant definition exported by a simulated scrip.
+ * A constant definition exported by a simulated script.
  */
 interface ExportConstant {
   type: "constant";
@@ -67,6 +67,27 @@ interface ExportConstant {
   name: string;
   /** The type as a Shesmu descriptor */
   returns: string;
+}
+/**
+ * An olive definition exported by a simulated script.
+ */
+interface ExportDefine {
+  type: "define";
+  /** The exported name */
+  name: string;
+  /** The input format consume by this olive*/
+  inputFormat: string;
+  /**
+   * The output variables and their types
+   */
+  output: { [name: string]: string };
+  /** The parameter types as Shesmu descriptors */
+  parameters: string[];
+  /** If true, the definition is returning an “unmodified” data stream.
+   *
+   * The data stream may actaully be modified through a <tt>Flatten</tt> or <tt>Require</tt> operation, but it is close enough to the original format to still compute signatures on.
+   */
+  isRoot: boolean;
 }
 /**
  * A function definition exported by a simulated script
@@ -461,6 +482,31 @@ export function initialiseSimulationDashboard(
                       ["Type", (x) => x[0]]
                     ),
                   ];
+                case "define":
+                  return [
+                    header(ex.name),
+                    table(
+                      [
+                        ["Input Format", ex.inputFormat],
+                        ["Should Sign After", ex.isRoot ? "Yes" : "No"],
+                      ]
+                        .concat(
+                          ex.parameters.map((type, index) => [
+                            `Parameter ${index + 1}`,
+                            type,
+                          ])
+                        )
+                        .concat(
+                          Object.entries(ex.output).map(([name, type]) => [
+                            `Output Variable ${name}`,
+                            type,
+                          ])
+                        ),
+                      ["Position", (x) => x[0]],
+                      ["Type", (x) => x[0]]
+                    ),
+                  ];
+
                 case "function":
                   return [
                     header(ex.name),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CallableDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CallableDefinition.java
@@ -1,0 +1,34 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * This is the definition from something that can be used in a “call” olive clause; one which calls
+ * a predefined olive chunk elsewhere.
+ */
+public interface CallableDefinition {
+
+  void collectSignables(
+      Set<String> signableNames, Consumer<SignableVariableCheck> addSignableCheck);
+
+  Stream<OliveClauseRow> dashboardInner(int line, int column);
+
+  Path filename();
+
+  boolean isRoot();
+
+  String name();
+
+  Optional<Stream<Target>> outputStreamVariables(
+      OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler);
+
+  int parameterCount();
+
+  Imyhat parameterType(int index);
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CallableDefinitionRenderer.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CallableDefinitionRenderer.java
@@ -1,0 +1,19 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+
+public interface CallableDefinitionRenderer {
+
+  Type currentType();
+
+  void generateCall(GeneratorAdapter methodGen);
+
+  void generatePreamble(GeneratorAdapter methodGen);
+
+  String name();
+
+  Type parameter(int i);
+
+  int parameters();
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
@@ -111,7 +111,7 @@ public abstract class Compiler {
    * @param name the internal name of the class to generate; it will extend {@link ActionGenerator}
    * @param path the source file's path for debugging information
    * @param exportConsumer a callback to handle the exported functions from this program
-   * @param allowDuplicates
+   * @param allowDuplicates allow redefinition of known functions (useful during checking)
    * @return whether compilation was successful
    */
   public final boolean compile(
@@ -145,6 +145,7 @@ public abstract class Compiler {
                 this::getFunction,
                 this::getAction,
                 this::getRefiller,
+                this::getOliveDefinition,
                 this::errorHandler,
                 constants,
                 signatures,
@@ -203,7 +204,7 @@ public abstract class Compiler {
       servicesMethodGen.returnValue();
       servicesMethodGen.visitMaxs(0, 0);
       servicesMethodGen.visitEnd();
-      program.get().render(builder);
+      program.get().render(builder, this::getOliveDefinitionRenderer);
       builder.finish();
       if (exportConsumer != null) {
         program.get().processExports(exportConsumer);
@@ -265,6 +266,16 @@ public abstract class Compiler {
    * @return the format definition, or null if no format is available
    */
   protected abstract InputFormatDefinition getInputFormats(String name);
+
+  /**
+   * Get a Define olive by name.
+   *
+   * @param name the name of the olive
+   * @return the olive or null if no function is available
+   */
+  protected abstract CallableDefinition getOliveDefinition(String name);
+
+  protected abstract CallableDefinitionRenderer getOliveDefinitionRenderer(String name);
 
   /**
    * Get a refiller by name.

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExportConsumer.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExportConsumer.java
@@ -2,11 +2,19 @@ package ca.on.oicr.gsi.shesmu.compiler;
 
 import ca.on.oicr.gsi.shesmu.plugin.functions.FunctionParameter;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public interface ExportConsumer {
   void constant(String name, Imyhat type);
+
+  void definition(
+      String name,
+      String inputFormat,
+      boolean root,
+      List<Imyhat> parameters,
+      List<Target> outputVariables);
 
   void function(String name, Imyhat returnType, Supplier<Stream<FunctionParameter>> parameters);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LiveExportConsumer.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LiveExportConsumer.java
@@ -1,13 +1,55 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.plugin.functions.FunctionParameter;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.lang.invoke.MethodHandle;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public interface LiveExportConsumer {
+  final class DefineVariableExport {
+
+    private final Flavour flavour;
+    private final MethodHandle method;
+    private final String name;
+    private final Imyhat type;
+
+    public DefineVariableExport(String name, Flavour flavour, Imyhat type, MethodHandle method) {
+      this.flavour = flavour;
+      this.name = name;
+      this.type = type;
+      this.method = method;
+    }
+
+    public Flavour flavour() {
+      return flavour;
+    }
+
+    public MethodHandle method() {
+      return method;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public Imyhat type() {
+      return type;
+    }
+  }
+
   void constant(MethodHandle method, String name, Imyhat type);
+
+  void defineOlive(
+      MethodHandle method,
+      String name,
+      String inputFormatName,
+      boolean isRoot,
+      List<Imyhat> parameterTypes,
+      List<DefineVariableExport> variables,
+      List<DefineVariableExport> checks);
 
   void function(
       MethodHandle method,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveBuilder.java
@@ -104,17 +104,18 @@ public final class OliveBuilder extends BaseOliveBuilder {
       InputFormatDefinition initialFormat,
       int line,
       int column,
-      Stream<? extends Target> signableNames) {
+      Stream<SignableRenderer> signableNames) {
     super(owner, initialFormat);
     this.line = line;
     this.column = column;
     accessorType =
         Type.getObjectType(String.format("shesmu/dyn/Signer Accessor %d:%d", line, column));
     signerPrefix = String.format("Olive %d:%d ", line, column);
-    final List<Target> signables = signableNames.collect(Collectors.toList());
+    final List<SignableRenderer> signables = signableNames.collect(Collectors.toList());
     owner
         .signatureVariables()
-        .forEach(signer -> createSignature(signerPrefix, initialFormat, signables, signer));
+        .forEach(
+            signer -> createSignature(signerPrefix, initialFormat, signables.stream(), signer));
   }
 
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNode.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -475,7 +476,10 @@ public abstract class OliveClauseNode {
    * @param state the current variable state
    */
   public abstract ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler);
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler);
 
   public abstract int line();
 
@@ -488,7 +492,7 @@ public abstract class OliveClauseNode {
   public abstract void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions);
+      Function<String, CallableDefinitionRenderer> definitions);
 
   /**
    * Resolve all variable plugins in this clause

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseDump.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseDump.java
@@ -72,7 +72,10 @@ public abstract class OliveClauseNodeBaseDump extends OliveClauseNode implements
 
   @Override
   public final ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
     return state;
   }
 
@@ -85,7 +88,7 @@ public abstract class OliveClauseNodeBaseDump extends OliveClauseNode implements
   public final void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Predicate<String> shouldCapture = captureVariable();
     final Renderer renderer =
         oliveBuilder.peek(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseJoin.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -76,7 +77,9 @@ public abstract class OliveClauseNodeBaseJoin extends OliveClauseNode {
 
   @Override
   public final ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
+      ClauseStreamOrder state, Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
     return state == ClauseStreamOrder.PURE ? ClauseStreamOrder.TRANSFORMED : state;
   }
 
@@ -91,7 +94,7 @@ public abstract class OliveClauseNodeBaseJoin extends OliveClauseNode {
   public final void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     outerKey.collectFreeVariables(freeVariables, Flavour::needsCapture);
     innerKey.collectFreeVariables(freeVariables, Flavour::needsCapture);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
@@ -10,12 +10,12 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -134,8 +134,11 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
 
   @Override
   public final ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
-    if (state == ClauseStreamOrder.PURE) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
+    if (state == ClauseStreamOrder.PURE || state == ClauseStreamOrder.ALMOST_PURE) {
       discriminators.forEach(
           d -> d.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals));
       children.forEach(c -> c.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals));
@@ -154,7 +157,7 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
   public void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     children.forEach(group -> group.collectFreeVariables(freeVariables, Flavour::needsCapture));
     discriminators.forEach(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
@@ -144,8 +144,11 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
 
   @Override
   public final ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
-    if (state == ClauseStreamOrder.PURE) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
+    if (state == ClauseStreamOrder.PURE || state == ClauseStreamOrder.ALMOST_PURE) {
       discriminators.forEach(
           d -> d.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals));
       inputExpressions.forEach(
@@ -174,7 +177,7 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
   public void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     children.forEach(group -> group.collectFreeVariables(freeVariables, Flavour::needsCapture));
     discriminators.forEach(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
@@ -74,8 +74,11 @@ public class OliveClauseNodeLet extends OliveClauseNode {
 
   @Override
   public ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
-    if (state == ClauseStreamOrder.PURE) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
+    if (state == ClauseStreamOrder.PURE || state == ClauseStreamOrder.ALMOST_PURE) {
       for (LetArgumentNode a : arguments) {
         a.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals);
       }
@@ -93,7 +96,7 @@ public class OliveClauseNodeLet extends OliveClauseNode {
   public void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     arguments.forEach(
         argument -> argument.collectFreeVariables(freeVariables, Flavour::needsCapture));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.objectweb.asm.Type;
@@ -95,7 +96,10 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
 
   @Override
   public ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
     return state;
   }
 
@@ -137,7 +141,7 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
   public void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     labels.forEach(arg -> arg.collectFreeVariables(freeVariables, Flavour::needsCapture));
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
@@ -9,11 +9,11 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -82,8 +82,11 @@ public class OliveClauseNodePick extends OliveClauseNode {
 
   @Override
   public ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
-    if (state == ClauseStreamOrder.PURE) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
+    if (state == ClauseStreamOrder.PURE || state == ClauseStreamOrder.ALMOST_PURE) {
       discriminatorVariables
           .stream()
           .filter(v -> v.flavour() == Flavour.STREAM_SIGNABLE)
@@ -103,7 +106,7 @@ public class OliveClauseNodePick extends OliveClauseNode {
   public void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     extractor.collectFreeVariables(freeVariables, Flavour::needsCapture);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
@@ -11,10 +11,10 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
@@ -73,8 +73,11 @@ public class OliveClauseNodeReject extends OliveClauseNode {
 
   @Override
   public ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
-    if (state == ClauseStreamOrder.PURE) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
+    if (state == ClauseStreamOrder.PURE || state == ClauseStreamOrder.ALMOST_PURE) {
       expression.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals);
     }
     return state;
@@ -89,7 +92,7 @@ public class OliveClauseNodeReject extends OliveClauseNode {
   public void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     expression.collectFreeVariables(freeVariables, Flavour::needsCapture);
     handlers.forEach(handler -> handler.collectFreeVariables(freeVariables));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
@@ -12,6 +12,7 @@ import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.objectweb.asm.Label;
@@ -97,8 +98,11 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
 
   @Override
   public ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
-    if (state == ClauseStreamOrder.PURE) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
+    if (state == ClauseStreamOrder.PURE || state == ClauseStreamOrder.ALMOST_PURE) {
       expression.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals);
       copySignatures = true;
     }
@@ -116,7 +120,7 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
   public void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     expression.collectFreeVariables(freeVariables, Flavour::needsCapture);
     handlers.forEach(handler -> handler.collectFreeVariables(freeVariables));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
@@ -8,10 +8,10 @@ import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class OliveClauseNodeWhere extends OliveClauseNode {
@@ -62,8 +62,11 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
 
   @Override
   public ClauseStreamOrder ensureRoot(
-      ClauseStreamOrder state, Set<String> signableNames, Consumer<String> errorHandler) {
-    if (state == ClauseStreamOrder.PURE) {
+      ClauseStreamOrder state,
+      Set<String> signableNames,
+      Consumer<SignableVariableCheck> addSignableCheck,
+      Consumer<String> errorHandler) {
+    if (state == ClauseStreamOrder.PURE || state == ClauseStreamOrder.ALMOST_PURE) {
       expression.collectFreeVariables(signableNames, Flavour.STREAM_SIGNABLE::equals);
     }
     return state;
@@ -78,7 +81,7 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
   public void render(
       RootBuilder builder,
       BaseOliveBuilder oliveBuilder,
-      Map<String, OliveDefineBuilder> definitions) {
+      Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> freeVariables = new HashSet<>();
     expression.collectFreeVariables(freeVariables, Flavour::needsCapture);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveCompilerServices.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveCompilerServices.java
@@ -14,7 +14,7 @@ public interface OliveCompilerServices extends ExpressionCompilerServices, Const
 
   InputFormatDefinition inputFormat(String format);
 
-  OliveNodeDefinition olive(String name);
+  CallableDefinition olive(String name);
 
   RefillerDefinition refiller(String name);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveDefineBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveDefineBuilder.java
@@ -1,8 +1,12 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
+
 import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.InputVariable;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -12,10 +16,16 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
 /** Creates bytecode for a “Define”-style olive to be used in call clauses */
-public final class OliveDefineBuilder extends BaseOliveBuilder {
+public final class OliveDefineBuilder extends BaseOliveBuilder
+    implements CallableDefinitionRenderer {
 
   public static final LoadableValue SIGNER_ACCESSOR_LOADABLE_VALUE =
       new LoadableValue() {
+        @Override
+        public void accept(Renderer renderer) {
+          renderer.methodGen().loadArg(5);
+        }
+
         @Override
         public String name() {
           return SIGNER_ACCESSOR_NAME;
@@ -25,19 +35,16 @@ public final class OliveDefineBuilder extends BaseOliveBuilder {
         public Type type() {
           return A_SIGNATURE_ACCESSOR_TYPE;
         }
-
-        @Override
-        public void accept(Renderer renderer) {
-          renderer.methodGen().loadArg(5);
-        }
       };
   private final Method method;
+  private final String name;
   private final List<LoadableValue> parameters;
 
   private final String signerPrefix;
 
   public OliveDefineBuilder(RootBuilder owner, String name, Stream<? extends Target> parameters) {
     super(owner, owner.inputFormatDefinition());
+    this.name = name;
     this.parameters =
         parameters
             .map(Pair.number(6))
@@ -58,20 +65,11 @@ public final class OliveDefineBuilder extends BaseOliveBuilder {
                     this.parameters.stream().map(LoadableValue::type))
                 .toArray(Type[]::new));
     signerPrefix = String.format("Define %s ", name);
-    owner
-        .signatureVariables()
-        .forEach(
-            signer -> {
-              owner
-                  .classVisitor
-                  .visitField(
-                      Opcodes.ACC_PRIVATE,
-                      signerPrefix + signer.name(),
-                      signer.storageType().getDescriptor(),
-                      null,
-                      null)
-                  .visitEnd();
-            });
+  }
+
+  @Override
+  public Type currentType() {
+    return super.currentType();
   }
 
   @Override
@@ -85,18 +83,62 @@ public final class OliveDefineBuilder extends BaseOliveBuilder {
             .methodGen()
             .invokeInterface(
                 A_SIGNATURE_ACCESSOR_TYPE, METHOD_SIGNATURE_ACCESSOR__DYNAMIC_SIGNATURE);
-        renderer.methodGen().unbox(signer.type().apply(TypeUtils.TO_ASM));
+        renderer.methodGen().unbox(signer.type().apply(TO_ASM));
         break;
       case STATIC:
         renderer
             .methodGen()
             .invokeInterface(
                 A_SIGNATURE_ACCESSOR_TYPE, METHOD_SIGNATURE_ACCESSOR__STATIC_SIGNATURE);
-        renderer.methodGen().unbox(signer.type().apply(TypeUtils.TO_ASM));
+        renderer.methodGen().unbox(signer.type().apply(TO_ASM));
         break;
       default:
         throw new UnsupportedOperationException();
     }
+  }
+
+  public void export(Stream<? extends Target> variables, Set<String> signedVariables) {
+    // If we are exporting this, we need to generate getters for each variable since we may be
+    // dealing with a slightly transformed stream and the consumer of this isn't going to have
+    // access to that type information
+    variables.forEach(
+        variable -> {
+          final GeneratorAdapter getter =
+              new GeneratorAdapter(
+                  Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                  new Method(
+                      method.getName() + " " + variable.name(),
+                      Type.getMethodDescriptor(variable.type().apply(TO_ASM), A_OBJECT_TYPE)),
+                  null,
+                  null,
+                  owner.classVisitor);
+          getter.visitCode();
+          getter.loadArg(0);
+          getter.checkCast(currentType());
+          if (variable instanceof InputVariable) {
+            ((InputVariable) variable).extract(getter);
+          } else {
+            getter.invokeVirtual(
+                currentType(),
+                new Method(
+                    variable.name(), variable.type().apply(TypeUtils.TO_ASM), new Type[] {}));
+          }
+          getter.returnValue();
+          getter.endMethod();
+          final GeneratorAdapter signerCheck =
+              new GeneratorAdapter(
+                  Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                  new Method(
+                      String.format("%s %s Signer Check", method.getName(), variable.name()),
+                      Type.getMethodDescriptor(Type.BOOLEAN_TYPE)),
+                  null,
+                  null,
+                  owner.classVisitor);
+          signerCheck.visitCode();
+          signerCheck.push(signedVariables.contains(variable.name()));
+          signerCheck.returnValue();
+          signerCheck.endMethod();
+        });
   }
 
   /**
@@ -108,7 +150,7 @@ public final class OliveDefineBuilder extends BaseOliveBuilder {
     final Renderer renderer =
         new RendererNoStream(
             owner,
-            new GeneratorAdapter(Opcodes.ACC_PRIVATE, method, null, null, owner.classVisitor),
+            new GeneratorAdapter(Opcodes.ACC_PUBLIC, method, null, null, owner.classVisitor),
             Stream.concat(parameters.stream(), Stream.of(SIGNER_ACCESSOR_LOADABLE_VALUE)),
             this::emitSigner);
     renderer.methodGen().visitCode();
@@ -117,6 +159,18 @@ public final class OliveDefineBuilder extends BaseOliveBuilder {
     renderer.methodGen().returnValue();
     renderer.methodGen().visitMaxs(0, 0);
     renderer.methodGen().visitEnd();
+  }
+
+  /** The method definition for this matcher */
+  @Override
+  public void generateCall(GeneratorAdapter methodGen) {
+    methodGen.invokeVirtual(owner.selfType(), method);
+  }
+
+  @Override
+  public void generatePreamble(GeneratorAdapter methodGen) {
+    methodGen.loadThis();
+    methodGen.swap();
   }
 
   @Override
@@ -154,17 +208,19 @@ public final class OliveDefineBuilder extends BaseOliveBuilder {
         .flatMap(Function.identity());
   }
 
-  /** The method definition for this matcher */
-  public Method method() {
-    return method;
+  @Override
+  public String name() {
+    return name;
   }
 
   /** The type of a bound parameter */
-  public Type parameterType(int i) {
+  @Override
+  public Type parameter(int i) {
     return parameters.get(i).type();
   }
 
   /** The number of bound parameters */
+  @Override
   public int parameters() {
     return parameters.size();
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -100,7 +100,7 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
   }
 
   @Override
-  public void build(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void build(RootBuilder builder, Map<String, CallableDefinitionRenderer> definitions) {
     // Do nothing.
   }
 
@@ -119,7 +119,7 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
 
   @Override
   public boolean collectDefinitions(
-      Map<String, OliveNodeDefinition> definedOlives,
+      Map<String, CallableDefinition> definedOlives,
       Map<String, Target> definedConstants,
       Consumer<String> errorHandler) {
     return true;
@@ -226,13 +226,15 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
   }
 
   @Override
-  public void render(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void render(
+      RootBuilder builder, Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> captures = new HashSet<>();
     ttl.collectFreeVariables(captures, Flavour::needsCapture);
     labels.forEach(label -> label.collectFreeVariables(captures, Flavour::needsCapture));
     annotations.forEach(
         annotation -> annotation.collectFreeVariables(captures, Flavour::needsCapture));
-    final OliveBuilder oliveBuilder = builder.buildRunOlive(line, column, signableNames);
+    final OliveBuilder oliveBuilder =
+        builder.buildRunOlive(line, column, signableNames, signableVariableChecks);
     clauses().forEach(clause -> clause.render(builder, oliveBuilder, definitions));
     oliveBuilder.line(line);
     final Renderer action =

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeConstant.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeConstant.java
@@ -31,7 +31,7 @@ public final class OliveNodeConstant extends OliveNode implements Target {
   }
 
   @Override
-  public void build(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void build(RootBuilder builder, Map<String, CallableDefinitionRenderer> definitions) {
     builder.defineConstant(
         name,
         body.type().apply(TypeUtils.TO_ASM),
@@ -56,7 +56,7 @@ public final class OliveNodeConstant extends OliveNode implements Target {
 
   @Override
   public boolean collectDefinitions(
-      Map<String, OliveNodeDefinition> definedOlives,
+      Map<String, CallableDefinition> definedOlives,
       Map<String, Target> definedConstants,
       Consumer<String> errorHandler) {
     if (definedConstants.containsKey(name)) {
@@ -109,7 +109,8 @@ public final class OliveNodeConstant extends OliveNode implements Target {
   }
 
   @Override
-  public void render(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void render(
+      RootBuilder builder, Function<String, CallableDefinitionRenderer> definitions) {
     // Nothing to do.
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeFunction.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeFunction.java
@@ -53,7 +53,7 @@ public class OliveNodeFunction extends OliveNode implements FunctionDefinition {
   }
 
   @Override
-  public void build(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void build(RootBuilder builder, Map<String, CallableDefinitionRenderer> definitions) {
     ownerType = builder.selfType();
     method =
         new Method(
@@ -80,7 +80,7 @@ public class OliveNodeFunction extends OliveNode implements FunctionDefinition {
 
   @Override
   public boolean collectDefinitions(
-      Map<String, OliveNodeDefinition> definedOlives,
+      Map<String, CallableDefinition> definedOlives,
       Map<String, Target> definedConstants,
       Consumer<String> errorHandler) {
     return true;
@@ -143,7 +143,8 @@ public class OliveNodeFunction extends OliveNode implements FunctionDefinition {
   }
 
   @Override
-  public void render(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void render(
+      RootBuilder builder, Function<String, CallableDefinitionRenderer> definitions) {
     final GeneratorAdapter methodGen =
         new GeneratorAdapter(Opcodes.ACC_PUBLIC, method, null, null, builder.classVisitor);
     methodGen.visitCode();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRefill.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRefill.java
@@ -92,7 +92,7 @@ public final class OliveNodeRefill extends OliveNodeWithClauses {
   }
 
   @Override
-  public void build(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void build(RootBuilder builder, Map<String, CallableDefinitionRenderer> definitions) {
     // Do nothing.
   }
 
@@ -109,7 +109,7 @@ public final class OliveNodeRefill extends OliveNodeWithClauses {
 
   @Override
   public boolean collectDefinitions(
-      Map<String, OliveNodeDefinition> definedOlives,
+      Map<String, CallableDefinition> definedOlives,
       Map<String, Target> definedConstants,
       Consumer<String> errorHandler) {
     return true;
@@ -158,8 +158,10 @@ public final class OliveNodeRefill extends OliveNodeWithClauses {
   }
 
   @Override
-  public void render(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
-    final OliveBuilder oliveBuilder = builder.buildRunOlive(line, column, signableNames);
+  public void render(
+      RootBuilder builder, Function<String, CallableDefinitionRenderer> definitions) {
+    final OliveBuilder oliveBuilder =
+        builder.buildRunOlive(line, column, signableNames, signableVariableChecks);
     clauses().forEach(clause -> clause.render(builder, oliveBuilder, definitions));
     oliveBuilder.line(line);
     oliveBuilder.finish(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
@@ -57,7 +57,7 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
   }
 
   @Override
-  public void build(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void build(RootBuilder builder, Map<String, CallableDefinitionRenderer> definitions) {
     // Do nothing.
   }
 
@@ -74,7 +74,7 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
 
   @Override
   public boolean collectDefinitions(
-      Map<String, OliveNodeDefinition> definedOlives,
+      Map<String, CallableDefinition> definedOlives,
       Map<String, Target> definedConstants,
       Consumer<String> errorHandler) {
     return true;
@@ -119,11 +119,13 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
   private static final Type A_STRING_TYPE = Type.getType(String.class);
 
   @Override
-  public void render(RootBuilder builder, Map<String, OliveDefineBuilder> definitions) {
+  public void render(
+      RootBuilder builder, Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> captures = new HashSet<>();
     arguments.forEach(arg -> arg.collectFreeVariables(captures, Flavour::needsCapture));
     variableTags.forEach(arg -> arg.collectFreeVariables(captures, Flavour::needsCapture));
-    final OliveBuilder oliveBuilder = builder.buildRunOlive(line, column, signableNames);
+    final OliveBuilder oliveBuilder =
+        builder.buildRunOlive(line, column, signableNames, signableVariableChecks);
     clauses().forEach(clause -> clause.render(builder, oliveBuilder, definitions));
     oliveBuilder.line(line);
     final Renderer action =

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PragmaNodeInputGuard.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PragmaNodeInputGuard.java
@@ -115,10 +115,11 @@ public class PragmaNodeInputGuard extends PragmaNode {
             LambdaBuilder.biconsumer(newType, A_OBJECT_TYPE),
             capturedVariables);
 
-    final List<Target> signables =
+    final List<SignableRenderer> signables =
         inputFormatDefinition
             .baseStreamVariables()
             .filter(t -> t.flavour() == Flavour.STREAM_SIGNABLE && signableNames.contains(t.name()))
+            .map(SignableRenderer::always)
             .collect(Collectors.toList());
     final String prefix = String.format("Guard %d:%d ", line, column);
     root.signatureVariables()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SignableRenderer.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SignableRenderer.java
@@ -1,0 +1,47 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.commons.GeneratorAdapter;
+
+public abstract class SignableRenderer {
+
+  protected final Target target;
+
+  private SignableRenderer(Target target) {
+    this.target = target;
+  }
+
+  public static SignableRenderer always(Target target) {
+    return new SignableRenderer(target) {
+      @Override
+      public void render(
+          GeneratorAdapter methodGen, BiConsumer<GeneratorAdapter, Target> callback) {
+        callback.accept(methodGen, target);
+      }
+    };
+  }
+
+  public static SignableRenderer conditional(Target target, List<SignableVariableCheck> checks) {
+    return new SignableRenderer(target) {
+      @Override
+      public void render(
+          GeneratorAdapter methodGen, BiConsumer<GeneratorAdapter, Target> callback) {
+        final Label end = methodGen.newLabel();
+        final Label present = methodGen.newLabel();
+        for (final SignableVariableCheck check : checks) {
+          check.render(methodGen);
+          methodGen.ifZCmp(GeneratorAdapter.NE, present);
+        }
+        methodGen.goTo(end);
+        methodGen.mark(present);
+        callback.accept(methodGen, target);
+        methodGen.mark(end);
+      }
+    };
+  }
+
+  public abstract void render(
+      GeneratorAdapter methodGen, BiConsumer<GeneratorAdapter, Target> callback);
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SignableVariableCheck.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SignableVariableCheck.java
@@ -1,0 +1,10 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import org.objectweb.asm.commons.GeneratorAdapter;
+
+public interface SignableVariableCheck {
+
+  String name();
+
+  void render(GeneratorAdapter methodGen);
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/DefinitionRepository.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/DefinitionRepository.java
@@ -1,5 +1,7 @@
 package ca.on.oicr.gsi.shesmu.compiler.definitions;
 
+import ca.on.oicr.gsi.shesmu.compiler.CallableDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.CallableDefinitionRenderer;
 import ca.on.oicr.gsi.shesmu.compiler.RefillerDefinition;
 import ca.on.oicr.gsi.shesmu.util.LoadedConfiguration;
 import ca.on.oicr.gsi.status.ConfigurationSection;
@@ -8,6 +10,7 @@ import java.util.stream.Stream;
 
 /** A service class that can provide external constants that should be visible to Shesmu programs */
 public interface DefinitionRepository extends LoadedConfiguration {
+  interface CallableOliveDefinition extends CallableDefinition, CallableDefinitionRenderer {}
 
   static DefinitionRepository concat(DefinitionRepository... definitionRepositories) {
     return new DefinitionRepository() {
@@ -20,6 +23,11 @@ public interface DefinitionRepository extends LoadedConfiguration {
       @Override
       public Stream<ConstantDefinition> constants() {
         return Stream.of(definitionRepositories).flatMap(DefinitionRepository::constants);
+      }
+
+      @Override
+      public Stream<CallableOliveDefinition> oliveDefinitions() {
+        return Stream.of(definitionRepositories).flatMap(DefinitionRepository::oliveDefinitions);
       }
 
       @Override
@@ -62,6 +70,9 @@ public interface DefinitionRepository extends LoadedConfiguration {
 
   /** Provide all constants know by this service */
   Stream<ConstantDefinition> constants();
+
+  /** Provide all olive definitions */
+  Stream<CallableOliveDefinition> oliveDefinitions();
 
   Stream<RefillerDefinition> refillers();
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureDefinition.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.compiler.definitions;
 
+import ca.on.oicr.gsi.shesmu.compiler.SignableRenderer;
 import ca.on.oicr.gsi.shesmu.compiler.Target;
 import ca.on.oicr.gsi.shesmu.compiler.TypeUtils;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
@@ -22,7 +23,8 @@ public abstract class SignatureDefinition implements Target {
     }
 
     @Override
-    public void build(GeneratorAdapter method, Type streamType, Stream<Target> variables) {
+    public void build(
+        GeneratorAdapter method, Type streamType, Stream<SignableRenderer> variables) {
       original.build(method, streamType, variables);
     }
 
@@ -66,7 +68,8 @@ public abstract class SignatureDefinition implements Target {
    * @param streamType the type of the input data
    * @param variables the input variables to capture
    */
-  public abstract void build(GeneratorAdapter method, Type streamType, Stream<Target> variables);
+  public abstract void build(
+      GeneratorAdapter method, Type streamType, Stream<SignableRenderer> variables);
 
   public abstract Path filename();
 
@@ -87,6 +90,10 @@ public abstract class SignatureDefinition implements Target {
 
   public final SignatureStorage storage() {
     return storage;
+  }
+
+  public Class<?> storageClass() {
+    return storage.holderClass(type.javaType());
   }
 
   public final Type storageType() {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureStorage.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureStorage.java
@@ -9,14 +9,26 @@ public enum SignatureStorage {
     public Type holderType(Type type) {
       return type;
     }
+
+    @Override
+    public Class<?> holderClass(Class<?> clazz) {
+      return clazz;
+    }
   },
   DYNAMIC {
     @Override
     public Type holderType(Type type) {
       return A_FUNCTION_TYPE;
     }
+
+    @Override
+    public Class<?> holderClass(Class<?> clazz) {
+      return Function.class;
+    }
   };
   private static final Type A_FUNCTION_TYPE = Type.getType(Function.class);
+
+  public abstract Class<?> holderClass(Class<?> clazz);
 
   public abstract Type holderType(Type type);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureVariableForStaticSigner.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureVariableForStaticSigner.java
@@ -1,7 +1,7 @@
 package ca.on.oicr.gsi.shesmu.compiler.definitions;
 
 import ca.on.oicr.gsi.shesmu.compiler.Renderer;
-import ca.on.oicr.gsi.shesmu.compiler.Target;
+import ca.on.oicr.gsi.shesmu.compiler.SignableRenderer;
 import ca.on.oicr.gsi.shesmu.compiler.TypeUtils;
 import ca.on.oicr.gsi.shesmu.plugin.signature.StaticSigner;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
@@ -28,15 +28,19 @@ public abstract class SignatureVariableForStaticSigner extends SignatureDefiniti
   }
 
   @Override
-  public final void build(GeneratorAdapter method, Type initialType, Stream<Target> variables) {
+  public final void build(
+      GeneratorAdapter method, Type initialType, Stream<SignableRenderer> variables) {
     newInstance(method);
     variables.forEach(
-        target -> {
-          method.dup();
-          method.push(target.name());
-          Renderer.loadImyhatInMethod(method, target.type().descriptor());
-          method.invokeInterface(A_SIGNER_TYPE, METHOD_STATIC_SIGNER__ADD_VARIABLE);
-        });
+        signableRenderer ->
+            signableRenderer.render(
+                method,
+                (m, target) -> {
+                  m.dup();
+                  m.push(target.name());
+                  Renderer.loadImyhatInMethod(method, target.type().descriptor());
+                  m.invokeInterface(A_SIGNER_TYPE, METHOD_STATIC_SIGNER__ADD_VARIABLE);
+                }));
     method.invokeInterface(A_SIGNER_TYPE, METHOD_STATIC_SIGNER__FINISH);
     method.unbox(type().apply(TypeUtils.TO_ASM));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
@@ -678,6 +678,11 @@ public final class StandardDefinitions implements DefinitionRepository {
   }
 
   @Override
+  public Stream<CallableOliveDefinition> oliveDefinitions() {
+    return Stream.empty();
+  }
+
+  @Override
   public Stream<FunctionDefinition> functions() {
     return Stream.of(FUNCTIONS);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignatureCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignatureCount.java
@@ -1,6 +1,6 @@
 package ca.on.oicr.gsi.shesmu.core.signers;
 
-import ca.on.oicr.gsi.shesmu.compiler.Target;
+import ca.on.oicr.gsi.shesmu.compiler.SignableRenderer;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureStorage;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
@@ -20,8 +20,22 @@ public final class SignatureCount extends SignatureDefinition {
   }
 
   @Override
-  public void build(GeneratorAdapter method, Type initialType, Stream<Target> variables) {
-    method.push(variables.count());
+  public void build(GeneratorAdapter method, Type initialType, Stream<SignableRenderer> variables) {
+    final int count = method.newLocal(Type.INT_TYPE);
+    method.push(0);
+    method.storeLocal(count);
+    variables.forEach(
+        signableRenderer ->
+            signableRenderer.render(
+                method,
+                (m, t) -> {
+                  m.loadLocal(count);
+                  m.push(1);
+                  m.math(GeneratorAdapter.ADD, Type.INT_TYPE);
+                  m.storeLocal(count);
+                }));
+    method.loadLocal(count);
+    method.cast(Type.INT_TYPE, Type.LONG_TYPE);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignatureNames.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/signers/SignatureNames.java
@@ -1,6 +1,6 @@
 package ca.on.oicr.gsi.shesmu.core.signers;
 
-import ca.on.oicr.gsi.shesmu.compiler.Target;
+import ca.on.oicr.gsi.shesmu.compiler.SignableRenderer;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureStorage;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
@@ -28,18 +28,21 @@ public final class SignatureNames extends SignatureDefinition {
   }
 
   @Override
-  public void build(GeneratorAdapter method, Type initialType, Stream<Target> variables) {
+  public void build(GeneratorAdapter method, Type initialType, Stream<SignableRenderer> variables) {
     method.newInstance(A_TREE_SET_TYPE);
     method.dup();
     method.invokeConstructor(A_TREE_SET_TYPE, CTOR_DEFAULT);
 
     variables.forEach(
-        target -> {
-          method.dup();
-          method.push(target.name());
-          method.invokeVirtual(A_TREE_SET_TYPE, METHOD_TREE_SET__ADD);
-          method.pop();
-        });
+        signableRenderer ->
+            signableRenderer.render(
+                method,
+                (m, target) -> {
+                  m.dup();
+                  m.push(target.name());
+                  m.invokeVirtual(A_TREE_SET_TYPE, METHOD_TREE_SET__ADD);
+                  m.pop();
+                }));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
@@ -1792,6 +1792,11 @@ public final class PluginManager
     return formatTypes.stream().flatMap(FormatTypeWrapper::constants);
   }
 
+  @Override
+  public Stream<CallableOliveDefinition> oliveDefinitions() {
+    return Stream.empty();
+  }
+
   public long count() {
     return (long) formatTypes.size();
   }

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/CompilerTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/CompilerTest.java
@@ -1,6 +1,8 @@
 package ca.on.oicr.gsi.shesmu;
 
 import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.compiler.CallableDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.CallableDefinitionRenderer;
 import ca.on.oicr.gsi.shesmu.compiler.Compiler;
 import ca.on.oicr.gsi.shesmu.compiler.RefillerDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.Renderer;
@@ -93,6 +95,16 @@ public class CompilerTest {
     @Override
     protected InputFormatDefinition getInputFormats(String name) {
       return RunTest.INPUT_FORMATS.get(name);
+    }
+
+    @Override
+    protected CallableDefinition getOliveDefinition(String name) {
+      return null;
+    }
+
+    @Override
+    protected CallableDefinitionRenderer getOliveDefinitionRenderer(String name) {
+      return null;
     }
 
     @Override

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
@@ -410,6 +410,11 @@ public class RunTest {
                     }
 
                     @Override
+                    public Stream<CallableOliveDefinition> oliveDefinitions() {
+                      return Stream.empty();
+                    }
+
+                    @Override
                     public Stream<FunctionDefinition> functions() {
                       return Stream.of(INT2STR, INT2DATE);
                     }
@@ -497,6 +502,18 @@ public class RunTest {
                   new LiveExportConsumer() {
                     @Override
                     public void constant(MethodHandle method, String name, Imyhat type) {
+                      // Do nothing
+                    }
+
+                    @Override
+                    public void defineOlive(
+                        MethodHandle method,
+                        String name,
+                        String inputFormatName,
+                        boolean isRoot,
+                        List<Imyhat> parameterTypes,
+                        List<DefineVariableExport> variables,
+                        List<DefineVariableExport> checks) {
                       // Do nothing
                     }
 

--- a/shesmu-server/src/test/resources/run/define-complex.shesmu
+++ b/shesmu-server/src/test/resources/run/define-complex.shesmu
@@ -1,7 +1,10 @@
 Version 1;
 Input test;
 
-Define foo({string, integer} s, [string] projects)
+# We export this, but the unit testing framework doesn't have a way to consume
+# it; however, it does exercise all the bytecode generation pathways involved
+# in exporting.
+Export Define foo({string, integer} s, [string] projects)
  Where project In projects || project == s[0];
 
 Olive


### PR DESCRIPTION
This allows exporting `Define` olives such that they might be consumed by other
script. Doing this requires a very messy understanding of two data formats
being the same, so it generates 3 outputs for each olive defined:

- a single function to actually call the olive on a stream
- a function for each variable in the output stream to access the data since
  the caller will not have direct access to the methods that generate the
  output
- a function for every variable in the input data format to decide if it should
  be part of a signature or not

Typically, Shesmu has considered the stream to be in one of two states: pure
(_i.e._, the input data format) or transformed (_e.g._, the output of
grouping). This change introduces a new distinction: almost pure. An almost
pure stream is one that resembles the original data format but may have
additional fields added by `Flatten` or `Require`. This means that for the
purposes of generating signatures, the downstream operations should consider it
pure, but the actual objects output are _not_ the same as the input format.