### PR TITLE
Export search options

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -32,6 +32,8 @@ import {
   checkRandomSequence,
   makeUrl,
   butter,
+  tableFromRows,
+  tableRow,
 } from "./html.js";
 import {
   StatefulModel,
@@ -371,29 +373,37 @@ export function actionDisplay(
                     "🡇 Export Command",
                     "Generate a command line to perform a command command.",
                     () =>
-                      dialog((close) =>
-                        response.bulkCommands.map(({ buttonText, command }) => [
-                          buttonText,
-                          button(
-                            "cUrl",
-                            `Copy a cURL command to invoke the ${command} command on the actions selected.`,
-                            () =>
-                              copyCUrlCommand("command", {
-                                command: command,
-                                filters: filters,
-                              })
-                          ),
-                          button(
-                            "Wget",
-                            `Copy a Wget command to invoke the ${command} command on the actions selected.`,
-                            () =>
-                              copyWgetCommand("command", {
-                                command: command,
-                                filters: filters,
-                              })
-                          ),
-                          br(),
-                        ])
+                      dialog((_close) =>
+                        tableFromRows(
+                          response.bulkCommands.map(({ buttonText, command }) =>
+                            tableRow(
+                              null,
+                              { contents: buttonText },
+                              {
+                                contents: button(
+                                  "cUrl",
+                                  `Copy a cURL command to invoke the ${command} command on the actions selected.`,
+                                  () =>
+                                    copyCUrlCommand("command", {
+                                      command: command,
+                                      filters: filters,
+                                    })
+                                ),
+                              },
+                              {
+                                contents: button(
+                                  "Wget",
+                                  `Copy a Wget command to invoke the ${command} command on the actions selected.`,
+                                  () =>
+                                    copyWgetCommand("command", {
+                                      command: command,
+                                      filters: filters,
+                                    })
+                                ),
+                              }
+                            )
+                          )
+                        )
                       )
                   )
                 : blank(),

--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -611,7 +611,8 @@ export function initialiseActionDash(
   );
   const { ui: statsUi, model: statsModel } = actionStats(
     (...limits) => addPropertySearch(...limits),
-    (typeName, start, end) => addRangeSearch(typeName, start, end)
+    (typeName, start, end) => addRangeSearch(typeName, start, end),
+    standardExports.concat(exportSearches)
   );
   const { ui: saveUi, model: saveModel } = singleState(
     (input: ActionFilter[]) =>

--- a/shesmu-server-ui/src/help.ts
+++ b/shesmu-server-ui/src/help.ts
@@ -220,9 +220,15 @@ function helpButton(
       hasNew ? "New tips are available!" : "Previous tips and advice.",
       (e) => {
         e.stopPropagation();
-        popup.style.left = `${e.pageX}px`;
-        popup.style.top = `${e.pageY}px`;
         document.body.appendChild(popupContainer);
+        popup.style.left = `${Math.min(
+          e.pageX,
+          document.body.clientWidth - popup.scrollWidth
+        )}px`;
+        popup.style.top = `${Math.min(
+          e.pageY,
+          document.body.clientHeight - popup.clientHeight
+        )}px`;
       }
     );
   });

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -1320,8 +1320,6 @@ export function popup(
     modal.className = "menucapture";
     document.body.appendChild(modal);
     const menu = document.createElement("div");
-    menu.style.left = `${e.pageX}px`;
-    menu.style.top = `${e.pageY}px`;
     for (const { label, action } of items) {
       const item = document.createElement("div");
       item.innerText = label;
@@ -1334,6 +1332,14 @@ export function popup(
       menu.appendChild(item);
     }
     modal.appendChild(menu);
+    menu.style.left = `${Math.min(
+      e.pageX,
+      document.body.clientWidth - menu.scrollWidth
+    )}px`;
+    menu.style.top = `${Math.min(
+      e.pageY,
+      document.body.clientHeight - menu.clientHeight
+    )}px`;
     modal.addEventListener("click", () => document.body.removeChild(modal));
   };
 }

--- a/shesmu-server-ui/src/olive.ts
+++ b/shesmu-server-ui/src/olive.ts
@@ -54,7 +54,11 @@ import {
   AlertFilter,
   loadFilterRegex,
 } from "./alert.js";
-import { actionDisplay, ExportSearchCommand } from "./action.js";
+import {
+  actionDisplay,
+  ExportSearchCommand,
+  standardExports,
+} from "./action.js";
 import { actionStats } from "./stats.js";
 import { helpArea } from "./help.js";
 
@@ -285,7 +289,8 @@ export function initialiseOliveDash(
   );
   const { ui: statsUi, model: statsModel } = actionStats(
     (...limits) => search.addPropertySearch(...limits),
-    (typeName, start, end) => search.addRangeSearch(typeName, start, end)
+    (typeName, start, end) => search.addRangeSearch(typeName, start, end),
+    standardExports.concat(exportSearches)
   );
   const { actions, bulkCommands, model: actionsModel } = actionDisplay(
     exportSearches

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -758,6 +758,9 @@ a.button.danger:visited {
   background: var(--widget-negative);
   border: 1px solid var(--widget-text);
   border-radius: 0.1em;
+  max-height: 90vh;
+  max-width: 90vw;
+  overflow: auto;
 }
 .menucapture > div > div {
   color: var(--widget-text);


### PR DESCRIPTION
- Prevent popup menus from appearing off screen  
  This stops popup menus and help tips from appearing off the edge of the user's screen and makes them scrollable if too large (probably more relevant for help than menus).
- Allow drill down on stats to export filter
  This was a feature request by Mike. It allows using a selection from a stats table or cross tab as the source for a new export. This is particularly helpful when pipeline lead wants to create a ticket for a problem area while excluding the base filter.
- Organise bulk command exports into a table
  It is really ugly since the rows are of different lengths


The export filter was a feature requested by Mike a long while back.