### PR TITLE
Fix UI bugs on _Actions_ dashboard

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+Changes:
+  * Fix problem in _Actions_ dashboard causing 400s using server searches
+
 # [1.0.3] - 2020-07-15T21:19+00:00
 
 Changes:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 Changes:
   * Fix problem in _Actions_ dashboard causing 400s using server searches
+  * Fix bug causing saved search to default to _All Actions_ on _Actions_ dashboard
 
 # [1.0.3] - 2020-07-15T21:19+00:00
 

--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -671,7 +671,6 @@ export function initialiseActionDash(
     sources,
     tags
   );
-  const currentName = savedSynchonizer.get();
   const {
     model: deleteModel,
     ui: deleteUi,
@@ -688,12 +687,7 @@ export function initialiseActionDash(
     (saved: Iterable<SearchDefinition>): UIElement =>
       dropdown(
         ([name, _filters]: SearchDefinition) => name,
-        currentName == "All Actions"
-          ? (["All Actions", []] as SearchDefinition)
-          : [
-              currentName,
-              serverSearches[currentName] || [localSearches.get(currentName)!],
-            ],
+        ([name, _filters]) => name == savedSynchonizer.get(),
         combineModels(
           deleteModel,
           mapModel(model, ([_name, filters]) => filters)

--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -115,7 +115,7 @@ type SearchDefinition = [string, ActionFilter[]];
 /**
  * The format of searches provided by the server
  */
-type ServerSearches = { [name: string]: ActionFilter };
+type ServerSearches = { [name: string]: ActionFilter[] };
 /**
  * The status of an action
  */
@@ -581,7 +581,7 @@ function collectSearches(
   return [["All Actions", []] as SearchDefinition].concat(
     [
       ...Object.entries(serverSearches).map(
-        ([name, filter]) => [name, [filter]] as SearchDefinition
+        ([name, filter]) => [name, filter] as SearchDefinition
       ),
       ...saved,
     ].sort((a, b) => a[0].localeCompare(b[0]))
@@ -692,10 +692,7 @@ export function initialiseActionDash(
           ? (["All Actions", []] as SearchDefinition)
           : [
               currentName,
-              [
-                (serverSearches[currentName] ||
-                  localSearches.get(currentName))!,
-              ],
+              serverSearches[currentName] || [localSearches.get(currentName)!],
             ],
         combineModels(
           deleteModel,

--- a/shesmu-server-ui/src/actionfilters.ts
+++ b/shesmu-server-ui/src/actionfilters.ts
@@ -737,7 +737,7 @@ function editTimeHorizon(
       offset.ui,
       dropdown(
         ([, n]) => n,
-        units.get(),
+        (unit) => unit == units.get(),
         units,
         null,
         [1, "milliseconds"],

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -493,7 +493,7 @@ export function dateEditor(
   const monthModel = temporaryState(initialMonth);
   const month = dropdown(
     ([_month, name]: [number, string]) => name,
-    initialMonth,
+    (m) => m == initialMonth,
     monthModel,
     null,
     ...months.entries()
@@ -583,7 +583,7 @@ export function dialog(
  */
 export function dropdown<T, S>(
   labelMaker: (input: T) => UIElement,
-  initial: T | null,
+  initial: ((item: T) => boolean) | null,
   model: StatefulModel<T>,
   synchronizer: {
     synchronizer: StateSynchronizer<S>;
@@ -629,7 +629,9 @@ export function dropdown<T, S>(
     }
   });
   const synchronizerCallbacks: ((state: S) => void)[] = [];
-  for (const item of items) {
+  const initialIndex =
+    initial === null ? 0 : Math.max(items.findIndex(initial), 0);
+  items.forEach((item, index) => {
     const element = document.createElement("span");
     const label = labelMaker(item);
     addElements(element, label);
@@ -644,7 +646,7 @@ export function dropdown<T, S>(
         synchronizer.synchronizer.statusChanged(synchronizer.extract(item));
       }
     });
-    if (item == initial || item == items[0]) {
+    if (index == initialIndex) {
       clearChildren(activeElement);
       addElements(activeElement, label);
       model.statusChanged(item);
@@ -660,7 +662,7 @@ export function dropdown<T, S>(
       }
     });
     listElement.appendChild(element);
-  }
+  });
   if (synchronizer) {
     synchronizer.synchronizer.listen((value) =>
       synchronizerCallbacks.forEach((callback) => callback(value))

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -514,7 +514,7 @@ export function initialiseSimulationDashboard(
             contents: [
               dropdown(
                 ([name, declaration]) => name,
-                Object.entries(response.refillers)[0],
+                null,
                 refillerState.model,
                 null,
                 ...Object.entries(response.refillers)
@@ -545,7 +545,7 @@ export function initialiseSimulationDashboard(
             contents: group(
               dropdown(
                 (input) => (input ? input[0] : blank()),
-                Object.entries(response.dumpers)[0],
+                null,
                 dumpState.model,
                 null,
                 ...Object.entries(response.dumpers)
@@ -652,7 +652,7 @@ export function initialiseSimulationDashboard(
               return "Unknown";
           }
         },
-        lastTheme,
+        (theme) => theme == lastTheme,
         combineModels(savedTheme, {
           reload: () => {},
           statusChanged: (input: string) => editor.setTheme(input),


### PR DESCRIPTION
- Replace dropdown initial with a predicate  
    There was causing a problem on the _Actions_ page where the initial was an
    array and since `==` compares arrays for reference equality, the initial value
    was never being selected. This changes it to use a predicate instead of
    reference equality and makes sure to only update the target model once even if
    the predicate returns true multiple times.
- Fix bug where server-provided searches caused 400
    This was due to an incorrect type annotation leading server searches to be
    nested in an extra array.
