### PR TITLE
Allow skipping integration tests

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -12,7 +12,7 @@ case "${JAVA_HOME}" in
 		;;
 esac
 
-mvn clean install
+mvn -DskipIT=false clean install
 echo ${SONAR} ${TRAVIS_PULL_REQUEST}  ${TRAVIS_PULL_REQUEST_SLUG} ${TRAVIS_REPO_SLUG}
 if ${SONAR}
 then

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM debian:testing
 
 USER root
 RUN apt-get update -m && \
-    apt-get install -y maven default-jdk-headless nodejs npm chromium
+    apt-get install -y maven default-jdk-headless nodejs npm
 RUN npm install -g typescript
 RUN mkdir /build
 COPY . /build/
 RUN cd /build && \
     tsc -p shesmu-server-ui && \
-    mvn -q -Dsurefire.useFile=false clean install && \
+    mvn -q -Dsurefire.useFile=false -DskipIT=true clean install && \
     mkdir /usr/share/shesmu && \
     cp shesmu-pluginapi/target/shesmu-pluginapi.jar shesmu-server/target/shesmu.jar plugin-*/target/shesmu-plugin-*.jar /usr/share/shesmu
 

--- a/plugin-niassa+pinery/pom.xml
+++ b/plugin-niassa+pinery/pom.xml
@@ -64,8 +64,13 @@
       <artifactId>commons-text</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/plugin-niassa+pinery/src/test/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BarcodeGrouperTest.java
+++ b/plugin-niassa+pinery/src/test/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BarcodeGrouperTest.java
@@ -1,12 +1,11 @@
 package ca.on.oicr.gsi.shesmu.pinery.barcodes;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BarcodeGrouperTest {
   class Result {

--- a/plugin-niassa+pinery/src/test/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BarcodeTest.java
+++ b/plugin-niassa+pinery/src/test/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BarcodeTest.java
@@ -1,8 +1,8 @@
 package ca.on.oicr.gsi.shesmu.pinery.barcodes;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** @author mlaszloffy */
 public class BarcodeTest {

--- a/plugin-niassa+pinery/src/test/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BasesMaskTest.java
+++ b/plugin-niassa+pinery/src/test/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BasesMaskTest.java
@@ -1,48 +1,49 @@
 package ca.on.oicr.gsi.shesmu.pinery.barcodes;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** @author mlaszloffy */
 public class BasesMaskTest {
 
   @Test
   public void testPairedEndSingleBarcodeParsing() {
-    Assert.assertEquals(BasesMask.fromString("y1n1,i1n1,y1n1").toString(), "y1n1,i1n1,y1n1");
-    Assert.assertEquals(BasesMask.fromString("y*n0,i1n1,y*n0").toString(), "y*,i1n1,y*");
-    Assert.assertEquals(BasesMask.fromString("y*n0,i6n0,y*n0").toString(), "y*,i6,y*");
-    Assert.assertEquals(BasesMask.fromString("y*,i6n*,y*").toString(), "y*,i6n*,y*");
-    Assert.assertEquals(BasesMask.fromString("y*,i6n2,y*").toString(), "y*,i6n2,y*");
-    Assert.assertEquals(BasesMask.fromString("y*,i6,y*").toString(), "y*,i6,y*");
+    Assertions.assertEquals(BasesMask.fromString("y1n1,i1n1,y1n1").toString(), "y1n1,i1n1,y1n1");
+    Assertions.assertEquals(BasesMask.fromString("y*n0,i1n1,y*n0").toString(), "y*,i1n1,y*");
+    Assertions.assertEquals(BasesMask.fromString("y*n0,i6n0,y*n0").toString(), "y*,i6,y*");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6n*,y*").toString(), "y*,i6n*,y*");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6n2,y*").toString(), "y*,i6n2,y*");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6,y*").toString(), "y*,i6,y*");
   }
 
   @Test
   public void testPairedEndDualBarcodeParsing() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         BasesMask.fromString("y1n1,i1n1,i1n1,y1n1").toString(), "y1n1,i1n1,i1n1,y1n1");
-    Assert.assertEquals(BasesMask.fromString("y*n0,i1n1,i1n1,y*n0").toString(), "y*,i1n1,i1n1,y*");
-    Assert.assertEquals(BasesMask.fromString("y*n0,i6n0,i6n0,y*n0").toString(), "y*,i6,i6,y*");
-    Assert.assertEquals(BasesMask.fromString("y*,i6n*,i6n*,y*").toString(), "y*,i6n*,i6n*,y*");
-    Assert.assertEquals(BasesMask.fromString("y*,i6n2,i6n2,y*").toString(), "y*,i6n2,i6n2,y*");
-    Assert.assertEquals(BasesMask.fromString("y*,i6,i6,y*").toString(), "y*,i6,i6,y*");
+    Assertions.assertEquals(
+        BasesMask.fromString("y*n0,i1n1,i1n1,y*n0").toString(), "y*,i1n1,i1n1,y*");
+    Assertions.assertEquals(BasesMask.fromString("y*n0,i6n0,i6n0,y*n0").toString(), "y*,i6,i6,y*");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6n*,i6n*,y*").toString(), "y*,i6n*,i6n*,y*");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6n2,i6n2,y*").toString(), "y*,i6n2,i6n2,y*");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6,i6,y*").toString(), "y*,i6,i6,y*");
   }
 
   @Test
   public void testSingleEndSingleBarcodeParsing() {
-    Assert.assertEquals(BasesMask.fromString("y1n1,i1n1").toString(), "y1n1,i1n1");
-    Assert.assertEquals(BasesMask.fromString("y*n0,i1n1").toString(), "y*,i1n1");
-    Assert.assertEquals(BasesMask.fromString("y*n0,i6n0").toString(), "y*,i6");
-    Assert.assertEquals(BasesMask.fromString("y*,i6n*").toString(), "y*,i6n*");
-    Assert.assertEquals(BasesMask.fromString("y*,i6n2").toString(), "y*,i6n2");
-    Assert.assertEquals(BasesMask.fromString("y*,i6").toString(), "y*,i6");
+    Assertions.assertEquals(BasesMask.fromString("y1n1,i1n1").toString(), "y1n1,i1n1");
+    Assertions.assertEquals(BasesMask.fromString("y*n0,i1n1").toString(), "y*,i1n1");
+    Assertions.assertEquals(BasesMask.fromString("y*n0,i6n0").toString(), "y*,i6");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6n*").toString(), "y*,i6n*");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6n2").toString(), "y*,i6n2");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6").toString(), "y*,i6");
   }
 
   @Test
   public void testSingleEndDualBarcodeParsing() {
-    Assert.assertEquals(BasesMask.fromString("y1n1,i1n1,i1n1").toString(), "y1n1,i1n1,i1n1");
-    Assert.assertEquals(BasesMask.fromString("y*n0,i1n1,i1n1").toString(), "y*,i1n1,i1n1");
-    Assert.assertEquals(BasesMask.fromString("y*n0,i6n0,i6n0").toString(), "y*,i6,i6");
-    Assert.assertEquals(BasesMask.fromString("y*,i6n*,i6n*").toString(), "y*,i6n*,i6n*");
-    Assert.assertEquals(BasesMask.fromString("y*,i6n2,i6n2").toString(), "y*,i6n2,i6n2");
+    Assertions.assertEquals(BasesMask.fromString("y1n1,i1n1,i1n1").toString(), "y1n1,i1n1,i1n1");
+    Assertions.assertEquals(BasesMask.fromString("y*n0,i1n1,i1n1").toString(), "y*,i1n1,i1n1");
+    Assertions.assertEquals(BasesMask.fromString("y*n0,i6n0,i6n0").toString(), "y*,i6,i6");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6n*,i6n*").toString(), "y*,i6n*,i6n*");
+    Assertions.assertEquals(BasesMask.fromString("y*,i6n2,i6n2").toString(), "y*,i6n2,i6n2");
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -113,9 +113,15 @@
         <version>0.0.26</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.6.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.6.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/shesmu-pluginapi/pom.xml
+++ b/shesmu-pluginapi/pom.xml
@@ -27,8 +27,13 @@
       <artifactId>server-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/shesmu-pluginapi/src/test/java/ca/on/oicr/gsi/shesmu/plugin/TextFilterParseTest.java
+++ b/shesmu-pluginapi/src/test/java/ca/on/oicr/gsi/shesmu/plugin/TextFilterParseTest.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TextFilterParseTest {
   private abstract static class TestFilterBuilder implements ActionFilterBuilder<Boolean> {
@@ -80,7 +80,7 @@ public class TextFilterParseTest {
 
   @Test
   public void testGoodBoth() {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ActionFilter.extractFromText(
                 "Random stuff \nshesmu:799AEF722968FF2D5433515989dc565e5ab54AAA shesmusearch:W3sidHlwZSI6InRleHQiLCJtYXRjaENhc2UiOmZhbHNlLCJ0ZXh0IjoidGVzdCJ9XQ==  ",
                 MAPPER)
@@ -105,7 +105,7 @@ public class TextFilterParseTest {
 
   @Test
   public void testGoodID() {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ActionFilter.extractFromText(
                 "Hot garbage shesmu:799AEF722968FF2D5433515989DC565E5AB54AAA  ", MAPPER)
             .map(
@@ -129,7 +129,7 @@ public class TextFilterParseTest {
 
   @Test
   public void testGoodQuery() {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ActionFilter.extractFromText(
                 "So much garbage shesmusearch:W3sidHlwZSI6InRleHQiLCJtYXRjaENhc2UiOmZhbHNlLCJ0ZXh0IjoidGVzdCJ9XQ==  ",
                 MAPPER)
@@ -152,7 +152,7 @@ public class TextFilterParseTest {
 
   @Test
   public void testNothing() {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         ActionFilter.extractFromText("NOTHING OF VALUE!!! SADNESS!!! DESPAIR!!!", MAPPER)
             .isPresent());
   }

--- a/shesmu-server/pom.xml
+++ b/shesmu-server/pom.xml
@@ -11,6 +11,7 @@
   <name>Shesmu Decision-Action Server</name>
   <url>https://github.com/oicr-gsi/shesmu</url>
   <properties>
+    <skipIT>true</skipIT>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <repositories>
@@ -82,8 +83,13 @@
       <artifactId>simpleclient_hotspot</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -176,6 +182,7 @@
           <trimStackTrace>false</trimStackTrace>
           <systemPropertyVariables>
             <shesmu.server.port>${shesmu.server.port}</shesmu.server.port>
+            <skipIT>${skipIT}</skipIT>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/CompilerTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/CompilerTest.java
@@ -29,8 +29,8 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -234,8 +234,7 @@ public class CompilerTest {
   public void testCompiler() throws IOException {
     try (Stream<Path> files =
         Files.walk(Paths.get(this.getClass().getResource("/compiler").getPath()), 1)) {
-      Assert.assertTrue(
-          "Compilation output not as expected!",
+      Assertions.assertTrue(
           files
                   .filter(Files::isRegularFile)
                   .filter(p -> p.getFileName().getFileName().toString().endsWith(".shesmu"))
@@ -247,7 +246,8 @@ public class CompilerTest {
                             return !ok;
                           }))
                   .count()
-              == 0);
+              == 0,
+          "Compilation output not as expected!");
     }
   }
 

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/LaneSplittingGrouperTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/LaneSplittingGrouperTest.java
@@ -5,8 +5,8 @@ import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
 import ca.on.oicr.gsi.shesmu.runtime.LaneSplittingGrouper;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LaneSplittingGrouperTest {
 
@@ -31,7 +31,7 @@ public class LaneSplittingGrouperTest {
                     new Pair<>(2L, "2")))
             .map(s -> s.build(i -> new TreeSet<>()).size())
             .collect(Collectors.toSet());
-    Assert.assertEquals(new TreeSet<>(Arrays.asList(3, 1)), outputs);
+    Assertions.assertEquals(new TreeSet<>(Arrays.asList(3, 1)), outputs);
   }
 
   @Test
@@ -57,7 +57,7 @@ public class LaneSplittingGrouperTest {
                     new Pair<>(2L, "C")))
             .map(s -> s.build(i -> new TreeSet<>()).size())
             .collect(Collectors.toSet());
-    Assert.assertEquals(Collections.emptySet(), outputs);
+    Assertions.assertEquals(Collections.emptySet(), outputs);
   }
 
   @Test
@@ -82,7 +82,7 @@ public class LaneSplittingGrouperTest {
                     new Pair<>(2L, "2")))
             .map(s -> s.build(i -> new TreeSet<>()).size())
             .collect(Collectors.toSet());
-    Assert.assertEquals(new TreeSet<>(Collections.singletonList(4)), outputs);
+    Assertions.assertEquals(new TreeSet<>(Collections.singletonList(4)), outputs);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class LaneSplittingGrouperTest {
                     new Pair<>(2L, "B")))
             .map(s -> s.build(i -> new TreeSet<>()).size())
             .collect(Collectors.toSet());
-    Assert.assertEquals(new TreeSet<>(Collections.singletonList(4)), outputs);
+    Assertions.assertEquals(new TreeSet<>(Collections.singletonList(4)), outputs);
   }
 
   @Test
@@ -135,6 +135,6 @@ public class LaneSplittingGrouperTest {
                     new Pair<>(2L, "2")))
             .map(s -> s.build(i -> new TreeSet<>()).size())
             .collect(Collectors.toSet());
-    Assert.assertEquals(new TreeSet<>(Arrays.asList(3, 1)), outputs);
+    Assertions.assertEquals(new TreeSet<>(Arrays.asList(3, 1)), outputs);
   }
 }

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/PickTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/PickTest.java
@@ -6,8 +6,8 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PickTest {
 
@@ -25,8 +25,8 @@ public class PickTest {
                 (a, b) -> a.first().equals(b.first()),
                 Comparator.comparing(Pair::second))
             .collect(Collectors.toMap(Pair::first, Pair::second));
-    Assert.assertEquals(2, results.size());
-    Assert.assertEquals(3, results.get(true).intValue());
-    Assert.assertEquals(5, results.get(false).intValue());
+    Assertions.assertEquals(2, results.size());
+    Assertions.assertEquals(3, results.get(true).intValue());
+    Assertions.assertEquals(5, results.get(false).intValue());
   }
 }

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
@@ -43,8 +43,8 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
@@ -378,15 +378,15 @@ public class RunTest {
     System.err.println("Testing data-handling code");
     try (Stream<Path> files =
         Files.walk(Paths.get(this.getClass().getResource("/run").getPath()), 1)) {
-      Assert.assertTrue(
-          "Sample program failed to run!",
+      Assertions.assertTrue(
           files
                   .filter(Files::isRegularFile)
                   .filter(f -> f.getFileName().toString().endsWith(".shesmu"))
                   .sorted(Comparator.comparing(Path::getFileName))
                   .filter(this::testFile)
                   .count()
-              == 0);
+              == 0,
+          "Sample program failed to run!");
     }
   }
 

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/SubsamplerTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/SubsamplerTest.java
@@ -6,11 +6,12 @@ import ca.on.oicr.gsi.shesmu.runtime.subsample.Squish;
 import ca.on.oicr.gsi.shesmu.runtime.subsample.Start;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SubsamplerTest {
 
@@ -19,65 +20,67 @@ public class SubsamplerTest {
   @Test
   public void testData() throws IOException {
     System.err.println("Testing subsamplers");
-    final Start<Integer> start = new Start<Integer>();
+    final Start<Integer> start = new Start<>();
 
     // Test for the Start<T> class
     // checking if the number of items is correct
-    Assert.assertTrue(
-        "Start subsample program failed to run!", start.subsample(Stream.of()).count() == 0);
-    Assert.assertTrue(
-        "Start subsample program failed to run!", start.subsample(Stream.of(5, 8, 9)).count() == 0);
+    Assertions.assertEquals(
+        0, start.subsample(Stream.of()).count(), "Start subsample program failed to run!");
+    Assertions.assertEquals(
+        0, start.subsample(Stream.of(5, 8, 9)).count(), "Start subsample program failed to run!");
 
     // Tests for the Fixed<T> class
-    final Fixed<Integer> fixed = new Fixed<Integer>(start, 6);
+    final Fixed<Integer> fixed = new Fixed<>(start, 6);
     // Empty Stream
-    Assert.assertTrue(
-        "FixedEmpty subsample program failed to run!", fixed.subsample(Stream.of()).count() == 0);
+    Assertions.assertEquals(
+        0, fixed.subsample(Stream.of()).count(), "FixedEmpty subsample program failed to run!");
     // Stream with more data than the limit
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(1, 2, 3, 4, 5, 6),
         fixed.subsample(Stream.of(1, 2, 3, 4, 5, 6, 7)).collect(Collectors.toList()));
     // Stream with less data than the limit
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(1, 2, 3), fixed.subsample(Stream.of(1, 2, 3)).collect(Collectors.toList()));
 
     // Tests for the FixedWithConditions<T> class
     final Predicate<Integer> lesserThan = i -> (i < 10);
     final FixedWithConditions<Integer> conditioned =
-        new FixedWithConditions<Integer>(start, 8, lesserThan);
-    Assert.assertTrue(
-        "FixedWithConditionsEmpty subsample program failed to run!",
-        conditioned.subsample(Stream.of()).count() == 0);
-    Assert.assertEquals(
+        new FixedWithConditions<>(start, 8, lesserThan);
+    Assertions.assertEquals(
+        0,
+        conditioned.subsample(Stream.of()).count(),
+        "FixedWithConditionsEmpty subsample program failed to run!");
+    Assertions.assertEquals(
         Arrays.asList(-9, -4, 0, 2, 6, 8, 9),
         conditioned
             .subsample(Stream.of(-9, -4, 0, 2, 6, 8, 9, 10, 2, 3, 6))
             .collect(Collectors.toList()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(-9, -4, 0, 2),
         conditioned.subsample(Stream.of(-9, -4, 0, 2)).collect(Collectors.toList()));
-    Assert.assertEquals(
-        Arrays.asList(),
+    Assertions.assertEquals(
+        Collections.emptyList(),
         conditioned.subsample(Stream.of(10, 12, 15, 543)).collect(Collectors.toList()));
 
     // Tests for the Squish<T> class
-    final Squish<Integer> squish = new Squish<Integer>(start, 10);
-    Assert.assertTrue(
-        "SquishEmpty subsample program failed to run!",
-        conditioned.subsample(Stream.of()).count() == 0);
-    Assert.assertEquals(
+    final Squish<Integer> squish = new Squish<>(start, 10);
+    Assertions.assertEquals(
+        0,
+        conditioned.subsample(Stream.of()).count(),
+        "SquishEmpty subsample program failed to run!");
+    Assertions.assertEquals(
         Arrays.asList(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5),
         squish.subsample(Stream.of(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5)).collect(Collectors.toList()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(-4, -2, 0, 2, 4, 6, 8, 10, 12, 14),
         squish
             .subsample(
                 Stream.of(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             .collect(Collectors.toList()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(-4, -2, 0),
         squish.subsample(Stream.of(-4, -2, 0)).collect(Collectors.toList()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5),
         squish
             .subsample(Stream.of(-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/UserInterfaceTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/UserInterfaceTest.java
@@ -8,8 +8,9 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.stream.Stream;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -17,13 +18,14 @@ import org.openqa.selenium.logging.LogType;
 import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.remote.CapabilityType;
 
+@DisabledIfSystemProperty(named = "skipIT", matches = "true")
 public class UserInterfaceTest {
 
   private final String baseUrl = "http://localhost:" + System.getProperty("shesmu.server.port");
   private static WebDriver driver;
   private static Server server;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException, ParseException {
     TimeZone.setDefault(TimeZone.getTimeZone("Canada/Eastern"));
     WebDriverManager.chromedriver().setup();


### PR DESCRIPTION
They intermittently fail when running under the Docker built in GitHub Actions.
This disables it for those contents; that requires a new JUnit feature, so this
also upgrade JUnit.