### PR TITLE
Expose Pinery provider in pinery_project source

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryProjectValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryProjectValue.java
@@ -5,9 +5,11 @@ import ca.on.oicr.ws.dto.SampleProjectDto;
 
 public class PineryProjectValue {
   private final SampleProjectDto backing;
+  private final String provider;
 
-  public PineryProjectValue(SampleProjectDto backing) {
+  public PineryProjectValue(SampleProjectDto backing, String provider) {
     this.backing = backing;
+    this.provider = provider;
   }
 
   @ShesmuVariable
@@ -23,6 +25,11 @@ public class PineryProjectValue {
   @ShesmuVariable
   public String name() {
     return backing.getName();
+  }
+
+  @ShesmuVariable
+  public String provider() {
+    return provider;
   }
 
   @ShesmuVariable

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
@@ -424,7 +424,9 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
 
   @ShesmuInputSource
   public Stream<PineryProjectValue> streamProjects(boolean readStale) {
-    return (readStale ? projects.getStale() : projects.get()).map(PineryProjectValue::new);
+    final String provider = config.map(PineryConfiguration::getProvider).orElse("unknown");
+    return (readStale ? projects.getStale() : projects.get())
+        .map(backing -> new PineryProjectValue(backing, provider));
   }
 
   @Override


### PR DESCRIPTION
The `pinery_project` source shows each project multiple times due to being
registered with different providers. This exposes that provider to allow
filtering.