### PR TITLE
Search fixes

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilter.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilter.java
@@ -818,7 +818,13 @@ public abstract class ActionFilter {
                     String.format("Unrecognised value “%s”.", matches.get().second().get(i)));
               }
             }
-            return ok ? Optional.of(constructor.apply(buffer)) : Optional.empty();
+            if (ok) {
+              final ActionFilter filter = constructor.apply(buffer);
+              filter.setNegate(matches.get().first());
+              return Optional.of(filter);
+            } else {
+              return Optional.empty();
+            }
           });
     }
     return result;

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterBuilder.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterBuilder.java
@@ -278,7 +278,7 @@ public interface ActionFilterBuilder<F> {
         @Override
         public Pair<String, Integer> negate(Pair<String, Integer> filter) {
           return new Pair<>(
-              "!" + (filter.second() > 1 ? "(" + filter.first() + ")" : filter.first()), 1);
+              "not " + (filter.second() > 1 ? "(" + filter.first() + ")" : filter.first()), 1);
         }
 
         @Override

--- a/shesmu-server-ui/src/actionfilters.ts
+++ b/shesmu-server-ui/src/actionfilters.ts
@@ -1092,9 +1092,11 @@ function searchAdvanced(
   search.type = "search";
   search.value = filter;
   search.style.width = "100%";
-  search.addEventListener("search", () =>
-    searchModel.statusChanged(search.value)
-  );
+  search.addEventListener("keydown", (e) => {
+    if (e.keyCode == 13) {
+      searchModel.statusChanged(search.value);
+    }
+  });
   searchModel.statusChanged(filter);
   const updateFromClick = (...filters: ActionFilter[]) => {
     const doUpdate = (existingQuery: ActionFilter[]) => {


### PR DESCRIPTION
- Fix bug with advanced search  
    The not-equals/in flag from the queries in the advanced search was being
    incorrectly disregarded.
- Fix event listener on advanced searches  
    The `search` event type is only available on Chrome and not Firefox. The
    `search` event is more standard.
