### PR TITLE
Fix HALP state for fixable actions

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowRunMatch.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowRunMatch.java
@@ -80,6 +80,7 @@ public class WorkflowRunMatch implements Comparable<WorkflowRunMatch> {
     // are provisioned out and others are not, so the LIMS keys are in hiding. So, if it's still
     // running and the only problem is missing LIMS keys, consider it inflight.
     if (comparison == AnalysisComparison.EXACT
+        || comparison == AnalysisComparison.FIXABLE
         || state.state() == ActionState.INFLIGHT && !extraLimsKeys && !stale && !fileSubset) {
       return state.state();
     } else {


### PR DESCRIPTION
Actions that are fixable (updatable by signatures) should transition to the
match's state rather than HALP.