### PR TITLE
Fix bug where hidden histograms aren't rendered

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -618,7 +618,7 @@ export function initialiseActionDash(
   const { actions: actionUi, bulkCommands, model: actionModel } = actionDisplay(
     exportSearches
   );
-  const { ui: statsUi, model: statsModel } = actionStats(
+  const { ui: statsUi, model: statsModel, reveal: statsReveal } = actionStats(
     (...limits) => addPropertySearch(...limits),
     (typeName, start, end) => addRangeSearch(typeName, start, end),
     standardExports.concat(exportSearches)
@@ -707,7 +707,7 @@ export function initialiseActionDash(
   );
 
   const { ui: tabsUi, find: tabFind } = tabs(
-    { contents: statsUi, name: "Overview" },
+    { contents: statsUi, name: "Overview", reveal: statsReveal },
     { contents: actionUi, name: "Actions", find: searchFind }
   );
   setFindHandler(tabFind);

--- a/shesmu-server-ui/src/histogram.ts
+++ b/shesmu-server-ui/src/histogram.ts
@@ -39,7 +39,7 @@ export function histogram(
   headerAngle: number,
   labels: string[],
   rows: HistogramRow[]
-): UIElement {
+): { ui: UIElement; redraw: () => void } {
   const div = document.createElement("div");
   div.className = "histogram";
   let selectionStart: HistogramSelection = null;
@@ -207,5 +207,5 @@ export function histogram(
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });
-  return div;
+  return { ui: div, redraw: redraw };
 }

--- a/shesmu-server-ui/src/olive.ts
+++ b/shesmu-server-ui/src/olive.ts
@@ -287,7 +287,7 @@ export function initialiseOliveDash(
     "toolbar",
     "main"
   );
-  const { ui: statsUi, model: statsModel } = actionStats(
+  const { ui: statsUi, model: statsModel, reveal: statsReveal } = actionStats(
     (...limits) => search.addPropertySearch(...limits),
     (typeName, start, end) => search.addRangeSearch(typeName, start, end),
     standardExports.concat(exportSearches)
@@ -383,6 +383,7 @@ export function initialiseOliveDash(
   const { ui, find, models: tabsModels } = tabsModel(1, {
     name: "Overview",
     contents: [components.overview, statsUi],
+    reveal: statsReveal,
   });
 
   const model = combineModels(


### PR DESCRIPTION
Drawing to a canvas that is not currently displayed does not render anything to
the canvas. This lead to the situation where trigging a data refresh while on
another tab would result in blank histograms. This adds a `reveal` function
that gets called when a tab is selected and triggers a redraw of this histogram
at that time.