### PR TITLE
Handle multiple tags in drilldown properly

### DIFF
--- a/shesmu-server-ui/src/stats.ts
+++ b/shesmu-server-ui/src/stats.ts
@@ -241,7 +241,7 @@ function renderStat(
                   header: false,
                   intensity: (value || 0) / maximum,
                   click: popupForProperty(
-                    { type: col.name, value: col.value },
+                    { type: stat.column, value: col.value },
                     { type: stat.row, value: rowValue }
                   ),
                 };

--- a/shesmu-server-ui/src/stats.ts
+++ b/shesmu-server-ui/src/stats.ts
@@ -128,14 +128,24 @@ function renderStat(
       {
         label: "Open Search for Only This Selection",
         action: () => {
-          const basic: BasicQuery = {};
-          updateBasicQueryForPropertySearch(limits, basic);
-          window.open(
-            makeUrl("actiondash", {
-              filters: basic,
-              saved: "All Actions",
-            })
-          );
+          const result = updateBasicQueryForPropertySearch(limits, {});
+          if (result instanceof Promise) {
+            result.then((query) =>
+              window.open(
+                makeUrl("actiondash", {
+                  filters: query,
+                  saved: "All Actions",
+                })
+              )
+            );
+          } else {
+            window.open(
+              makeUrl("actiondash", {
+                filters: result,
+                saved: "All Actions",
+              })
+            );
+          }
         },
       },
       {


### PR DESCRIPTION
- Fix filter type in crosstab cells
- Upgrade to advanced search when basic won't do  
    When multiple tags are selected, the drill-down option doesn't work because the
    tags are OR'd together rather than AND'd together. If the user attempts this,
    switch them to the _Advanced_ search interface.
