### PR TITLE
Fix incorrect splitting when Run Scanner returns an error

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/LaneSplittingGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/LaneSplittingGrouper.java
@@ -49,6 +49,12 @@ public class LaneSplittingGrouper<I, T, O> implements Grouper<I, O> {
       }
     }
 
+    // If we failed to get information from Run Scanner, then the flow cell geometry is the empty
+    // list and we should not try to group this row.
+    if (canMerge.isEmpty()) {
+      return Stream.empty();
+    }
+
     // Bin input by the lane it claims to be
     final Map<Long, List<I>> groups =
         inputs

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/LaneSplittingGrouperTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/LaneSplittingGrouperTest.java
@@ -31,7 +31,7 @@ public class LaneSplittingGrouperTest {
                     new Pair<>(2L, "2")))
             .map(s -> s.build(i -> new TreeSet<>()).size())
             .collect(Collectors.toSet());
-    Assertions.assertEquals(new TreeSet<>(Arrays.asList(3, 1)), outputs);
+    Assertions.assertEquals(Collections.emptySet(), outputs);
   }
 
   @Test


### PR DESCRIPTION
The Run Scanner plugin makes the assumption that if it fails to fetch the
flowcell geometry, it can return an empty list and downstream processes will
consider this an error state. The lane splitting grouper however, did not
reject such records. This change rejects them.