### PR TITLE
Add a comment when reopening tickets

### DIFF
--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/FileTicket.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/FileTicket.java
@@ -34,7 +34,7 @@ public final class FileTicket extends BaseTicketAction {
     if (matches.isEmpty()) {
       return createIssue(services, description, assignee);
     }
-    return transitionIssues(services, matches.stream(), null);
+    return transitionIssues(services, matches.stream(), "Still not fixed:\n" + description);
   }
 
   /**


### PR DESCRIPTION
Since the description may have changed, when reopening a ticket, add the
description as a comment.