### PR TITLE
Ignore unknown fields on source locations

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/SourceOliveLocation.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/SourceOliveLocation.java
@@ -1,8 +1,10 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
 import ca.on.oicr.gsi.shesmu.plugin.SourceLocation;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.function.Predicate;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SourceOliveLocation implements Predicate<SourceLocation> {
   private Integer column;
   private String file;


### PR DESCRIPTION
When the front end copies locations from the backend, they may be a `"url"`
property that prevents them from being read correctly.