### PR TITLE
Streamline UI internals

### DIFF
--- a/shesmu-server-ui/src/histogram.ts
+++ b/shesmu-server-ui/src/histogram.ts
@@ -39,7 +39,7 @@ export function histogram(
   headerAngle: number,
   labels: string[],
   rows: HistogramRow[]
-): { ui: UIElement; redraw: () => void } {
+): UIElement {
   const div = document.createElement("div");
   div.className = "histogram";
   let selectionStart: HistogramSelection = null;
@@ -207,5 +207,5 @@ export function histogram(
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });
-  return { ui: div, redraw: redraw };
+  return { element: div, find: null, reveal: redraw, type: "ui" };
 }

--- a/shesmu-server-ui/src/io.ts
+++ b/shesmu-server-ui/src/io.ts
@@ -1,24 +1,25 @@
 import {
+  UIElement,
+  blank,
+  busyDialog,
   button,
   dialog,
-  busyDialog,
-  text,
-  UIElement,
   pager,
-  blank,
   singleState,
+  text,
+  svgFromStr,
 } from "./html.js";
 import {
   MutableStore,
-  StatefulModel,
   SplitStatefulModel,
-  splitModel,
-  mapModel,
-  promiseModel,
-  mapSplitModel,
+  StatefulModel,
   combineModels,
-  promiseTupleModel,
+  mapModel,
+  mapSplitModel,
   mapTupleModel,
+  promiseModel,
+  promiseTupleModel,
+  splitModel,
 } from "./util.js";
 
 /**
@@ -333,15 +334,7 @@ export function refreshableSvg<I>(
       requestModel(
         input,
         mapModel(promiseModel(output), (promise: Promise<Response>) =>
-          promise
-            .then((response) => response.text())
-            .then((data: string) => {
-              const svg = new window.DOMParser().parseFromString(
-                data,
-                "image/svg+xml"
-              );
-              return document.adoptNode(svg.documentElement);
-            })
+          promise.then((response) => response.text()).then(svgFromStr)
         ),
         false
       ),

--- a/shesmu-server-ui/src/util.ts
+++ b/shesmu-server-ui/src/util.ts
@@ -1,7 +1,7 @@
 /**
  * A function which converts file names to something with linebreaks
  */
-export type FilenameFormatter = (path: string) => Node[] | string;
+export type FilenameFormatter = (path: string) => (string | null)[] | string;
 
 /**
  * An interface for dealing with an updatable data store. It is a subset of the standard Map type
@@ -80,15 +80,9 @@ export const validIdentifier = /[a-z][a-zA-Z0-9_]*/;
 /**
  * Join items with a soft line-break at every delimiter.
  */
-export function softJoin(delimiter: string, text: string[]): Node[] {
+export function softJoin(delimiter: string, text: string[]): (string | null)[] {
   return text.flatMap((chunk: string, index: number) =>
-    index == 0
-      ? [document.createTextNode(chunk)]
-      : [
-          document.createTextNode(delimiter),
-          document.createElement("WBR"),
-          document.createTextNode(chunk),
-        ]
+    index == 0 ? [chunk] : [delimiter, null, chunk]
   );
 }
 
@@ -107,7 +101,7 @@ export function shuffle<T>(array: T[]): void {
 /**
  * Break text containing slashes into text with soft breaks to wrap long paths.
  */
-export function breakSlashes(text: string): Node[] {
+export function breakSlashes(text: string): (string | null)[] {
   return softJoin("/", text.split(/\//g));
 }
 /**

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -71,7 +71,7 @@ a.button:visited {
 .button,
 a.button,
 .dropdown,
-.olivemenu {
+.tablemenucapture > div {
   margin: 0.2em;
   padding: 0.4em;
   border: 1px solid var(--widget-lowlight);
@@ -85,11 +85,11 @@ a.button {
 }
 
 .dropdown,
-.olivemenu {
+.tablemenucapture > div {
   color: var(--widget-negative);
   background-color: var(--widget-lowlight);
 }
-.olivemenu {
+.tablemenucapture > div {
   font-weight: bold;
 }
 
@@ -185,31 +185,9 @@ a.button.danger:visited {
   font-size: 90%;
 }
 
-.dropdown > div,
-.olivemenu > div {
+.dropdowncapture > div > *,
+.tablemenucapture > div {
   position: absolute;
-  min-width: 200px;
-  background-color: var(--widget-negative);
-  border: 1px solid var(--widget-lowlight);
-  box-shadow: 0.2em 0.2em 5px 0px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
-  visibility: hidden;
-  opacity: 0;
-  border-radius: 0.1em;
-  font-weight: normal;
-  transition: visibility 0s linear 0s, opacity 0.3s linear;
-}
-
-.dropdown:hover > div.ready,
-.dropdown > div.forceOpen,
-.olivemenu:hover > div.ready,
-.olivemenu > div.forceOpen {
-  visibility: visible;
-  opacity: 1;
-}
-
-.dropdown > div > *,
-.olivemenu > div {
   display: block;
   max-width: 50vw;
   color: var(--widget-lowlight);
@@ -217,17 +195,17 @@ a.button.danger:visited {
   padding: 0.5em;
 }
 
-.dropdown > div > * {
+.dropdowncapture > div > * {
   overflow-wrap: break-word;
   word-break: break-all;
 }
 
-.dropdown > div > span:hover {
+.dropdowncapture > div > span:hover {
   background-color: var(--widget-highlight);
   color: var(--widget-negative);
 }
 
-.olivemenu table {
+.tablemenucapture table {
   width: auto;
 }
 
@@ -708,10 +686,12 @@ a.button.danger:visited {
 }
 
 .modal,
+.dropdowncapture,
 .menucapture,
+.tablemenucapture,
 .helpcapture {
   position: fixed;
-  z-index: 10;
+  z-index: 1000;
   left: 0;
   top: 0;
   margin: 0;
@@ -761,14 +741,15 @@ a.button.danger:visited {
   max-width: 80%;
   overflow: auto;
 }
-.menucapture > div > div {
+.menucapture > div > span {
   color: var(--widget-text);
   background-color: var(--widget-negative);
   padding: 0.5em;
   cursor: pointer;
+  display: block;
 }
 
-.menucapture > div > div:hover {
+.menucapture > div > span:hover {
   color: var(--widget-negative);
   background-color: var(--widget-highlight);
 }
@@ -831,7 +812,7 @@ table.errors {
   width: 100%;
 }
 
-.olivemenu div.olivelist {
+.tablemenucapture div.olivelist {
   margin-top: 1em;
   max-height: 80vh;
   overflow-y: auto;


### PR DESCRIPTION
Currently, the UI has a bunch of things that get tracked out-of-band: the
reveal functions needed to trigger canvas drawing and the custom find handlers.
This changes the UI so both of those things are handled inline, simplifying
use. It also redesigns the drop down menus to use the same popup handlers as
everything else rather than CSS hover stuff.