### PR TITLE
Log cache information during exceptions

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/BaseRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/BaseRecord.java
@@ -45,7 +45,7 @@ public abstract class BaseRecord<R, S> implements Record<R> {
   }
 
   @Override
-  public final R refresh() {
+  public final R refresh(String context) {
     final boolean doRefresh;
     boolean shouldThrow;
     synchronized (this) {
@@ -69,6 +69,7 @@ public abstract class BaseRecord<R, S> implements Record<R> {
           shouldThrow = false;
         }
       } catch (final Exception e) {
+        System.err.printf("Exception occured while refreshing cache %s is as follows:\n", context);
         e.printStackTrace();
         staleRefreshError.labels(fetcher.owner().name()).inc();
       } finally {

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/ExclusiveRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/ExclusiveRecord.java
@@ -1,6 +1,5 @@
 package ca.on.oicr.gsi.shesmu.plugin.cache;
 
-import ca.on.oicr.gsi.shesmu.plugin.cache.ExclusiveRecord.Lifetime;
 import java.io.Closeable;
 import java.time.Instant;
 import java.util.concurrent.Semaphore;
@@ -68,8 +67,8 @@ public class ExclusiveRecord<T> implements Record<ExclusiveRecord<T>.Lifetime> {
   }
 
   @Override
-  public Lifetime refresh() {
-    final T value = inner.refresh();
+  public Lifetime refresh(String context) {
+    final T value = inner.refresh(context);
     lock.acquireUninterruptibly();
     return new Lifetime(value);
   }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/InvalidatableRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/InvalidatableRecord.java
@@ -56,7 +56,7 @@ public class InvalidatableRecord<V> implements Record<Optional<V>> {
   }
 
   @Override
-  public synchronized Optional<V> refresh() {
+  public synchronized Optional<V> refresh(String context) {
     value = value.filter(isValid);
     if (value.isPresent()) {
       return value;

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/KeyValueCache.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/KeyValueCache.java
@@ -105,7 +105,7 @@ public abstract class KeyValueCache<K, I, V> implements Owner, Iterable<Map.Entr
     maxCount = Math.max(maxCount, record.collectionSize());
     innerCount.labels(name).set(maxCount);
     count.labels(name).set(records.size());
-    return record.refresh();
+    return record.refresh(String.format("%s [key=%s]", name, key));
   }
 
   /**

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/LabelledKeyValueCache.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/LabelledKeyValueCache.java
@@ -112,7 +112,7 @@ public abstract class LabelledKeyValueCache<K, L, I, V>
     maxCount = Math.max(maxCount, record.collectionSize());
     innerCount.labels(name).set(maxCount);
     count.labels(name).set(records.size());
-    return record.refresh();
+    return record.refresh(String.format("%s [key=%s]", name, key));
   }
   /**
    * Get an item from cache without updating it

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/Record.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/Record.java
@@ -34,8 +34,12 @@ public interface Record<V> {
   /** Get the current item value, but do not fetch */
   V readStale();
 
-  /** Get the current item value, fetching if necessary */
-  V refresh();
+  /**
+   * Get the current item value, fetching if necessary
+   *
+   * @param context information about the owner's cache to log if an exception occurs
+   */
+  V refresh(String context);
 
   /** The callback used by this record to fetch data */
   Updater<?> updater();

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/TimeoutRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/TimeoutRecord.java
@@ -112,14 +112,14 @@ public class TimeoutRecord<V> implements Record<V> {
   }
 
   @Override
-  public V refresh() {
+  public V refresh(String context) {
     try {
       LOCK.acquire();
       TIMEOUTS.put(
           Thread.currentThread(),
           new Pair<>(Instant.now().plus(maxRuntime, ChronoUnit.MINUTES), this));
       LOCK.release();
-      final V result = inner.refresh();
+      final V result = inner.refresh(context);
       LOCK.acquire();
       TIMEOUTS.remove(Thread.currentThread());
       LOCK.release();

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/ValueCache.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/ValueCache.java
@@ -89,7 +89,7 @@ public abstract class ValueCache<I, V> implements Owner {
    *     is in an error state
    */
   public V get() {
-    final V item = value.refresh();
+    final V item = value.refresh(name);
     innerCount.labels(name).set(value.collectionSize());
     return item;
   }


### PR DESCRIPTION
When the analysis provenance cache fails, it would be useful to know which
workflow was the problem. This logs the caching information (including the key,
which is the workflow for the analysis provenance cache) to the console with
the exception.