### PR TITLE
Create type accessor for input formats

### DIFF
--- a/language.md
+++ b/language.md
@@ -1132,6 +1132,12 @@ Provides the type of an argument to a function. The number is the zero-based ind
 
 Provides the inner type of a list or optional.
 
+- `InputType` _format_ _variable_
+
+Provides the type of _variable_ from the input format _format_. Variables from
+the current input format selected with `Input` are also available as
+_variable_`_type`.
+
 - `ReturnType` _name_
 
 Provides the return type of function

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -2450,6 +2450,11 @@ public final class Server implements ServerConfig, ActionServices {
                                           }
 
                                           @Override
+                                          public InputFormatDefinition inputFormat(String format) {
+                                            return CompiledGenerator.SOURCES.get(format);
+                                          }
+
+                                          @Override
                                           public Imyhat imyhat(String name) {
                                             return types.apply(name);
                                           }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionCompilerServices.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionCompilerServices.java
@@ -15,4 +15,6 @@ public interface ExpressionCompilerServices {
   Imyhat imyhat(String name);
 
   InputFormatDefinition inputFormat();
+
+  InputFormatDefinition inputFormat(String format);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalOf.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalOf.java
@@ -68,6 +68,11 @@ public class ExpressionNodeOptionalOf extends ExpressionNode {
     }
 
     @Override
+    public InputFormatDefinition inputFormat(String format) {
+      return expressionCompilerServices.inputFormat(format);
+    }
+
+    @Override
     public Imyhat imyhat(String name) {
       return expressionCompilerServices.imyhat(name);
     }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNode.java
@@ -134,6 +134,22 @@ public abstract class ImyhatNode {
       output.accept(new ImyhatNodeTuple(inner.get()));
       return result;
     }
+    final Parser inputVariableParser = input.keyword("InputType");
+    if (inputVariableParser.isGood()) {
+      final AtomicReference<String> inputFormat = new AtomicReference<>();
+      final AtomicReference<String> variable = new AtomicReference<>();
+      final Parser result =
+          inputVariableParser
+              .whitespace()
+              .qualifiedIdentifier(inputFormat::set)
+              .whitespace()
+              .qualifiedIdentifier(variable::set)
+              .whitespace();
+      output.accept(
+          new ImyhatNodeInputVariable(
+              input.line(), input.column(), inputFormat.get(), variable.get()));
+      return result;
+    }
     final Parser unlistParser = input.keyword("In");
     if (unlistParser.isGood()) {
       final AtomicReference<ImyhatNode> inner = new AtomicReference<>();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNodeInputVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ImyhatNodeInputVariable.java
@@ -1,0 +1,44 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.InputVariable;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class ImyhatNodeInputVariable extends ImyhatNode {
+  private final int column;
+  private final String inputFormat;
+  private final int line;
+  private final String variable;
+
+  public ImyhatNodeInputVariable(int line, int column, String inputFormat, String variable) {
+    this.line = line;
+    this.column = column;
+    this.inputFormat = inputFormat;
+    this.variable = variable;
+  }
+
+  @Override
+  public Imyhat render(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    final InputFormatDefinition definition = expressionCompilerServices.inputFormat(inputFormat);
+    if (definition == null) {
+      errorHandler.accept(
+          String.format("%d:%d: Unknown input format %s.", line, column, inputFormat));
+      return Imyhat.BAD;
+    }
+    final Optional<Imyhat> varType =
+        definition
+            .baseStreamVariables()
+            .filter(v -> v.name().equals(variable))
+            .map(InputVariable::type)
+            .findAny();
+    if (!varType.isPresent()) {
+      errorHandler.accept(
+          String.format(
+              "%d:%d: Input format %s has no variable %s.", line, column, inputFormat, variable));
+    }
+    return varType.orElse(Imyhat.BAD);
+  }
+}

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
@@ -54,6 +54,7 @@ ace.define(
             "Import",
             "In",
             "Input",
+            "InputType",
             "IntersectionJoin",
             "Into",
             "Join",

--- a/shesmu-server/src/test/resources/run/type-alias3.shesmu
+++ b/shesmu-server/src/test/resources/run/type-alias3.shesmu
@@ -1,7 +1,7 @@
 Version 1;
 Input test;
 
-TypeAlias thingie {project = project_type, count = integer};
+TypeAlias thingie {project = InputType test project, count = integer};
 
 Function is_project(In [project_type] p, [project_type] projects) p In projects;
 

--- a/vim/syntax.vim
+++ b/vim/syntax.vim
@@ -49,6 +49,7 @@ syn keyword shesmuKeyword If
 syn keyword shesmuKeyword Import
 syn keyword shesmuKeyword In
 syn keyword shesmuKeyword Input
+syn keyword shesmuKeyword InputType
 syn keyword shesmuKeyword IntersectionJoin
 syn keyword shesmuKeyword Into
 syn keyword shesmuKeyword Join


### PR DESCRIPTION
The types of the input variables are available in a script as
_variable_`_type`. However, this is limited to only one in put format. This
adds a new `InputType` to access these types.