### PR TITLE
Allow joining against the output of Define olives

### DIFF
--- a/language.md
+++ b/language.md
@@ -240,10 +240,12 @@ This reshapes the data.
 
 - `Join` _outerkey_ `To` _input_ _innerkey_
 - `IntersectionJoin` _outerkey_ `To` _input_ _innerkey_
+- `Join` _outerkey_ `To Call` _name_`(`_args_`)` _innerkey_
+- `IntersectionJoin` _outerkey_ `To Call` _name_`(`_args_`)` _innerkey_
 
 Does a join where incoming rows are joined against rows from the _input_ data
-source. Names between the two data sources must not overlap. Rows are joined if
-_outerkey_ and _innerkey_ match:
+source or the output of the `Define` olive _name_. Names between the two data
+sources must not overlap. Rows are joined if _outerkey_ and _innerkey_ match:
 
 | Operation          | Outer Key | Inner Key | Behaviour |
 |--------------------|-----------|-----------|---|
@@ -261,23 +263,24 @@ used to find output process that used some of the input.
 If an set-to-single value join is required, use `IntersectionJoin` and put the
 single element in a list.
 
-
 This reshapes the data.
 
  - `LeftJoin` _outerkey_ `To` [`Prefix` _prefix_]  _input_ _innerkey_ [`Where` _condition_] _collectionname1_ `=` _collector1_ [`,` ...]
  - `LeftIntersectionJoin` _outerkey_ `To` [`Prefix` _prefix_]  _input_ _innerkey_ [`Where` _condition_] _collectionname1_ `=` _collector1_ [`,` ...]
+ - `LeftJoin` _outerkey_ `To` [`Prefix` _prefix_]  `Call` _name_`(`_args_`)` _innerkey_ [`Where` _condition_] _collectionname1_ `=` _collector1_ [`,` ...]
+ - `LeftIntersectionJoin` _outerkey_ `To` [`Prefix` _prefix_]  `Call` _name_ `(`_args_`)` _innerkey_ [`Where` _condition_] _collectionname1_ `=` _collector1_ [`,` ...]
 
 Does a left-join operation between the current data and the data from the
-_input_ data format. This is done using a merge join where keys are computed
-for both datasets and then only matching entries are processed. _outerkey_ is
-the key on the incoming data and _innerkey_ is the key on the data being joined
-against. A tuple can be used if joining on multiple keys is required. Each row
-in the outer data is treated as a kind of group and the matching inner keys are
-processed through the _collectors_. This means that outer data is used only
-once but inner data maybe reused multiple times if multiple outer rows have the
-same key. Each collector can have `Where` filters that limit the collected
-data. Optionally, a `Where` filter can be applied to all the collectors by
-providing _condition_.
+_input_ data format or the output of the `Define` olive _name_. This is done
+using a merge join where keys are computed for both datasets and then only
+matching entries are processed. _outerkey_ is the key on the incoming data and
+_innerkey_ is the key on the data being joined against. A tuple can be used if
+joining on multiple keys is required. Each row in the outer data is treated as
+a kind of group and the matching inner keys are processed through the
+_collectors_. This means that outer data is used only once but inner data maybe
+reused multiple times if multiple outer rows have the same key. Each collector
+can have `Where` filters that limit the collected data. Optionally, a `Where`
+filter can be applied to all the collectors by providing _condition_.
 
 When doing left join, there will likely be collisions between many variables,
 including all the signatures. While it is possible to reshape the data to avoid

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
@@ -424,6 +424,7 @@ public final class Check extends Compiler {
     return new CallableDefinition() {
       final boolean isRoot = node.get("isRoot").asBoolean();
       final String name = node.get("name").asText();
+      final String format = node.get("format").asText();
       final List<Imyhat> parameters =
           Utils.stream(node.get("parameters").elements())
               .map(parameter -> Imyhat.parse(parameter.asText()))
@@ -472,6 +473,11 @@ public final class Check extends Compiler {
       @Override
       public Path filename() {
         return null;
+      }
+
+      @Override
+      public String format() {
+        return format;
       }
 
       @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CallableDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CallableDefinition.java
@@ -21,6 +21,8 @@ public interface CallableDefinition {
 
   Path filename();
 
+  String format();
+
   boolean isRoot();
 
   String name();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinInputSource.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinInputSource.java
@@ -1,0 +1,15 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
+import org.objectweb.asm.Type;
+
+public interface JoinInputSource {
+
+  InputFormatDefinition format();
+
+  String name();
+
+  void render(Renderer renderer);
+
+  Type type();
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNode.java
@@ -1,0 +1,83 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.plugin.Parser;
+import ca.on.oicr.gsi.shesmu.plugin.Parser.ParseDispatch;
+import ca.on.oicr.gsi.shesmu.runtime.InputProvider;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
+
+public abstract class JoinSourceNode {
+
+  protected static final Type A_INPUT_PROVIDER_TYPE = Type.getType(InputProvider.class);
+  protected static final Type A_STREAM_TYPE = Type.getType(Stream.class);
+  protected static final Type A_STRING_TYPE = Type.getType(String.class);
+  private static final ParseDispatch<JoinSourceNode> DISPATCH = new ParseDispatch<>();
+  protected static final Method METHOD_INPUT_PROVIDER__FETCH =
+      new Method("fetch", A_STREAM_TYPE, new Type[] {A_STRING_TYPE});
+
+  static {
+    DISPATCH.addKeyword(
+        "Call",
+        (p, o) -> {
+          final AtomicReference<String> name = new AtomicReference<>();
+          final AtomicReference<List<ExpressionNode>> arguments = new AtomicReference<>();
+          final Parser result =
+              p.qualifiedIdentifier(name::set)
+                  .whitespace()
+                  .symbol("(")
+                  .whitespace()
+                  .listEmpty(arguments::set, ExpressionNode::parse, ',')
+                  .symbol(")")
+                  .whitespace();
+          if (result.isGood()) {
+            o.accept(new JoinSourceNodeCall(p.line(), p.column(), name.get(), arguments.get()));
+          }
+          return result;
+        });
+    DISPATCH.addRaw(
+        "input format",
+        (p, o) -> {
+          final AtomicReference<String> name = new AtomicReference<>();
+          final Parser result = p.identifier(name::set).whitespace();
+          if (result.isGood()) {
+            o.accept(new JoinSourceNodeInput(p.line(), p.column(), name.get()));
+          }
+          return result;
+        });
+  }
+
+  public static Parser parse(Parser input, Consumer<JoinSourceNode> output) {
+    return input.dispatch(DISPATCH, output);
+  }
+
+  public abstract boolean canSign();
+
+  public abstract void collectPlugins(Set<Path> pluginFileNames);
+
+  public abstract JoinInputSource render(
+      BaseOliveBuilder oliveBuilder,
+      Function<String, CallableDefinitionRenderer> definitions,
+      String prefix,
+      String variablePrefix,
+      Predicate<String> signatureUsed,
+      Predicate<String> singableUsed);
+
+  public abstract Stream<? extends Target> resolve(
+      String syntax,
+      OliveCompilerServices oliveCompilerServices,
+      NameDefinitions defs,
+      Consumer<String> errorHandler);
+
+  public abstract boolean resolveDefinitions(
+      OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler);
+
+  public abstract boolean typeCheck(Consumer<String> errorHandler);
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeCall.java
@@ -1,0 +1,151 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.objectweb.asm.Type;
+
+public class JoinSourceNodeCall extends JoinSourceNode {
+
+  private final List<ExpressionNode> arguments;
+  private final int column;
+  private final int line;
+  private final String name;
+  private CallableDefinition target;
+  private InputFormatDefinition format;
+
+  public JoinSourceNodeCall(int line, int column, String name, List<ExpressionNode> arguments) {
+    this.line = line;
+    this.column = column;
+    this.name = name;
+    this.arguments = arguments;
+  }
+
+  @Override
+  public boolean canSign() {
+    return target.isRoot();
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    arguments.forEach(arg -> arg.collectPlugins(pluginFileNames));
+  }
+
+  @Override
+  public JoinInputSource render(
+      BaseOliveBuilder oliveBuilder,
+      Function<String, CallableDefinitionRenderer> definitions,
+      String prefix,
+      String variablePrefix,
+      Predicate<String> signatureUsed,
+      Predicate<String> singableUsed) {
+
+    return new JoinInputSource() {
+      private final CallableDefinitionRenderer defineOlive = definitions.apply(name);
+
+      @Override
+      public InputFormatDefinition format() {
+        return format;
+      }
+
+      @Override
+      public String name() {
+        return target.name();
+      }
+
+      @Override
+      public void render(Renderer renderer) {
+        renderer.methodGen().push(target.format());
+        renderer.methodGen().invokeInterface(A_INPUT_PROVIDER_TYPE, METHOD_INPUT_PROVIDER__FETCH);
+        defineOlive.generatePreamble(renderer.methodGen());
+        oliveBuilder.loadOliveServices(renderer.methodGen());
+        oliveBuilder.loadInputProvider(renderer.methodGen());
+        oliveBuilder.loadOwnerSourceLocation(renderer.methodGen());
+        oliveBuilder.loadAccessor(renderer);
+        for (final ExpressionNode rendererConsumer : arguments) {
+          rendererConsumer.render(renderer);
+        }
+        defineOlive.generateCall(renderer.methodGen());
+      }
+
+      @Override
+      public Type type() {
+        return defineOlive.currentType();
+      }
+    };
+  }
+
+  @Override
+  public Stream<? extends Target> resolve(
+      String syntax,
+      OliveCompilerServices oliveCompilerServices,
+      NameDefinitions defs,
+      Consumer<String> errorHandler) {
+    final NameDefinitions limitedDefs = defs.replaceStream(Stream.empty(), true);
+    if (arguments.stream().filter(argument -> argument.resolve(limitedDefs, errorHandler)).count()
+        != arguments.size()) {
+      return null;
+    }
+    return target.outputStreamVariables(oliveCompilerServices, errorHandler).orElse(null);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler) {
+    final boolean ok =
+        arguments
+                .stream()
+                .filter(
+                    argument -> argument.resolveDefinitions(oliveCompilerServices, errorHandler))
+                .count()
+            == arguments.size();
+    target = oliveCompilerServices.olive(name);
+    if (target != null) {
+      if (target.parameterCount() != arguments.size()) {
+        errorHandler.accept(
+            String.format(
+                "%d:%d: “Define %s” specifies %d parameters, but only %d arguments provided.",
+                line, column, name, target.parameterCount(), arguments.size()));
+        return false;
+      }
+      format = oliveCompilerServices.inputFormat(target.format());
+      return ok;
+    }
+    errorHandler.accept(
+        String.format("%d:%d: Cannot find matching “Define %s” for call.", line, column, name));
+    return false;
+  }
+
+  @Override
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    return IntStream.range(0, arguments.size())
+            .filter(
+                index -> {
+                  if (!arguments.get(index).typeCheck(errorHandler)) {
+                    return false;
+                  }
+                  final boolean isSame =
+                      arguments.get(index).type().isSame(target.parameterType(index));
+                  if (!isSame) {
+                    errorHandler.accept(
+                        String.format(
+                            "%d:%d: Parameter %d to “%s” expects %s, but got %s.",
+                            line,
+                            column,
+                            index,
+                            name,
+                            target.parameterType(index).name(),
+                            arguments.get(index).type().name()));
+                  }
+                  return isSame;
+                })
+            .count()
+        == arguments.size();
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeInput.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeInput.java
@@ -1,0 +1,108 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.objectweb.asm.Type;
+
+public final class JoinSourceNodeInput extends JoinSourceNode {
+
+  protected final int column;
+  private final String format;
+  private InputFormatDefinition inputFormat;
+  protected final int line;
+
+  public JoinSourceNodeInput(int line, int column, String format) {
+    this.line = line;
+    this.column = column;
+    this.format = format;
+  }
+
+  @Override
+  public boolean canSign() {
+    return true;
+  }
+
+  @Override
+  public final void collectPlugins(Set<Path> pluginFileNames) {
+    // Do nothing
+  }
+
+  @Override
+  public final JoinInputSource render(
+      BaseOliveBuilder oliveBuilder,
+      Function<String, CallableDefinitionRenderer> definitions,
+      String prefix,
+      String variablePrefix,
+      Predicate<String> signatureUsed,
+      Predicate<String> signableUsed) {
+    oliveBuilder
+        .owner
+        .signatureVariables()
+        .filter(signature -> signatureUsed.test(variablePrefix + signature.name()))
+        .forEach(
+            signatureDefinition ->
+                oliveBuilder.createSignature(
+                    prefix,
+                    inputFormat,
+                    inputFormat
+                        .baseStreamVariables()
+                        .filter(input -> signableUsed.test(variablePrefix + input.name()))
+                        .map(SignableRenderer::always),
+                    signatureDefinition));
+
+    return new JoinInputSource() {
+      @Override
+      public InputFormatDefinition format() {
+        return inputFormat;
+      }
+
+      @Override
+      public String name() {
+        return inputFormat.name();
+      }
+
+      @Override
+      public void render(Renderer renderer) {
+        renderer.methodGen().push(inputFormat.name());
+        renderer.methodGen().invokeInterface(A_INPUT_PROVIDER_TYPE, METHOD_INPUT_PROVIDER__FETCH);
+      }
+
+      @Override
+      public Type type() {
+        return inputFormat.type();
+      }
+    };
+  }
+
+  @Override
+  public final Stream<? extends Target> resolve(
+      String syntax,
+      OliveCompilerServices oliveCompilerServices,
+      NameDefinitions defs,
+      Consumer<String> errorHandler) {
+    inputFormat = oliveCompilerServices.inputFormat(format);
+    if (inputFormat == null) {
+      errorHandler.accept(
+          String.format("%d:%d: Unknown input format “%s” in %s.", line, column, format, syntax));
+      return null;
+    }
+
+    return Stream.concat(inputFormat.baseStreamVariables(), oliveCompilerServices.signatures());
+  }
+
+  @Override
+  public final boolean resolveDefinitions(
+      OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler) {
+    return true;
+  }
+
+  @Override
+  public final boolean typeCheck(Consumer<String> errorHandler) {
+    return true;
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
@@ -111,6 +111,15 @@ public class OliveClauseNodeCall extends OliveClauseNode {
             == arguments.size();
     target = oliveCompilerServices.olive(name);
     if (target != null) {
+      // Format is only ever null in a cycle.
+      if (target.format() != null
+          && !target.format().equals(oliveCompilerServices.inputFormat().name())) {
+        errorHandler.accept(
+            String.format(
+                "%d:%d: “Define %s” is for %s, but olive is processing %s.",
+                line, column, name, target.format(), oliveCompilerServices.inputFormat().name()));
+        return false;
+      }
       if (target.parameterCount() != arguments.size()) {
         errorHandler.accept(
             String.format(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeIntersectionJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeIntersectionJoin.java
@@ -7,8 +7,12 @@ import java.util.Optional;
 public class OliveClauseNodeIntersectionJoin extends OliveClauseNodeBaseJoin {
 
   public OliveClauseNodeIntersectionJoin(
-      int line, int column, String format, ExpressionNode outerKey, ExpressionNode innerKey) {
-    super(line, column, format, outerKey, innerKey);
+      int line,
+      int column,
+      JoinSourceNode source,
+      ExpressionNode outerKey,
+      ExpressionNode innerKey) {
+    super(line, column, source, outerKey, innerKey);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
@@ -6,8 +6,12 @@ import java.util.Optional;
 public class OliveClauseNodeJoin extends OliveClauseNodeBaseJoin {
 
   public OliveClauseNodeJoin(
-      int line, int column, String format, ExpressionNode outerKey, ExpressionNode innerKey) {
-    super(line, column, format, outerKey, innerKey);
+      int line,
+      int column,
+      JoinSourceNode source,
+      ExpressionNode outerKey,
+      ExpressionNode innerKey) {
+    super(line, column, source, outerKey, innerKey);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftIntersectionJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftIntersectionJoin.java
@@ -10,13 +10,13 @@ public final class OliveClauseNodeLeftIntersectionJoin extends OliveClauseNodeBa
   public OliveClauseNodeLeftIntersectionJoin(
       int line,
       int column,
-      String format,
+      JoinSourceNode source,
       ExpressionNode outerKey,
       String variablePrefix,
       ExpressionNode innerKey,
       List<GroupNode> children,
       Optional<ExpressionNode> where) {
-    super(line, column, format, outerKey, variablePrefix, innerKey, children, where);
+    super(line, column, source, outerKey, variablePrefix, innerKey, children, where);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
@@ -9,13 +9,13 @@ public final class OliveClauseNodeLeftJoin extends OliveClauseNodeBaseLeftJoin {
   public OliveClauseNodeLeftJoin(
       int line,
       int column,
-      String format,
+      JoinSourceNode source,
       ExpressionNode outerKey,
       String variablePrefix,
       ExpressionNode innerKey,
       List<GroupNode> children,
       Optional<ExpressionNode> where) {
-    super(line, column, format, outerKey, variablePrefix, innerKey, children, where);
+    super(line, column, source, outerKey, variablePrefix, innerKey, children, where);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
@@ -104,6 +104,11 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
     return null;
   }
 
+  @Override
+  public String format() {
+    return inputFormat;
+  }
+
   public boolean isRoot() {
     return clauses().stream().noneMatch(OliveClauseNodeGroup.class::isInstance);
   }
@@ -166,7 +171,6 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
     if (outputStreamVariables != null) {
       return true;
     }
-    inputFormat = oliveCompilerServices.inputFormat().name();
     resolveLock = true;
     final NameDefinitions result =
         clauses()
@@ -194,6 +198,7 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
   @Override
   protected boolean resolveDefinitionsExtra(
       OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler) {
+    inputFormat = oliveCompilerServices.inputFormat().name();
     return true;
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
@@ -288,6 +288,11 @@ public class CompiledGenerator implements DefinitionRepository {
           }
 
           @Override
+          public String format() {
+            return inputFormatName;
+          }
+
+          @Override
           public void generateCall(GeneratorAdapter methodGen) {
             methodGen.invokeDynamic(
                 qualifiedName,

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
@@ -28,6 +28,7 @@ ace.define(
             "As",
             "Begin",
             "By",
+            "Call",
             "Check",
             "Count",
             "Default",

--- a/shesmu-server/src/test/resources/run/intersectionjoin.shesmu
+++ b/shesmu-server/src/test/resources/run/intersectionjoin.shesmu
@@ -2,6 +2,7 @@ Version 1;
 Input test;
 
 Olive
+ Let accession
  IntersectionJoin [False, True] To inner_test [True]
  Group By accession Into ls = List l
  Run ok With ok = (For l In ls: Count) == 2;

--- a/shesmu-server/src/test/resources/run/join-call.shesmu
+++ b/shesmu-server/src/test/resources/run/join-call.shesmu
@@ -1,0 +1,9 @@
+Version 1;
+Input test;
+
+Define foo()
+ Let a = accession, p = project;
+
+Olive
+ Join accession To Call foo() a
+ Run ok With ok = p == project;

--- a/shesmu-server/src/test/resources/run/join-define.shesmu
+++ b/shesmu-server/src/test/resources/run/join-define.shesmu
@@ -2,6 +2,7 @@ Version 1;
 Input test;
 
 Define foo()
+ Let accession
  Join True To inner_test True
  Group By accession Into ls = List l;
 

--- a/shesmu-server/src/test/resources/run/join.shesmu
+++ b/shesmu-server/src/test/resources/run/join.shesmu
@@ -2,6 +2,7 @@ Version 1;
 Input test;
 
 Olive
+ Let accession
  Join True To inner_test True
  Group By accession Into ls = List l
  Run ok With ok = (For l In ls: Count) == 2;

--- a/shesmu-server/src/test/resources/run/leftjoin-call.shesmu
+++ b/shesmu-server/src/test/resources/run/leftjoin-call.shesmu
@@ -1,0 +1,12 @@
+Version 1;
+Input test;
+
+Define foo()
+ Let ls = library_size
+ LeftJoin ls To inner_test l
+    num = Count;
+
+Olive
+ LeftJoin library_size To Call foo() ls
+   x = Univalued num Default 0
+ Run ok With ok = x == 1;

--- a/vim/syntax.vim
+++ b/vim/syntax.vim
@@ -22,6 +22,7 @@ syn keyword shesmuKeyword ArgumentType
 syn keyword shesmuKeyword As
 syn keyword shesmuKeyword Begin
 syn keyword shesmuKeyword By
+syn keyword shesmuKeyword Call
 syn keyword shesmuKeyword Check
 syn keyword shesmuKeyword Count
 syn keyword shesmuKeyword Default


### PR DESCRIPTION
* Allow joining against `Define` olive output
    For more complicated joining conditions, it is useful to do some preprocessing
    of the data to be joined. This allows using a separate `Define` olive as the
    source of data in a join to do the preprocessing.
* Fix bad tests
    These tests should have been failing because there are signatures on both sides
    of the join, which leads to conflicting names.
* Add check for format compatibility
    Olives can only call `Define` olives if the input is the same format. This was
    always true until exporting olives was allowed.
