### PR TITLE
Fix signer accessor hoisting bug

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BaseOliveBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BaseOliveBuilder.java
@@ -229,7 +229,8 @@ public abstract class BaseOliveBuilder {
       InputFormatDefinition inputFormat,
       Stream<SignableRenderer> signables,
       SignatureDefinition signer) {
-    createSignatureInfrastructure(owner, prefix, inputFormat, signables.collect(Collectors.toList()), signer);
+    createSignatureInfrastructure(
+        owner, prefix, inputFormat, signables.collect(Collectors.toList()), signer);
   }
 
   /**
@@ -311,7 +312,23 @@ public abstract class BaseOliveBuilder {
           new LambdaBuilder(
               owner,
               String.format("Flatten %d:%d✨", line, column),
-              LambdaBuilder.bifunction(newType, oldType, unrollType));
+              LambdaBuilder.bifunction(newType, oldType, unrollType),
+              new LoadableValue() {
+                @Override
+                public String name() {
+                  return SIGNER_ACCESSOR_NAME;
+                }
+
+                @Override
+                public Type type() {
+                  return A_SIGNATURE_ACCESSOR_TYPE;
+                }
+
+                @Override
+                public void accept(Renderer renderer) {
+                  loadAccessor(renderer);
+                }
+              });
 
       final Renderer constructorRenderer = constructLambda.renderer(oldType, 0, this::emitSigner);
       constructorRenderer.methodGen().visitCode();

--- a/shesmu-server/src/test/resources/run/define-sign-hoist.shesmu
+++ b/shesmu-server/src/test/resources/run/define-sign-hoist.shesmu
@@ -1,0 +1,16 @@
+Version 1;
+Input test;
+
+Define do_the_thing()
+  Require
+    whatever = If project == "the_foo_study" Then `project` Else ``
+  OnReject
+    Alert
+      alertname = "Whatever",
+      project = project
+    For 30mins
+  Resume;
+
+Olive
+  do_the_thing()
+  Run ok With ok = whatever != "";


### PR DESCRIPTION
Corrects a problem where when using `Flatten` or `Require` in a `Define` olive,
the internal use `Signer Accessor` variable was not hoisted into the lambda
resulting in a compiler error.