### PR TITLE
Make sure all exported definitions are available in simulation

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -2087,12 +2087,7 @@ public final class Server implements ServerConfig, ActionServices {
           final SimulateRequest request =
               RuntimeSupport.MAPPER.readValue(t.getRequestBody(), SimulateRequest.class);
           request.run(
-              definitionRepository,
-              compiler::functions,
-              compiler::oliveDefinitions,
-              this,
-              inputSource,
-              t);
+              DefinitionRepository.concat(definitionRepository, compiler), this, inputSource, t);
         });
 
     add(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
@@ -313,8 +313,6 @@ public class SimulateRequest {
 
   public void run(
       DefinitionRepository definitionRepository,
-      Supplier<Stream<FunctionDefinition>> importableFunctions,
-      Supplier<Stream<CallableOliveDefinition>> importableOliveDefinitions,
       ActionServices actionServices,
       InputSource inputSource,
       HttpExchange http)
@@ -370,13 +368,12 @@ public class SimulateRequest {
 
                 @Override
                 public Stream<CallableOliveDefinition> oliveDefinitions() {
-                  return Stream.concat(
-                      definitionRepository.oliveDefinitions(), importableOliveDefinitions.get());
+                  return definitionRepository.oliveDefinitions();
                 }
 
                 @Override
                 public Stream<FunctionDefinition> functions() {
-                  return Stream.concat(definitionRepository.functions(), importableFunctions.get());
+                  return definitionRepository.functions();
                 }
 
                 @Override


### PR DESCRIPTION
Mike noticed that exported constants were not available in _Simulation_.