### PR TITLE
Allow default values for required JIRA fields

### DIFF
--- a/plugin-jira/README.md
+++ b/plugin-jira/README.md
@@ -18,6 +18,7 @@ To set up a JIRA integration, create a file ending in `.jira` as follows:
           "CLOSED",
           "RESOLVED"
         ],
+        "defaultFieldValues": {},
         "issueType": "Bug",
         "passwordFile": "/path/to/jira/password",
         "projectKey": "PK",
@@ -42,10 +43,13 @@ the `closeActions`, `reopenActions`, and `closedStatuses` will be the same for
 most projects on a JIRA server, but they need not be, hence the need for
 separate configuration files.
 
-Shesmu needs to create and reopen tickets, but it can only do so if there is no
-mandatory fields to fill in beyond the summary and description. Shesmu allows
-setting an assignee on new tickets, but the assignee field must be available in
-the _Create Ticket_ window or an error will occur.
+Shesmu needs to create and reopen tickets, but it can only do so if there are
+either no mandatory fields to fill in beyond the summary and description or it
+has the required fields.  `defaultFieldValues` provides values to use on
+required fields. Fields which are not required are not sent even if a default
+is provided. Shesmu allows setting an assignee on new tickets, but the assignee
+field must be available in the _Create Ticket_ window or an error will occur.
+
 
 The `searches` section allow JIRA tickets to be integrated with Shesmu's action
 searches on the _Actions_ page. The idea is meant for the following use case:

--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/Configuration.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/Configuration.java
@@ -2,10 +2,12 @@ package ca.on.oicr.gsi.shesmu.jira;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public final class Configuration {
   private List<String> closeActions;
   private List<String> closedStatuses;
+  private Map<String, String> defaultFieldValues = Collections.emptyMap();
   private String issueType;
   private String passwordFile;
   private String projectKey;
@@ -20,6 +22,10 @@ public final class Configuration {
 
   public List<String> getClosedStatuses() {
     return closedStatuses;
+  }
+
+  public Map<String, String> getDefaultFieldValues() {
+    return defaultFieldValues;
   }
 
   public String getIssueType() {
@@ -56,6 +62,10 @@ public final class Configuration {
 
   public void setClosedStatuses(List<String> closedStatuses) {
     this.closedStatuses = closedStatuses;
+  }
+
+  public void setDefaultFieldValues(Map<String, String> defaultFieldValues) {
+    this.defaultFieldValues = defaultFieldValues;
   }
 
   public void setIssueType(String issueType) {

--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
@@ -173,13 +173,14 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
               IssueFieldId.LABELS_FIELD)
           .map(x -> x.id)
           .collect(Collectors.toSet());
-  private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("YYYY-MM-dd HH:mm");
+  private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private JiraRestClient client;
 
   private List<String> closeActions = Collections.emptyList();
 
   private List<String> closedStatuses = Collections.emptyList();
+  private Map<String, String> defaultFieldValues = Collections.emptyMap();
   private final Supplier<JiraConnection> definer;
   private final FilterCache filters;
   private long issueTypeId;
@@ -237,6 +238,10 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
       @ShesmuParameter(description = "keyword") String keyword,
       @ShesmuParameter(description = "is ticket open") boolean open) {
     return issues().filter(new IssueFilter(keyword, open)).count();
+  }
+
+  final String defaultFieldValues(String key) {
+    return defaultFieldValues.get(key);
   }
 
   @Override
@@ -334,6 +339,7 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
       closeActions = config.getCloseActions();
       reopenActions = config.getReopenActions();
       searches = config.getSearches();
+      defaultFieldValues = config.getDefaultFieldValues();
       issues.invalidate();
       filters.invalidateAll();
       final Project project = client.getProjectClient().getProject(projectKey).claim();


### PR DESCRIPTION
Put default values in the JIRA configuration to allow transitions between
different states that require additional information.