### PR TITLE
Return full-qualified names during binding

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Definer.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Definer.java
@@ -79,8 +79,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param clazz the class which implements the actions
    * @param supplier a generator of new instances of this action
    * @param parameters the parameters that cannot be inferred by annotations
+   * @return the full-qualified name to the action
    */
-  <A extends Action> void defineAction(
+  <A extends Action> String defineAction(
       String name,
       String description,
       Class<A> clazz,
@@ -94,8 +95,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param description the help text for the constant
    * @param type the Shesmu type for the object
    * @param value the current value of the object
+   * @return the full-qualified name to the constant
    */
-  void defineConstant(String name, String description, Imyhat type, Object value);
+  String defineConstant(String name, String description, Imyhat type, Object value);
 
   /**
    * Define a constant using a particular value
@@ -104,8 +106,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param description the help text for the constant
    * @param returnType the Shesmu type for the constant
    * @param value the current value of the object
+   * @return the full-qualified name to the constant
    */
-  <R> void defineConstant(
+  <R> String defineConstant(
       String name, String description, ReturnTypeGuarantee<R> returnType, R value);
 
   /**
@@ -115,8 +118,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param description the help text for the constant
    * @param returnType the Shesmu type for the constant
    * @param constant a callback to compute the current value of the constant
+   * @return the full-qualified name to the constant
    */
-  <R> void defineConstant(
+  <R> String defineConstant(
       String name, String description, ReturnTypeGuarantee<R> returnType, Supplier<R> constant);
 
   /**
@@ -126,8 +130,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param description the help text for the constant
    * @param type the Shesmu type for the object
    * @param supplier a callback to compute the current value of the constant
+   * @return the full-qualified name to the constant
    */
-  void defineConstantBySupplier(
+  String defineConstantBySupplier(
       String name, String description, Imyhat type, Supplier<Object> supplier);
 
   /**
@@ -136,8 +141,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param name the name of the signature
    * @param returnType the return type of the signature
    * @param signer a function to construct new signers
+   * @return the full-qualified name to the signer
    */
-  <R> void defineDynamicSigner(
+  <R> String defineDynamicSigner(
       String name, ReturnTypeGuarantee<R> returnType, Supplier<? extends DynamicSigner<R>> signer);
 
   /**
@@ -148,8 +154,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param returnType the returned Shesmu type of the function
    * @param function the implementation of the function
    * @param parameters the Shesmu types and help text of the parameters of the function
+   * @return the full-qualified name to the function
    */
-  void defineFunction(
+  String defineFunction(
       String name,
       String description,
       Imyhat returnType,
@@ -165,8 +172,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param parameterName the help text of the parameter
    * @param parameterType the type of the parameter
    * @param function the implementation of the function
+   * @return the full-qualified name to the function
    */
-  <A, R> void defineFunction(
+  <A, R> String defineFunction(
       String name,
       String description,
       ReturnTypeGuarantee<R> returnType,
@@ -185,8 +193,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param parameter2Name the help text of the second parameter
    * @param parameter2Type the type of the second parameter
    * @param function the implementation of the function
+   * @return the full-qualified name to the function
    */
-  <A, B, R> void defineFunction(
+  <A, B, R> String defineFunction(
       String name,
       String description,
       ReturnTypeGuarantee<R> returnType,
@@ -201,8 +210,9 @@ public interface Definer<T> extends Supplier<T> {
    *
    * @param name the name of the refiller
    * @param description the help text for the refiller
+   * @return the full-qualified name to the refiller
    */
-  void defineRefiller(String name, String description, RefillDefiner definer);
+  String defineRefiller(String name, String description, RefillDefiner definer);
 
   /**
    * Define a new dynamic input source
@@ -223,8 +233,9 @@ public interface Definer<T> extends Supplier<T> {
    * @param name the name of the signature
    * @param returnType the return type of the signature
    * @param signer a function to construct new signers
+   * @return the full-qualified name to the signer
    */
-  <R> void defineStaticSigner(
+  <R> String defineStaticSigner(
       String name, ReturnTypeGuarantee<R> returnType, Supplier<? extends StaticSigner<R>> signer);
 
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/CheckConfig.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/CheckConfig.java
@@ -58,6 +58,7 @@ public class CheckConfig {
       System.exit(1);
       return;
     }
+    @SuppressWarnings("rawtypes")
     final ServiceLoader<PluginFileType> pluginFileTypes = ServiceLoader.load(PluginFileType.class);
     for (final String file : files) {
       final Path path = Paths.get(file);
@@ -116,46 +117,52 @@ public class CheckConfig {
               }
 
               @Override
-              public <A extends Action> void defineAction(
+              public <A extends Action> String defineAction(
                   String name,
                   String description,
                   Class<A> clazz,
                   Supplier<A> supplier,
                   Stream<CustomActionParameter<A>> parameters) {
                 System.out.printf("Action %s bound to %s.\n", name, clazz.getName());
+                return name;
               }
 
               @Override
-              public void defineConstant(
+              public String defineConstant(
                   String name, String description, Imyhat type, Object value) {
                 System.out.printf("Constant %s of type %s.\n", name, type.name());
+                return name;
               }
 
               @Override
-              public <R> void defineConstant(
+              public <R> String defineConstant(
                   String name, String description, ReturnTypeGuarantee<R> returnType, R value) {
                 System.out.printf("Constant %s of type %s.\n", name, returnType.type().name());
+                return name;
               }
 
               @Override
-              public <R> void defineConstant(
+              public <R> String defineConstant(
                   String name,
                   String description,
                   ReturnTypeGuarantee<R> returnType,
                   Supplier<R> constant) {
                 System.out.printf("Constant %s of type %s.\n", name, returnType.type().name());
+                return name;
               }
 
               @Override
-              public void defineConstantBySupplier(
+              public String defineConstantBySupplier(
                   String name, String description, Imyhat type, Supplier<Object> supplier) {
                 System.out.printf("Constant %s of type %s.\n", name, type.name());
+                return name;
               }
 
               @Override
-              public void defineRefiller(String name, String description, RefillDefiner definer) {
+              public String defineRefiller(String name, String description, RefillDefiner definer) {
                 RefillInfo<Object, ?> info = definer.info(Object.class);
                 System.out.printf("Refiller %s bound to %s.\n", name, info.type().getName());
+                return name;
               }
 
               @Override
@@ -164,15 +171,16 @@ public class CheckConfig {
               }
 
               @Override
-              public <R> void defineDynamicSigner(
+              public <R> String defineDynamicSigner(
                   String name,
                   ReturnTypeGuarantee<R> returnType,
                   Supplier<? extends DynamicSigner<R>> signer) {
                 System.out.printf("Signer %s of type %s.\n", name, returnType.type().name());
+                return name;
               }
 
               @Override
-              public void defineFunction(
+              public String defineFunction(
                   String name,
                   String description,
                   Imyhat returnType,
@@ -185,10 +193,11 @@ public class CheckConfig {
                         .map(p -> p.type().name())
                         .collect(Collectors.joining(",")),
                     returnType.name());
+                return name;
               }
 
               @Override
-              public <A, R> void defineFunction(
+              public <A, R> String defineFunction(
                   String name,
                   String description,
                   ReturnTypeGuarantee<R> returnType,
@@ -198,12 +207,11 @@ public class CheckConfig {
                 System.out.printf(
                     "Function %s of type (%s) %s.\n",
                     name, parameterType.type().name(), returnType.type().name());
-                // Dummy.
-
+                return name;
               }
 
               @Override
-              public <A, B, R> void defineFunction(
+              public <A, B, R> String defineFunction(
                   String name,
                   String description,
                   ReturnTypeGuarantee<R> returnType,
@@ -218,14 +226,16 @@ public class CheckConfig {
                     parameter1Type.type().name(),
                     parameter2Type.type().name(),
                     returnType.type().name());
+                return name;
               }
 
               @Override
-              public <R> void defineStaticSigner(
+              public <R> String defineStaticSigner(
                   String name,
                   ReturnTypeGuarantee<R> returnType,
                   Supplier<? extends StaticSigner<R>> signer) {
                 System.out.printf("Signer %s of type %s.\n", name, returnType.type().name());
+                return name;
               }
 
               @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
@@ -440,7 +440,7 @@ public final class PluginManager
       }
 
       @Override
-      public <A extends Action> void defineAction(
+      public <A extends Action> String defineAction(
           String name,
           String description,
           Class<A> clazz,
@@ -448,14 +448,13 @@ public final class PluginManager
           Stream<CustomActionParameter<A>> parameters) {
         final MethodHandle handle =
             MH_SUPPLIER_GET.bindTo(supplier).asType(MethodType.methodType(clazz));
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
         actions.put(
             name,
             new ArbitraryActionDefintition(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 handle,
                 description,
                 instance.fileName(),
@@ -463,104 +462,109 @@ public final class PluginManager
                     parameters.map(p -> new InvokeDynamicActionParameterDescriptor(name, p)),
                     InvokeDynamicActionParameterDescriptor.findActionDefinitionsByAnnotation(
                         clazz, fileFormat.lookup()))));
+        return qualifiedName;
       }
 
       @Override
-      public void defineConstant(String name, String description, Imyhat type, Object value) {
+      public String defineConstant(String name, String description, Imyhat type, Object value) {
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
         constants.put(
             name,
             new ArbitraryConstantDefinition(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 MethodHandles.constant(type.javaType(), value),
                 type,
                 description,
                 instance.fileName()));
+        return qualifiedName;
       }
 
       @Override
-      public <R> void defineConstant(
+      public <R> String defineConstant(
           String name, String description, ReturnTypeGuarantee<R> type, R value) {
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
         constants.put(
             name,
             new ArbitraryConstantDefinition(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 MethodHandles.constant(type.type().javaType(), value),
                 type.type(),
                 description,
                 instance.fileName()));
+        return qualifiedName;
       }
 
       @Override
-      public <R> void defineConstant(
+      public <R> String defineConstant(
           String name,
           String description,
           ReturnTypeGuarantee<R> returnType,
           Supplier<R> constant) {
-
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
         constants.put(
             name,
             new ArbitraryConstantDefinition(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 MH_SUPPLIER_GET.bindTo(constant),
                 returnType.type(),
                 description,
                 instance.fileName()));
+        return qualifiedName;
       }
 
       @Override
-      public void defineConstantBySupplier(
+      public String defineConstantBySupplier(
           String name, String description, Imyhat type, Supplier<Object> supplier) {
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
+
         constants.put(
             name,
             new ArbitraryConstantDefinition(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 MH_SUPPLIER_GET.bindTo(supplier),
                 type,
                 description,
                 instance.fileName()));
+        return qualifiedName;
       }
 
       @Override
-      public <R> void defineDynamicSigner(
+      public <R> String defineDynamicSigner(
           String name,
           ReturnTypeGuarantee<R> returnType,
           Supplier<? extends DynamicSigner<R>> signer) {
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
+
         signatures.put(
             name,
             new ArbitraryDynamicSignatureDefintion(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 MH_SUPPLIER_GET.bindTo(signer),
                 returnType.type(),
                 instance.fileName()));
+        return qualifiedName;
       }
 
       @Override
-      public void defineFunction(
+      public String defineFunction(
           String name,
           String description,
           Imyhat returnType,
           VariadicFunction function,
           FunctionParameter... parameters) {
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
         final MethodHandle handle =
             MH_VARIADICFUNCTION_APPLY
                 .bindTo(function)
@@ -572,26 +576,21 @@ public final class PluginManager
         functions.put(
             name,
             new ArbitraryFunctionDefinition(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
-                description,
-                instance.fileName(),
-                handle,
-                returnType,
-                parameters));
+                qualifiedName, description, instance.fileName(), handle, returnType, parameters));
+        return qualifiedName;
       }
 
       @Override
-      public <A, R> void defineFunction(
+      public <A, R> String defineFunction(
           String name,
           String description,
           ReturnTypeGuarantee<R> returnType,
           String parameterDescription,
           TypeGuarantee<A> parameterType,
           Function<A, R> function) {
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
         final MethodHandle handle =
             MH_FUNCTION_APPLY
                 .bindTo(function)
@@ -601,20 +600,17 @@ public final class PluginManager
         functions.put(
             name,
             new ArbitraryFunctionDefinition(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 description,
                 instance.fileName(),
                 handle,
                 returnType.type(),
                 new FunctionParameter(parameterDescription, parameterType.type())));
+        return qualifiedName;
       }
 
       @Override
-      public <A, B, R> void defineFunction(
+      public <A, B, R> String defineFunction(
           String name,
           String description,
           ReturnTypeGuarantee<R> returnType,
@@ -623,6 +619,8 @@ public final class PluginManager
           String parameter2Description,
           TypeGuarantee<B> parameter2Type,
           BiFunction<A, B, R> function) {
+        final String qualifiedName =
+            String.join(Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, name);
         final MethodHandle handle =
             MH_BIFUNCTION_APPLY
                 .bindTo(function)
@@ -656,8 +654,7 @@ public final class PluginManager
 
               @Override
               public String name() {
-                return String.join(
-                    Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, name);
+                return qualifiedName;
               }
 
               @Override
@@ -688,19 +685,19 @@ public final class PluginManager
                 return returnType.type();
               }
             });
+        return qualifiedName;
       }
 
       @Override
-      public void defineRefiller(String name, String description, RefillDefiner refillerDefiner) {
+      public String defineRefiller(String name, String description, RefillDefiner refillerDefiner) {
         final RefillInfo<?, ?> info = refillerDefiner.info(Object.class);
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
         refillers.put(
             name,
             new ArbitraryRefillerDefinition(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 MH_REFILL_INFO_CREATE.bindTo(info),
                 instance.fileName(),
                 description,
@@ -710,6 +707,7 @@ public final class PluginManager
                         InvokeDynamicRefillerParameterDescriptor
                             .findRefillerDefinitionsByAnnotation(info.type(), fileFormat.lookup()))
                     .collect(Collectors.toList())));
+        return qualifiedName;
       }
 
       @Override
@@ -724,21 +722,21 @@ public final class PluginManager
       }
 
       @Override
-      public <R> void defineStaticSigner(
+      public <R> String defineStaticSigner(
           String name,
           ReturnTypeGuarantee<R> returnType,
           Supplier<? extends StaticSigner<R>> signer) {
+        final String qualifiedName =
+            String.join(
+                Parser.NAMESPACE_SEPARATOR, fileFormat.namespace(), instanceName, validate(name));
         signatures.put(
             name,
             new ArbitraryStaticSignatureDefintion(
-                String.join(
-                    Parser.NAMESPACE_SEPARATOR,
-                    fileFormat.namespace(),
-                    instanceName,
-                    validate(name)),
+                qualifiedName,
                 MH_SUPPLIER_GET.bindTo(signer),
                 returnType.type(),
                 instance.fileName()));
+        return qualifiedName;
       }
 
       public Stream<Object> fetch(String format, boolean readStale) {


### PR DESCRIPTION
This allows plugins to know the exact name, including the namespace, of an
action, function, constant, or signer after being bound. The use case of this
is for a plugin to be able to interpret `ActionName` for the actions it has
bound.