### PR TITLE
Allow unused variables if definition is exported

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
@@ -48,6 +48,9 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
 
   @Override
   public boolean checkUnusedDeclarationsExtra(Consumer<String> errorHandler) {
+    if (export) {
+      return true;
+    }
     boolean ok = true;
     for (final OliveParameter parameter : parameters) {
       if (!parameter.isRead()) {


### PR DESCRIPTION
Without this, exported definitions fail to compile, which is...unhelpful.