### PR TITLE
Don't require output be used in Export Define olives

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -341,6 +341,11 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
   }
 
   @Override
+  public boolean skipCheckUnusedDeclarations() {
+    return false;
+  }
+
+  @Override
   public boolean resolveTypes(
       OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler) {
     return true;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
@@ -48,9 +48,6 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
 
   @Override
   public boolean checkUnusedDeclarationsExtra(Consumer<String> errorHandler) {
-    if (export) {
-      return true;
-    }
     boolean ok = true;
     for (final OliveParameter parameter : parameters) {
       if (!parameter.isRead()) {
@@ -203,6 +200,11 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
       OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler) {
     inputFormat = oliveCompilerServices.inputFormat().name();
     return true;
+  }
+
+  @Override
+  public boolean skipCheckUnusedDeclarations() {
+    return export;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRefill.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRefill.java
@@ -161,7 +161,7 @@ public final class OliveNodeRefill extends OliveNodeWithClauses {
   public void render(
       RootBuilder builder, Function<String, CallableDefinitionRenderer> definitions) {
     final OliveBuilder oliveBuilder =
-        builder.buildRunOlive(line, column, null,  signableNames, signableVariableChecks);
+        builder.buildRunOlive(line, column, null, signableNames, signableVariableChecks);
     clauses().forEach(clause -> clause.render(builder, oliveBuilder, definitions));
     oliveBuilder.line(line);
     oliveBuilder.finish(
@@ -276,6 +276,11 @@ public final class OliveNodeRefill extends OliveNodeWithClauses {
       ok = false;
     }
     return ok;
+  }
+
+  @Override
+  public boolean skipCheckUnusedDeclarations() {
+    return false;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
@@ -125,7 +125,8 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
     arguments.forEach(arg -> arg.collectFreeVariables(captures, Flavour::needsCapture));
     variableTags.forEach(arg -> arg.collectFreeVariables(captures, Flavour::needsCapture));
     final OliveBuilder oliveBuilder =
-        builder.buildRunOlive(line, column, definition.name(), signableNames, signableVariableChecks);
+        builder.buildRunOlive(
+            line, column, definition.name(), signableNames, signableVariableChecks);
     clauses().forEach(clause -> clause.render(builder, oliveBuilder, definitions));
     oliveBuilder.line(line);
     final Renderer action =
@@ -283,6 +284,11 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
                 .filter(tag -> tag.resolveDefinitions(oliveCompilerServices, errorHandler))
                 .count()
             == variableTags.size();
+  }
+
+  @Override
+  public boolean skipCheckUnusedDeclarations() {
+    return false;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeWithClauses.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeWithClauses.java
@@ -25,9 +25,9 @@ public abstract class OliveNodeWithClauses extends OliveNode {
 
   @Override
   public final boolean checkUnusedDeclarations(Consumer<String> errorHandler) {
-    return clauses.stream().filter(c -> c.checkUnusedDeclarations(errorHandler)).count()
-            == clauses.size()
-        & checkUnusedDeclarationsExtra(errorHandler);
+    return checkUnusedDeclarationsExtra(errorHandler) & skipCheckUnusedDeclarations()
+        || clauses.stream().filter(c -> c.checkUnusedDeclarations(errorHandler)).count()
+            == clauses.size();
   }
 
   public abstract boolean checkUnusedDeclarationsExtra(Consumer<String> errorHandler);
@@ -98,6 +98,8 @@ public abstract class OliveNodeWithClauses extends OliveNode {
   /** Do any further non-variable definition resolution specific to this class */
   protected abstract boolean resolveDefinitionsExtra(
       OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler);
+
+  public abstract boolean skipCheckUnusedDeclarations();
 
   /** Type check this olive and all its constituent parts */
   @Override


### PR DESCRIPTION
This fixes a previous patch that implemented the wrong behaviour.