### PR TITLE
Asynchronously fetch tags

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -589,7 +589,6 @@ function collectSearches(
 
 export function initialiseActionDash(
   serverSearches: ServerSearches,
-  tags: string[],
   sources: SourceLocation[],
   savedQueryName: string | null,
   userFilters: string | BasicQuery | null,
@@ -665,8 +664,7 @@ export function initialiseActionDash(
     combinedActionsModel,
     true,
     filenameFormatter,
-    sources,
-    tags
+    sources
   );
   const { model: deleteModel, ui: deleteUi } = singleState(
     (input: SearchDefinition) =>

--- a/shesmu-server-ui/src/olive.ts
+++ b/shesmu-server-ui/src/olive.ts
@@ -284,14 +284,12 @@ export function initialiseOliveDash(
   const { actions, bulkCommands, model: actionsModel } = actionDisplay(
     exportSearches
   );
-  let dynamicTags = iterableModel<string>();
   const search = createSearch(
     actionFilterState,
     combineModels(statsModel, actionsModel),
     false,
     filenameFormatter,
-    [],
-    dynamicTags
+    []
   );
   const metroRequest = refreshableSvg(
     "metrodiagram",
@@ -428,20 +426,6 @@ export function initialiseOliveDash(
         }
       }
     ),
-    mapModel(dynamicTags, (selected: OliveReference) => {
-      if (selected) {
-        if (selected.olive) {
-          return selected.olive.olive.tagsDynamic;
-        }
-        return [
-          ...new Set(
-            selected.script.olives.flatMap((olive) => olive.tagsDynamic)
-          ),
-        ];
-      } else {
-        return [];
-      }
-    }),
     mapModel(tabsModels[0], (selected: OliveReference) => {
       if (!selected) return [];
       const tabList: Tab[] = [];


### PR DESCRIPTION
Collecting all of the dynamic tags for a large set of actions can be slow and
since this must be done for every olive in the _Olives_ dashboard and all
actions in the _Actions_ dashboard, it is prohibatively slow. This fetches the
tags that are available only if the user chooses to add a tags filter, saving
load time and potentially providing a shorter and more relevant subset of tags.