### PR TITLE
Fix signature while joining

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/BaseRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/BaseRecord.java
@@ -69,7 +69,7 @@ public abstract class BaseRecord<R, S> implements Record<R> {
           shouldThrow = false;
         }
       } catch (final Exception e) {
-        System.err.printf("Exception occured while refreshing cache %s is as follows:\n", context);
+        System.err.printf("Exception occurred while refreshing cache %s is as follows:\n", context);
         e.printStackTrace();
         staleRefreshError.labels(fetcher.owner().name()).inc();
       } finally {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BaseOliveBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BaseOliveBuilder.java
@@ -400,7 +400,9 @@ public abstract class BaseOliveBuilder {
           outerKeyLambda.push(renderer);
           innerKeyLambda.push(renderer);
           LambdaBuilder.pushNew(
-              renderer, LambdaBuilder.bifunction(newType, oldType, innerType.type()));
+              renderer,
+              LambdaBuilder.bifunction(newType, oldType, innerType.type()),
+              renderer.getNamed(SIGNER_ACCESSOR_NAME));
 
           renderer
               .methodGen()
@@ -469,7 +471,9 @@ public abstract class BaseOliveBuilder {
           outerKeyLambda.push(renderer);
           innerKeyLambda.push(renderer);
           LambdaBuilder.pushNew(
-              renderer, LambdaBuilder.bifunction(joinedType, oldType, innerType.type()));
+              renderer,
+              LambdaBuilder.bifunction(joinedType, oldType, innerType.type()),
+              renderer.getNamed(SIGNER_ACCESSOR_NAME));
           newMethod.push(renderer);
           collectLambda.push(renderer);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseLeftJoin.java
@@ -4,7 +4,6 @@ import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.compiler.OliveNode.ClauseStreamOrder;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputVariable;
-import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
 import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
@@ -25,26 +24,6 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
 public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
-
-  private class PrefixedSignatureDefinition extends SignatureDefinition {
-    private final SignatureDefinition backing;
-
-    private PrefixedSignatureDefinition(SignatureDefinition backing) {
-      super(variablePrefix + backing.name(), backing.storage(), backing.type());
-      this.backing = backing;
-    }
-
-    @Override
-    public void build(
-        GeneratorAdapter method, Type streamType, Stream<SignableRenderer> variables) {
-      backing.build(method, streamType, variables);
-    }
-
-    @Override
-    public Path filename() {
-      return backing.filename();
-    }
-  }
 
   private class PrefixedTarget implements Target {
     private final Target backing;
@@ -358,7 +337,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
     }
 
     /*
-     * This code uses PrefixedTarget, PrefixedSignatureDefinition, and PrefixedInputVariable and you might wonder why
+     * This code uses PrefixedTarget, and PrefixedInputVariable and you might wonder why
      * three given they all just slap a prefix on the name and why are they where they are. The answer is that when
      * reading a variable, the code behaves differently for three cases. If the variable is coming from the outside
      * world, it will be of type Object and we need to do a little dance to load it since it might be from a
@@ -375,14 +354,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
     final NameDefinitions joinedDefs =
         defs.replaceStream(
             Stream.concat(
-                discriminators.stream(),
-                this.innerVariables
-                    .stream()
-                    .map(
-                        t ->
-                            t instanceof SignatureDefinition
-                                ? new PrefixedSignatureDefinition((SignatureDefinition) t)
-                                : new PrefixedTarget(t))),
+                discriminators.stream(), this.innerVariables.stream().map(PrefixedTarget::new)),
             true);
 
     final boolean ok =

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Renderer.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Renderer.java
@@ -128,8 +128,7 @@ public abstract class Renderer {
   public abstract void loadStream();
 
   public final void loadTarget(Target target) {
-    if (target.flavour() == Target.Flavour.STREAM_SIGNATURE) {
-
+    if (target instanceof SignatureDefinition) {
       emitSigner((SignatureDefinition) target);
     } else if (target.flavour().isStream()) {
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -238,7 +239,8 @@ public abstract class RootBuilder {
    */
   public final OliveBuilder buildRunOlive(
       int line,
-      int column,String actionName,
+      int column,
+      String actionName,
       Set<String> signableNames,
       List<SignableVariableCheck> signableVariableChecks) {
     final Map<String, List<SignableVariableCheck>> checks =
@@ -250,7 +252,8 @@ public abstract class RootBuilder {
         this,
         inputFormatDefinition,
         line,
-        column, actionName,
+        column,
+        actionName,
         inputFormatDefinition
             .baseStreamVariables()
             .filter(t -> t.flavour() == Flavour.STREAM_SIGNABLE)
@@ -434,11 +437,16 @@ public abstract class RootBuilder {
    *
    * <p>No stream variables are available in this context
    */
-  public final Renderer rootRenderer(boolean allowUserDefined, String actionName) {
+  public final Renderer rootRenderer(
+      boolean allowUserDefined, String actionName, LoadableValue... captures) {
     return new RendererNoStream(
         this,
         runMethod,
-        Stream.concat(constants(allowUserDefined), Stream.of(actionNameSpecial(actionName))),
+        Stream.of(
+                constants(allowUserDefined),
+                Stream.of(actionNameSpecial(actionName)),
+                Stream.of(captures))
+            .flatMap(Function.identity()),
         RootBuilder::invalidSignerEmitter);
   }
 


### PR DESCRIPTION
- Don't prefix qualified names in join.
  When you have `std::signature::sha1` with a prefix, it should remain that and not become `prefixstd::signature::sha1`.
- Create a new signer accessor when joining against a call
  When doing a join against a `Call` to a `Define` olive, the source olive and the target olive may have different input format and so have different signature generators. The target olive will expect a signature generator in its own format.

  To accomplish this:
  - the code to produce a signer accessor (the code that generates signatures) is factored out of `OliveBuilder`
  - `Join` and `LeftJoin` both produce a signer accessor using the refactored code
  - when doing the join, an intermediate variable is create that holds both left and right join values (_a.k.a._ `JoinTemporary`). It used to be possible to copy the signature into the temporary, but now that it can be affected by the target of the call, this isn't possible. This code was removed.
   - Join temporaries now have a new code path to compute the signature on the values the temporary is holding.
  - Since `Renderer` only knows how to access a stream variable from arguments or locals, `JoinHalfRenderer` is an extension that knows how to use the _inner_ or _outer_ half of the stream allowing the renderer to compute the signature in that context.
  - This reduces the weird packaging of renamed signatures via `PrefixedSignatureDefinition` in `LeftJoin`.
