### PR TITLE
Fix `Match` producing bad bytecode

### DIFF
--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/DeleteAction.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/DeleteAction.java
@@ -28,7 +28,7 @@ public class DeleteAction extends Action {
           Preference.ALLOW_BULK,
           Preference.PROMPT) {
         @Override
-        protected boolean execute(DeleteAction action, Optional user) {
+        protected boolean execute(DeleteAction action, Optional<String> user) {
           if (!action.automatic) {
             action.automatic = true;
             return true;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeMatch.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeMatch.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -67,7 +68,8 @@ public class ExpressionNodeMatch extends ExpressionNode {
     final Map<Integer, List<MatchBranchNode>> paths =
         cases
             .stream()
-            .collect(Collectors.groupingBy(b -> b.name().hashCode(), Collectors.toList()));
+            .collect(
+                Collectors.groupingBy(b -> b.name().hashCode(), TreeMap::new, Collectors.toList()));
 
     final Label alternativePath = renderer.methodGen().newLabel();
     final int[] pathValues = new int[paths.size()];

--- a/shesmu-server/src/test/resources/run/algebraic5.shesmu
+++ b/shesmu-server/src/test/resources/run/algebraic5.shesmu
@@ -1,0 +1,17 @@
+Version 1;
+Input test;
+
+Function x(string p)
+  If p == "the_foo_study" Then OK Else SOMETHING {False};
+
+Function y(BAD | SOMETHING {boolean} x)
+  Match x
+    When BAD Then False
+    When SOMETHING {v} Then v;
+# The underlying lookupswitch is sensitive to the order of keys, so make sure we've sorted them in the compiler.
+Function y2(BAD | SOMETHING {boolean} x)
+  Match x
+    When SOMETHING {v} Then v
+    When BAD Then False;
+
+Olive Run ok With ok = Match x(project) When OK Then True Remainder (r) y(r) && y2(r);


### PR DESCRIPTION
- Fix invalid bytecode generated
  The `LOOKUPSWITCH` instruction expects the values to be in ascending numeric order. This ensures they are sorted before bytecode generation.
- Add missing type parameter
