### PR TITLE
More UI improvements

### DIFF
--- a/shesmu-server-ui/src/alert.ts
+++ b/shesmu-server-ui/src/alert.ts
@@ -463,13 +463,15 @@ function breakdown(
       {
         contents: tableFromRows(
           [
-            tableRow(
-              null,
-              { contents: "Label", header: true },
-              { contents: "Type", header: true },
-              { contents: "Value", header: true },
-              { contents: blank(), header: true }
-            ),
+            [
+              tableRow(
+                null,
+                { contents: "Label", header: true },
+                { contents: "Type", header: true },
+                { contents: "Value", header: true },
+                { contents: blank(), header: true }
+              ),
+            ],
             commonRows,
             breakdownRows,
           ].flat()

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -1704,7 +1704,7 @@ export function pickFromSetCustom<T>(
   ...extra: DisplayElement[]
 ) {
   dialog((close) => {
-    const selected: T[] = [];
+    let selected: T[] = [];
     const { ui, model } = singleState<T[]>((items) =>
       items.length
         ? items.map((item) => {
@@ -1715,6 +1715,8 @@ export function pickFromSetCustom<T>(
                   setItems(selected);
                   e.stopPropagation();
                   close();
+                } else {
+                  selectedModel.statusChanged(selected);
                 }
               }),
               breakLines ? br() : blank(),
@@ -1722,6 +1724,34 @@ export function pickFromSetCustom<T>(
           })
         : "No matches."
     );
+    const { ui: selectedUi, model: selectedModel } = singleState<T[]>((items) =>
+      items.length
+        ? [
+            "Going to add:",
+            br(),
+            items.map((item) => {
+              return [
+                render(item, (e) => {
+                  selected = selected.filter((i) => i != item);
+                  selectedModel.statusChanged(selected);
+                }),
+                breakLines ? br() : blank(),
+              ];
+            }),
+            br(),
+            buttonAccessory("➕ Add Selected", "Add selected items.", () => {
+              setItems(selected);
+              close();
+            }),
+            buttonAccessory("⌫ Clear Selected", "Clear selected items.", () => {
+              selected = [];
+              selectedModel.statusChanged([]);
+              close();
+            }),
+          ]
+        : blank()
+    );
+
     const showItems = (p: (input: T) => boolean) =>
       model.statusChanged(
         items.filter((item) => selected.indexOf(item) == -1).filter(p)
@@ -1750,6 +1780,7 @@ export function pickFromSetCustom<T>(
       br(),
       ui,
       paragraph("Control-click to select multiple."),
+      selectedUi,
     ];
   });
 }

--- a/shesmu-server-ui/src/olive.ts
+++ b/shesmu-server-ui/src/olive.ts
@@ -427,7 +427,7 @@ export function initialiseOliveDash(
       }
     ),
     mapModel(tabsModels[0], (selected: OliveReference) => {
-      if (!selected) return [];
+      if (!selected) return { tabs: [], activate: false };
       const tabList: Tab[] = [];
       if (
         selected.olive
@@ -458,7 +458,7 @@ export function initialiseOliveDash(
       }
       tabList.push({ name: "Bytecode", contents: components.bytecode });
 
-      return tabList;
+      return { tabs: tabList, activate: false };
     })
   );
   const oliveSelector = dropdownTable(

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -630,7 +630,7 @@ export function initialiseSimulationDashboard(
           });
         }
       }
-      return tabList;
+      return { tabs: tabList, activate: true };
     }
   );
   const main = refreshable(

--- a/shesmu-server-ui/src/util.ts
+++ b/shesmu-server-ui/src/util.ts
@@ -44,6 +44,16 @@ export interface Publisher<T> extends StatefulModel<T> {
 }
 
 /**
+ * A stateful model that allows access to the current value of the model.
+ */
+export interface ObservableModel<T> extends StatefulModel<T> {
+  /**
+   * The current/last value observed by the model.
+   */
+  value: T;
+}
+
+/**
  * An interface for something that can render itself using a preferred type or a secondary type
  *
  * This can be useful when the update is a slow operation
@@ -452,6 +462,24 @@ export function mutableStoreWatcher<K, V>(
       store.set(key, value);
       model.statusChanged(store);
     },
+  };
+}
+/**
+ * Create a model that holds the last value pushed into the model.
+ *
+ * Error states are ignored and the last good value is returned.
+ * @param initial the value before the model is updated
+ */
+export function observableModel<T>(initial: T): ObservableModel<T> {
+  let value = initial;
+  return {
+    reload: () => {},
+    get value(): T {
+      return value;
+    },
+    statusChanged: (input: T) => (value = input),
+    statusFailed: (message, retry) => console.log(message),
+    statusWaiting: () => {},
   };
 }
 


### PR DESCRIPTION
- Fix tab switching on reload
  When a tab model is updated, it would flip to the newly updated groups. This is  in the simulation dashboard, but irritating everywhere else. This improves this behaviour.
- Show selected items when doing a multi-select
  Adds a pane for the already selected items when doing a multi-select and provides an opportunity to remove them.
- Fix array nesting on alert dashboard
  This has no effect since `.flat()` remove this structure, but make it a clearer `Row[][]` rather than `(Row | Row[])[]`.
- Make _Add Filter_ → _Tags_ only show relevant tags
  The tags list was filtered by the query but not by the base filter (the selected search on the _Actions_ page or the selected olive on the _Olives_ page). This adds the base filter to limit the tags further.
- Create a model that stores its last state