### PR TITLE
Handle source references better

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -331,9 +331,21 @@ public final class Server implements ServerConfig, ActionServices {
                   String filename,
                   int line,
                   int column,
+                  String hash,
+                  String oliveFile,
                   int oliveLine,
-                  int oliveColumn) {
-                return processor.measureFlow(input, filename, line, column, oliveLine, oliveColumn);
+                  int oliveColumn,
+                  String oliveHash) {
+                return processor.measureFlow(
+                    input,
+                    filename,
+                    line,
+                    column,
+                    hash,
+                    oliveFile,
+                    oliveLine,
+                    oliveColumn,
+                    oliveHash);
               }
 
               @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeCall.java
@@ -1,6 +1,6 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
-import static ca.on.oicr.gsi.shesmu.compiler.BaseOliveBuilder.ACTION_NAME;
+import static ca.on.oicr.gsi.shesmu.compiler.BaseOliveBuilder.*;
 import static org.objectweb.asm.Type.VOID_TYPE;
 
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
@@ -107,7 +107,10 @@ public class JoinSourceNodeCall extends JoinSourceNode {
         oliveBuilder.loadOliveServices(renderer.methodGen());
         oliveBuilder.loadInputProvider(renderer.methodGen());
         renderer.emitNamed(ACTION_NAME);
-        oliveBuilder.loadOwnerSourceLocation(renderer.methodGen());
+        renderer.emitNamed(SOURCE_LOCATION_FILE);
+        renderer.emitNamed(SOURCE_LOCATION_LINE);
+        renderer.emitNamed(SOURCE_LOCATION_COLUMN);
+        renderer.emitNamed(SOURCE_LOCATION_HASH);
         renderer.methodGen().newInstance(accessorType);
         renderer.methodGen().dup();
         renderer.methodGen().invokeConstructor(accessorType, CTOR_DEFAULT);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseJoin.java
@@ -134,7 +134,7 @@ public abstract class OliveClauseNodeBaseJoin extends OliveClauseNode {
 
     join.finish();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseLeftJoin.java
@@ -294,7 +294,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
 
     leftJoin.second().finish();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
@@ -4,7 +4,6 @@ import ca.on.oicr.gsi.shesmu.compiler.OliveNode.ClauseStreamOrder;
 import ca.on.oicr.gsi.shesmu.compiler.description.OliveClauseRow;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -82,7 +81,7 @@ public class OliveClauseNodeCall extends OliveClauseNode {
     oliveBuilder.call(
         definitions.apply(name), arguments.stream().map(argument -> argument::render));
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
@@ -125,7 +125,7 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
 
     flattenBuilder.finish();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
@@ -179,7 +179,7 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
     children.forEach(group -> group.render(regrouperForChildren, builder));
     regroup.finish();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
@@ -299,7 +299,7 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
     children.forEach(group -> group.render(regrouperForChildren, builder));
     regroup.finish();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
     // We have now thoroughly hosed equals and hashCode in the output. If the next clause was
     // another grouper and it tried to stick things in a hashmap, everything might be endless
     // suffering. So, we make a hidden 1:1 let clause to stop the chaos.

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
@@ -112,7 +112,7 @@ public class OliveClauseNodeLet extends OliveClauseNode {
     let.finish();
     if (arguments.stream().anyMatch(LetArgumentNode::filters)) {
       oliveBuilder.filterNonNull();
-      oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+      oliveBuilder.measureFlow(line, column);
     }
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
@@ -129,7 +129,7 @@ public class OliveClauseNodePick extends OliveClauseNode {
     extractorMethod.methodGen().visitMaxs(0, 0);
     extractorMethod.methodGen().visitEnd();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
@@ -135,7 +135,7 @@ public class OliveClauseNodeReject extends OliveClauseNode {
     renderer.methodGen().visitMaxs(0, 0);
     renderer.methodGen().visitEnd();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
@@ -176,7 +176,7 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
 
     flattenBuilder.finish();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
@@ -99,7 +99,7 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
     filter.methodGen().visitMaxs(0, 0);
     filter.methodGen().visitEnd();
 
-    oliveBuilder.measureFlow(builder.sourcePath(), line, column);
+    oliveBuilder.measureFlow(line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeConstant.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeConstant.java
@@ -35,7 +35,7 @@ public final class OliveNodeConstant extends OliveNode implements Target {
     builder.defineConstant(
         name,
         body.type().apply(TypeUtils.TO_ASM),
-        method -> body.render(builder.rootRenderer(false, null)));
+        method -> body.render(builder.rootRenderer(false, null, Stream.empty())));
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PragmaNodeFrequency.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PragmaNodeFrequency.java
@@ -29,7 +29,7 @@ public class PragmaNodeFrequency extends PragmaNode {
 
   @Override
   public void renderAtExit(RootBuilder builder) {
-    Renderer renderer = builder.rootRenderer(false, null);
+    Renderer renderer = builder.rootRenderer(false, null, Stream.empty());
     renderer.methodGen().loadThis();
     renderer
         .methodGen()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
@@ -438,14 +438,11 @@ public abstract class RootBuilder {
    * <p>No stream variables are available in this context
    */
   public final Renderer rootRenderer(
-      boolean allowUserDefined, String actionName, LoadableValue... captures) {
+      boolean allowUserDefined, String actionName, Stream<LoadableValue> captures) {
     return new RendererNoStream(
         this,
         runMethod,
-        Stream.of(
-                constants(allowUserDefined),
-                Stream.of(actionNameSpecial(actionName)),
-                Stream.of(captures))
+        Stream.of(constants(allowUserDefined), Stream.of(actionNameSpecial(actionName)), captures)
             .flatMap(Function.identity()),
         RootBuilder::invalidSignerEmitter);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
@@ -304,8 +304,10 @@ public class CompiledGenerator implements DefinitionRepository {
                                 A_OLIVE_SERVICES_TYPE,
                                 A_INPUT_PROVIDER_TYPE,
                                 A_OPTIONAL_TYPE,
+                                A_STRING_TYPE,
                                 Type.INT_TYPE,
                                 Type.INT_TYPE,
+                                A_STRING_TYPE,
                                 A_SIGNATURE_ACCESSOR_TYPE),
                             parameterTypes.stream().map(t -> t.apply(TO_ASM)))
                         .toArray(Type[]::new)),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/MonitoredOliveServices.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/MonitoredOliveServices.java
@@ -138,8 +138,17 @@ public final class MonitoredOliveServices implements OliveServices, AutoCloseabl
 
   @Override
   public <T> Stream<T> measureFlow(
-      Stream<T> input, String filename, int line, int column, int oliveLine, int oliveColumn) {
-    return backing.measureFlow(input, filename, line, column, oliveLine, oliveColumn);
+      Stream<T> input,
+      String filename,
+      int line,
+      int column,
+      String hash,
+      String oliveFile,
+      int oliveLine,
+      int oliveColumn,
+      String oliveHash) {
+    return backing.measureFlow(
+        input, filename, line, column, hash, oliveFile, oliveLine, oliveColumn, oliveHash);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/OliveServices.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/OliveServices.java
@@ -23,7 +23,15 @@ public interface OliveServices {
   boolean isOverloaded(String... services);
 
   <T> Stream<T> measureFlow(
-      Stream<T> input, String filename, int line, int column, int oliveLine, int oliveColumn);
+      Stream<T> input,
+      String filename,
+      int line,
+      int column,
+      String hash,
+      String oliveFile,
+      int oliveLine,
+      int oliveColumn,
+      String oliveHash);
 
   void oliveRuntime(String filename, int line, int column, long timeInNs);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -393,7 +393,15 @@ public final class ActionProcessor
   public static final Gauge OLIVE_FLOW =
       Gauge.build(
               "shesmu_olive_data_flow", "The number of items passing through each olive clause.")
-          .labelNames("filename", "line", "column", "olive_line", "olive_column")
+          .labelNames(
+              "filename",
+              "line",
+              "column",
+              "hash",
+              "olive_file",
+              "olive_line",
+              "olive_column",
+              "olive_hash")
           .register();
   private static final Gauge OLIVE_RUN_TIME =
       Gauge.build("shesmu_olive_run_time", "The runtime of an olive in seconds.")
@@ -1040,14 +1048,25 @@ public final class ActionProcessor
 
   @Override
   public <T> Stream<T> measureFlow(
-      Stream<T> input, String fileName, int line, int column, int oliveLine, int oliveColumn) {
+      Stream<T> input,
+      String fileName,
+      int line,
+      int column,
+      String hash,
+      String oliveFile,
+      int oliveLine,
+      int oliveColumn,
+      String oliveHash) {
     final Gauge.Child child =
         OLIVE_FLOW.labels(
             fileName,
             Integer.toString(line),
             Integer.toString(column),
+            hash,
+            oliveFile,
             Integer.toString(oliveLine),
-            Integer.toString(oliveColumn));
+            Integer.toString(oliveColumn),
+            oliveHash);
     final AtomicLong counter = new AtomicLong();
     return input.peek(x -> counter.incrementAndGet()).onClose(() -> child.set(counter.get()));
   }
@@ -1103,15 +1122,26 @@ public final class ActionProcessor
   }
 
   @Override
-  public Long read(String filename, int line, int column, int oliveLine, int oliveColumn) {
+  public Long read(
+      String filename,
+      int line,
+      int column,
+      String hash,
+      String oliveFilename,
+      int oliveLine,
+      int oliveColumn,
+      String oliveHash) {
     return (long)
         OLIVE_FLOW
             .labels(
                 filename,
                 Integer.toString(line),
                 Integer.toString(column),
+                hash,
+                oliveFilename,
                 Integer.toString(oliveLine),
-                Integer.toString(oliveColumn))
+                Integer.toString(oliveColumn),
+                oliveHash)
             .get();
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/HotloadingCompiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/HotloadingCompiler.java
@@ -217,8 +217,10 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
                                                       OliveServices.class,
                                                       InputProvider.class,
                                                       Optional.class,
+                                                      String.class,
                                                       int.class,
                                                       int.class,
+                                                      String.class,
                                                       SignatureAccessor.class),
                                                   parameters.stream().map(Imyhat::javaType))
                                               .toArray(Class[]::new)))

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/MasterRunner.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/MasterRunner.java
@@ -98,9 +98,21 @@ public class MasterRunner {
                 String filename,
                 int line,
                 int column,
+                String hash,
+                String oliveFile,
                 int oliveLine,
-                int oliveColumn) {
-              return services.measureFlow(input, filename, line, column, oliveLine, oliveColumn);
+                int oliveColumn,
+                String oliveHash) {
+              return services.measureFlow(
+                  input,
+                  filename,
+                  line,
+                  column,
+                  hash,
+                  oliveFile,
+                  oliveLine,
+                  oliveColumn,
+                  oliveHash);
             }
 
             @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/MetroDiagram.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/MetroDiagram.java
@@ -30,11 +30,18 @@ public class MetroDiagram {
      * @param filename the file name containing the olive
      * @param line the source line of the clause being measured
      * @param column the source column of the clause being measured
-     * @param oliveLine the source line of the olive
-     * @param oliveColumn the source column of the olive
+     * @param hash the source hash
      * @return the number of rows or null if unknown
      */
-    Long read(String filename, int line, int column, int oliveLine, int oliveColumn);
+    Long read(
+        String filename,
+        int line,
+        int column,
+        String hash,
+        String oliveFilename,
+        int oliveLine,
+        int oliveColumn,
+        String oliveHash);
   }
 
   private static final class DeathChecker implements Predicate<OliveClauseRow> {
@@ -270,8 +277,11 @@ public class MetroDiagram {
                                 filename,
                                 clause.line(),
                                 clause.column(),
+                                hash,
+                                filename,
                                 olive.line(),
-                                olive.column())
+                                olive.column(),
+                                hash)
                             : null,
                         new SourceLocation(filename, clause.line(), clause.column(), hash));
                   } catch (XMLStreamException e) {

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
@@ -106,7 +106,15 @@ public class RunTest {
 
     @Override
     public <T> Stream<T> measureFlow(
-        Stream<T> input, String filename, int line, int column, int oliveLine, int oliveColumn) {
+        Stream<T> input,
+        String filename,
+        int line,
+        int column,
+        String hash,
+        String oliveFile,
+        int oliveLine,
+        int oliveColumn,
+        String oliveHash) {
       return input;
     }
 


### PR DESCRIPTION
This fixes a number of subtle bugs with how line numbers are handled.

- Alerts from `Reject` or `Require` clauses would have the line number of the
  clause rather than the line number of the olive. This prevents the _Olives_
	page from showing any alerts related to the selected olive and makes link
  from the _Alerts_ page to the _Olives_ page fail.
- Data flow counts for `Export Define` olives are reported to Prometheus, but
  in a meaningless way since they are identified by the defining file rather
  than the consuming file. This changes that metric to have both values.

To accomplish this:

- 4 hidden values are created for the file name, column, line, and hash of the
  caller
- `loadOwnerSourceLocation` is replaced by these 4 variables
- `measureFlow` is updated to include the caller filename and hash
- `Define` is updated to include the caller filename and hash
- `Alert` is updated to use these variables instead of harcoded values

This also means that information about what is happening in a `Define` olive is
accessible to the metro diagrams, though they have no way to render it at
present.