### PR TITLE
Make front-end API access type checked

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -48,7 +48,6 @@ import {
 } from "./util.js";
 import { ActionFilter, BasicQuery, createSearch } from "./actionfilters.js";
 import {
-  fetchCustomWithBusyDialog,
   fetchJsonWithBusyDialog,
   loadFile,
   mutableLocalStore,
@@ -264,16 +263,13 @@ export function actionDisplay(
                       () =>
                         fetchJsonWithBusyDialog(
                           "purge",
-                          {
-                            body: JSON.stringify([
-                              {
-                                type: "id",
-                                ids: [action.actionId],
-                              },
-                            ]),
-                            method: "POST",
-                          },
-                          (count: number) => {
+                          [
+                            {
+                              type: "id",
+                              ids: [action.actionId],
+                            },
+                          ],
+                          (count) => {
                             if (count > 1) {
                               dialog(() => [
                                 `Purged ${count} actions!!! This is awkward. The unique action IDs aren't unique!`,
@@ -380,17 +376,10 @@ export function actionDisplay(
               "☠️ Purge Actions",
               "Remove actions from Shesmu. This does not stop an olive from generating them again.",
               () =>
-                fetchJsonWithBusyDialog(
-                  "purge",
-                  {
-                    body: JSON.stringify(filters),
-                    method: "POST",
-                  },
-                  (count: number) => {
-                    butterForPurgeCount(count);
-                    reload();
-                  }
-                )
+                fetchJsonWithBusyDialog("purge", filters, (count) => {
+                  butterForPurgeCount(count);
+                  reload();
+                })
             )
           : blank(),
         response
@@ -476,18 +465,15 @@ function createCallbackForActionCommand(
     fetchJsonWithBusyDialog(
       "command",
       {
-        body: JSON.stringify({
-          command: command.command,
-          filters: [
-            {
-              type: "id",
-              ids: [id],
-            },
-          ] as ActionFilter[],
-        }),
-        method: "POST",
+        command: command.command,
+        filters: [
+          {
+            type: "id",
+            ids: [id],
+          },
+        ],
       },
-      (count: number) => {
+      (count) => {
         if (count == 0) {
           dialog(() => [
             "This action is indifferent to your pleas. Maybe the action's internal state has changed? Try refreshing.",
@@ -529,13 +515,10 @@ function createCallbackForBulkCommand(
     fetchJsonWithBusyDialog(
       "command",
       {
-        body: JSON.stringify({
-          command: command.command,
-          filters: filters,
-        }),
-        method: "POST",
+        command: command.command,
+        filters: filters,
       },
-      (count: number) => {
+      (count) => {
         butter(5000, `The command executed on ${count} actions.`);
         reload();
       }
@@ -776,22 +759,16 @@ export function initialiseActionDash(
                 filters = JSON.parse(search);
               }
               if (filters) {
-                fetchCustomWithBusyDialog(
+                fetchJsonWithBusyDialog(
                   "printquery",
                   {
-                    method: "POST",
-                    body: JSON.stringify({
-                      type: "and",
-                      filters: filters,
-                    } as ActionFilter),
+                    type: "and",
+                    filters: filters,
                   },
-                  (p) =>
-                    p
-                      .then((response) => response.text())
-                      .then((_r) => {
-                        // We don't really want this value from the server, but it has validated the filter for us.
-                        localSearches.set(name, filters!);
-                      })
+                  (_r) => {
+                    // We don't really want this value from the server, but it has validated the filter for us.
+                    localSearches.set(name, filters!);
+                  }
                 );
                 close();
               } else {

--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -606,6 +606,7 @@ export function initialiseActionDash(
     saved: savedSynchonizer,
   } = synchronizerFields(
     historyState(
+      "actiondash",
       {
         filters: userFilters === null ? {} : userFilters,
         saved: savedQueryName || "All Actions",

--- a/shesmu-server-ui/src/alert.ts
+++ b/shesmu-server-ui/src/alert.ts
@@ -1,6 +1,5 @@
 import { fetchJsonWithBusyDialog, refreshable } from "./io.js";
 import {
-  ComplexElement,
   StateSynchronizer,
   UIElement,
   UpdateableList,
@@ -547,9 +546,9 @@ export function initialiseAlertDashboard(
   output: HTMLElement
 ) {
   if (location.hash) {
-    fetchJsonWithBusyDialog<PrometheusAlert | null>(
-      "/getalert",
-      { body: JSON.stringify(location.hash.substring(1)), method: "POST" },
+    fetchJsonWithBusyDialog(
+      "getalert",
+      location.hash.substring(1),
       (selectedAlert) =>
         setRootDashboard(
           output,
@@ -595,12 +594,7 @@ export function initialiseAlertDashboard(
       "main",
       "toolbar"
     );
-    const refresher = refreshable(
-      "/allalerts",
-      (input: string) => ({ method: input }),
-      alertState.model,
-      true
-    );
+    const refresher = refreshable("allalerts", alertState.model, true);
     setRootDashboard(
       output,
       refreshButton(refresher.reload),
@@ -609,7 +603,7 @@ export function initialiseAlertDashboard(
       br(),
       alertState.components.main
     );
-    refresher.statusChanged("GET");
+    refresher.statusChanged(null);
   }
 }
 

--- a/shesmu-server-ui/src/alert.ts
+++ b/shesmu-server-ui/src/alert.ts
@@ -564,6 +564,7 @@ export function initialiseAlertDashboard(
   } else {
     const filterState = synchronizerFields(
       historyState(
+        "alerts",
         {
           filters: loadFilterRegex(initialFilters),
         },

--- a/shesmu-server-ui/src/histogram.ts
+++ b/shesmu-server-ui/src/histogram.ts
@@ -91,9 +91,9 @@ export function histogram(
       rows.forEach((row, rowIndex) => {
         if (row.counts.length != labels.length - 1) {
           throw new Error(
-            `Row ${rowIndex} has ${row.counts.length} but expected ${
-              labels.length - 1
-            }`
+            `Row ${rowIndex} has ${
+              row.counts.length
+            } but expected ${labels.length - 1}`
           );
         }
         const logMax = Math.log(Math.max(...row.counts));

--- a/shesmu-server-ui/src/olive.ts
+++ b/shesmu-server-ui/src/olive.ts
@@ -248,6 +248,7 @@ export function initialiseOliveDash(
   const container = document.getElementById("olives")!;
   const filenameFormatter = commonPathPrefix(oliveFiles.map((f) => f.file));
   const dashboardState = historyState(
+    "olivedash",
     {
       alert: loadFilterRegex(alertFilters || []),
       saved: saved,

--- a/shesmu-server-ui/src/pause.ts
+++ b/shesmu-server-ui/src/pause.ts
@@ -171,10 +171,7 @@ export function initialisePauseDashboard(pauses: Pauses) {
                       () =>
                         fetchJsonWithBusyDialog(
                           pause.line ? "pauseolive" : "pausefile",
-                          {
-                            method: "POST",
-                            body: JSON.stringify({ ...pause, pause: false }),
-                          },
+                          { ...pause, pause: false },
                           (isPause) => {
                             if (!isPause) {
                               refresher.statusChanged(null);
@@ -190,24 +187,18 @@ export function initialisePauseDashboard(pauses: Pauses) {
                       () =>
                         fetchJsonWithBusyDialog(
                           "purge",
-                          {
-                            method: "POST",
-                            body: JSON.stringify([
-                              {
-                                type: "sourcelocation",
-                                locations: [copyLocation(pause)],
-                              },
-                            ]),
-                          },
-                          (count: number) =>
+                          [
+                            {
+                              type: "sourcelocation",
+                              locations: [copyLocation(pause)],
+                            },
+                          ],
+                          (count) =>
                             fetchJsonWithBusyDialog(
                               pause.line ? "pauseolive" : "pausefile",
                               {
-                                method: "POST",
-                                body: JSON.stringify({
-                                  ...pause,
-                                  pause: false,
-                                }),
+                                ...pause,
+                                pause: false,
                               },
                               (isPause) => {
                                 if (!isPause) {
@@ -229,12 +220,7 @@ export function initialisePauseDashboard(pauses: Pauses) {
       : "No pauses set right now.";
   });
 
-  const refresher = refreshable(
-    "pauses",
-    (input: null) => ({ method: "GET" }),
-    selectorTable.model,
-    true
-  );
+  const refresher = refreshable("pauses", selectorTable.model, true);
 
   setRootDashboard(
     document.getElementById("pausedash")!,

--- a/shesmu-server-ui/src/stats.ts
+++ b/shesmu-server-ui/src/stats.ts
@@ -91,7 +91,7 @@ interface StatText {
 /**
  * A statistic value computed by the server
  */
-type Stat = StatCrosstab | StatHistogram | StatTable | StatText;
+export type Stat = StatCrosstab | StatHistogram | StatTable | StatText;
 /**
  * A callback to add a property limit to the existing search filter
  */
@@ -319,15 +319,7 @@ export function actionStats(
       return "No statistics are available.";
     }
   );
-  const io = refreshable(
-    "stats",
-    (filters: ActionFilter[]) => ({
-      body: JSON.stringify(filters),
-      method: "POST",
-    }),
-    model,
-    false
-  );
+  const io = refreshable("stats", model, false);
   return {
     ui: ui,
     model: io,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -2656,11 +2656,10 @@ public final class Server implements ServerConfig, ActionServices {
         t -> {
           final ActionFilter input =
               RuntimeSupport.MAPPER.readValue(t.getRequestBody(), ActionFilter.class);
-          t.getResponseHeaders().set("Content-type", "text/plain");
+          t.getResponseHeaders().set("Content-type", "application/json");
           t.sendResponseHeaders(200, 0);
           try (OutputStream os = t.getResponseBody()) {
-            os.write(
-                input.convert(ActionFilterBuilder.QUERY).first().getBytes(StandardCharsets.UTF_8));
+            RuntimeSupport.MAPPER.writeValue(os, input.convert(ActionFilterBuilder.QUERY).first());
           }
         });
     add("/resume", new EmergencyThrottlerHandler(false));

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/swagger.json
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/swagger.json
@@ -1507,7 +1507,7 @@
         "responses": {
           "200": {
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
                   "type": "string"
                 }


### PR DESCRIPTION
This uses some TypeScript wizardry to define the request and response type of
every API endpoint on the back end so that all access is type checked at
compile time.