### PR TITLE
Add new `barcode_kit` field from v8 Pinery

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/BaseProvenancePluginType.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/BaseProvenancePluginType.java
@@ -73,6 +73,7 @@ public abstract class BaseProvenancePluginType<C extends AutoCloseable>
                   final CerberusFileProvenanceValue result =
                       new CerberusFileProvenanceValue(
                           fp.getFileSWID().toString(),
+                          limsAttr(fp, "barcode_kit", badSetInRecord::add),
                           limsAttr(fp, "cell_viability", badSetInRecord::add)
                               .map(Double::parseDouble),
                           fp.getLastModified().toInstant(),

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusFileProvenanceValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusFileProvenanceValue.java
@@ -14,6 +14,7 @@ import java.util.*;
  */
 public final class CerberusFileProvenanceValue {
   private final String accession;
+  private final Optional<String> barcode_kit;
   private final Optional<Double> cell_viability;
   private final Instant completed_date;
   private final String donor;
@@ -61,6 +62,7 @@ public final class CerberusFileProvenanceValue {
 
   public CerberusFileProvenanceValue(
       String accession,
+      Optional<String> barcode_kit,
       Optional<Double> cell_viability,
       Instant completed_date,
       String donor,
@@ -108,6 +110,7 @@ public final class CerberusFileProvenanceValue {
       Tuple workflow_version) {
     super();
     this.accession = accession;
+    this.barcode_kit = barcode_kit;
     this.cell_viability = cell_viability;
     this.completed_date = completed_date;
     this.donor = donor;
@@ -159,6 +162,11 @@ public final class CerberusFileProvenanceValue {
   @ShesmuVariable
   public String accession() {
     return accession;
+  }
+
+  @ShesmuVariable(signable = true)
+  public Optional<String> barcode_kit() {
+    return barcode_kit;
   }
 
   @ShesmuVariable(signable = true)

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryIUSValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryIUSValue.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 /** IUS information from Pinery */
 public final class PineryIUSValue {
+  private final Optional<String> barcode_kit;
   private final String bases_mask;
   private final Optional<Double> cell_viability;
   private final Optional<Instant> completed_date;
@@ -54,6 +55,7 @@ public final class PineryIUSValue {
   private final boolean umis;
 
   public PineryIUSValue(
+      Optional<String> barcode_kit,
       String bases_mask,
       Optional<Double> cell_viability,
       Optional<Instant> completed_date,
@@ -98,6 +100,7 @@ public final class PineryIUSValue {
       boolean umis,
       boolean is_sample) {
     super();
+    this.barcode_kit = barcode_kit;
     this.bases_mask = bases_mask;
     this.cell_viability = cell_viability;
     this.completed_date = completed_date;
@@ -141,6 +144,11 @@ public final class PineryIUSValue {
     this.tissue_region = tissue_region;
     this.tissue_type = tissue_type;
     this.umis = umis;
+  }
+
+  @ShesmuVariable(signable = true)
+  public Optional<String> barcode_kit() {
+    return barcode_kit;
   }
 
   @ShesmuVariable(signable = true)

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
@@ -125,6 +125,7 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
                 addLane.accept(lp.getSequencerRunName(), lp.getLaneNumber());
 
                 return new PineryIUSValue(
+                    Optional.empty(),
                     run.getRunBasesMask() == null ? "" : run.getRunBasesMask(),
                     Optional.empty(),
                     Optional.ofNullable(lp.getCreatedDate()).map(ZonedDateTime::toInstant),
@@ -199,6 +200,7 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
                 if (run == null) return null;
                 final PineryIUSValue result =
                     new PineryIUSValue(
+                        limsAttr(sp, "barcode_kit", badSetInRecord::add, false),
                         run.getRunBasesMask() == null ? "" : run.getRunBasesMask(),
                         limsAttr(sp, "cell_viability", badSetInRecord::add, false)
                             .map(Double::parseDouble),


### PR DESCRIPTION
Adds the `barcode_kit` field to both `cerberus_fp` and `pinery_ius` as an
optional string.