### PR TITLE
Deal with string truncation

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -821,7 +821,7 @@ public final class WorkflowAction extends Action {
   }
 
   void setAnnotation(String tag, String value) {
-    annotations.putIfAbsent(tag, value);
+    annotations.putIfAbsent(tag, value.length() < 256 ? value : value.substring(0, 255));
   }
 
   private void skipWorkflowRun(int workflowRunSwid, long workflowSwid) {

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
@@ -1863,7 +1863,7 @@ public abstract class Imyhat {
         return parse(input.subSequence(1, input.length()), output, allowEmpty).asOptional();
       case 't':
       case 'o':
-        return parseComplex(input, output, allowEmpty, false);
+        return parseComplex(input, output, allowEmpty, true);
       case 'u':
         int count = 0;
         int index;
@@ -1873,6 +1873,7 @@ public abstract class Imyhat {
         if (count == 0) {
           return BAD;
         }
+        output.set(input.subSequence(index, input.length()));
         final Map<String, Imyhat> unions = new TreeMap<>();
         for (int i = 0; i < count; i++) {
           final StringBuilder name = new StringBuilder();
@@ -1881,8 +1882,13 @@ public abstract class Imyhat {
             name.append(output.get().charAt(dollar));
             dollar++;
           }
-          output.set(output.get().subSequence(dollar + 1, output.get().length()));
-          unions.put(name.toString(), parseComplex(input, output, allowEmpty, true));
+          unions.put(
+              name.toString(),
+              parseComplex(
+                  (output.get().subSequence(dollar + 1, output.get().length())),
+                  output,
+                  allowEmpty,
+                  false));
         }
         return new AlgebraicImyhat(unions);
       default:
@@ -1898,7 +1904,7 @@ public abstract class Imyhat {
       boolean noZero) {
     int count = 0;
     int index;
-    for (index = 1; Character.isDigit(input.charAt(index)); index++) {
+    for (index = 1; index < input.length() && Character.isDigit(input.charAt(index)); index++) {
       count = 10 * count + Character.digit(input.charAt(index), 10);
     }
     if (count == 0 && noZero) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeUtils.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeUtils.java
@@ -224,39 +224,21 @@ public class TypeUtils {
                           new AlgebraicVisitor<String>() {
                             @Override
                             public String empty(String name) {
-                              return "parser.u_e(" + quote(name) + ")";
+                              return quote(name) + ": null";
                             }
 
                             @Override
                             public String object(
                                 String name, Stream<Pair<String, Imyhat>> contents) {
-                              return "parser.u_o("
-                                  + quote(name)
-                                  + ","
-                                  + contents
-                                      .map(
-                                          f ->
-                                              "["
-                                                  + quote(f.first())
-                                                  + ","
-                                                  + f.second().apply(TO_JS_PARSER)
-                                                  + "]")
-                                      .collect(Collectors.joining(","))
-                                  + ")";
+                              return quote(name) + ": " + TO_JS_PARSER.object(contents);
                             }
 
                             @Override
                             public String tuple(String name, Stream<Imyhat> contents) {
-                              return "parser.u_t("
-                                  + quote(name)
-                                  + ","
-                                  + contents
-                                      .map(c -> c.apply(TO_JS_PARSER))
-                                      .collect(Collectors.joining(","))
-                                  + ")";
+                              return quote(name) + ": " + TO_JS_PARSER.tuple(contents);
                             }
                           }))
-              .collect(Collectors.joining(",", "parser.u(", ")"));
+              .collect(Collectors.joining(",", "parser.u({", "})"));
         }
 
         private String quote(String name) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeUtils.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/TypeUtils.java
@@ -242,7 +242,7 @@ public class TypeUtils {
         }
 
         private String quote(String name) {
-          return new String(JsonStringEncoder.getInstance().quoteAsString(name));
+          return "\"" + new String(JsonStringEncoder.getInstance().quoteAsString(name)) + "\"";
         }
 
         @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
@@ -247,6 +247,22 @@ public final class StandardDefinitions implements DefinitionRepository {
             "Remove white space from a string.",
             Imyhat.STRING,
             new FunctionParameter("input to trim", Imyhat.STRING)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "string", "truncate"),
+            RuntimeSupport.class,
+            "truncate",
+            "Truncates a string to a maximum length.",
+            Imyhat.STRING,
+            new FunctionParameter("input string", Imyhat.STRING),
+            new FunctionParameter("maximum length", Imyhat.INTEGER),
+            new FunctionParameter(
+                "method",
+                Imyhat.algebraicTuple("START")
+                    .unify(Imyhat.algebraicTuple("START_ELLIPSIS", Imyhat.STRING))
+                    .unify(Imyhat.algebraicTuple("MIDDLE"))
+                    .unify(Imyhat.algebraicTuple("MIDDLE_ELLIPSIS", Imyhat.STRING))
+                    .unify(Imyhat.algebraicTuple("END"))
+                    .unify(Imyhat.algebraicTuple("END_ELLIPSIS", Imyhat.STRING)))),
         FunctionDefinition.virtualMethod(
             String.join(Parser.NAMESPACE_SEPARATOR, "std", "string", "lower"),
             "toLowerCase",

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
@@ -1,6 +1,7 @@
 package ca.on.oicr.gsi.shesmu.runtime;
 
 import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.AlgebraicValue;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.Utils;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
@@ -606,6 +607,46 @@ public final class RuntimeSupport {
   public static String toString(Instant instant, String format) {
     return DateTimeFormatter.ofPattern(format)
         .format(LocalDateTime.ofInstant(instant, ZoneOffset.UTC));
+  }
+
+  public static String truncate(String input, long maxLength, AlgebraicValue where) {
+    if (input.length() < maxLength) {
+      return input;
+    }
+    switch (where.name()) {
+      case "START":
+        return input.substring(0, (int) maxLength);
+      case "START_ELLIPSIS":
+        final String startEllipsis = (String) where.get(0);
+        if (startEllipsis.length() >= maxLength) {
+          return startEllipsis;
+        }
+        return input.substring(0, (int) maxLength - startEllipsis.length()) + startEllipsis;
+      case "MIDDLE":
+        return input.substring(0, (int) (maxLength / 2))
+            + input.substring((int) (input.length() - maxLength / 2));
+      case "MIDDLE_ELLIPSIS":
+        final String middleEllipsis = (String) where.get(0);
+        if (middleEllipsis.length() >= maxLength) {
+          return middleEllipsis;
+        }
+        final int firstLength = (int) Math.ceil(maxLength / 2.0 - middleEllipsis.length() / 2.0);
+        return input.substring(0, firstLength)
+            + middleEllipsis
+            + input.substring(
+                (int) (input.length() - maxLength + firstLength + middleEllipsis.length()));
+      case "END":
+        return input.substring((int) (input.length() - maxLength));
+      case "END_ELLIPSIS":
+        final String endEllipsis = (String) where.get(0);
+        if (endEllipsis.length() >= maxLength) {
+          return endEllipsis;
+        }
+        return endEllipsis
+            + input.substring((int) (input.length() - maxLength + endEllipsis.length()));
+      default:
+        throw new IllegalArgumentException("Invalid ADT received.");
+    }
   }
 
   /** Determine the union of two sets. */


### PR DESCRIPTION
- Create a `std::string::truncate` function
  This allows truncating a string to a maximum length at the beginning, middle, or end with an optional ellipses inserted.
- Truncate annotations in Niassa to 255 characters (required by the DB)
- Fix bugs parsing algebraic type signatures
- Add missing parser in front end for algebraic types
