### PR TITLE
Fix cast bug with `Require`

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
@@ -155,7 +155,7 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
             & expression.resolve(defs, errorHandler)
             & name.resolve(oliveCompilerServices, errorHandler);
     return defs.replaceStream(
-            Stream.concat(incoming.stream().map(Target::wrap), name.targets()), ok)
+            Stream.concat(incoming.stream().map(Target::softWrap), name.targets()), ok)
         .withProvider(
             UndefinedVariableProvider.combine(
                 name,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
@@ -206,7 +206,10 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
                     .count()
                 == handlers.size();
     return defs.replaceStream(
-            Stream.concat(name.targets(), defs.stream().filter(t -> t.flavour().isStream())), good)
+            Stream.concat(
+                name.targets(),
+                defs.stream().filter(t -> t.flavour().isStream()).map(Target::softWrap)),
+            good)
         .withProvider(
             UndefinedVariableProvider.combine(
                 name,

--- a/shesmu-server/src/test/resources/run/flatten-signature.shesmu
+++ b/shesmu-server/src/test/resources/run/flatten-signature.shesmu
@@ -4,4 +4,5 @@ Input test;
 Olive
  Where project == "the_foo_study"
  Flatten x In stuff
- Run ok With ok = "project" In std::signature::names && x != "";
+ Where library_size > 0
+ Run ok With ok = "project" In std::signature::names && "library_size" In std::signature::names && x != "";

--- a/shesmu-server/src/test/resources/run/require-signature.shesmu
+++ b/shesmu-server/src/test/resources/run/require-signature.shesmu
@@ -1,0 +1,7 @@
+Version 1;
+Input test;
+
+Olive
+ Require x = `project` OnReject Resume
+ Where library_size > 0
+ Run ok With ok = "library_size" In std::signature::names && x != "";


### PR DESCRIPTION
Variable access after `Require` can cause a class cast exception. This is due
to a bug where bytecode is generated assuming the object is in the original
data type instead of the modified wrapper containing the additional variable
introduced by `Require`.