### PR TITLE
Improve `Group By` discriminators

### DIFF
--- a/language.md
+++ b/language.md
@@ -218,11 +218,13 @@ variables.
 
 Discriminators come in multiple forms:
 
-|Syntax                       | Behaviour                                                                                               |
-|---                          |---                                                                                                      |
-| _name_ `=` _expr_           | Compute the value from _expr_ for teach row and use it for grouping; assign it to _name_ in the output. |
-| _name_                      | Use an existing variable _name_ for grouping and copy it to the output.                                 |
-| `@`_gang_                   | Use all variables in a gang for grouping and copy them to the output.                                   |
+|Syntax                       | Behaviour                                                                                                                                                                                       |
+|---                          |---                                                                                                                                                                                              |
+| _name_ `=` _expr_           | Compute the value from _expr_ for each row and use it for grouping; assign it to _name_ in the output. _name_ can use destructuring.                                                            |
+| _name_ `= OnlyIf` _expr_    | Compute the value from _expr_, which must be an optional value, for each row and, if it contains a value, use it for grouping; assign it to _name_ in the output. _name_ can use destructuring. |
+| _name_ `= Univalued` _expr_ | Compute the value from _expr_, which must be a list, for each row and, if it contains a single value, use it for grouping; assign it to _name_ in the output. _name_ can use destructuring.     |
+| _name_                      | Use an existing variable _name_ for grouping and copy it to the output.                                                                                                                         |
+| `@`_gang_                   | Use all variables in a gang for grouping and copy them to the output.                                                                                                                           |
 
 Custom groupers take parameters. Some parameters are per-row, which may use
 variables, and some are fixed, which must use constants or parameters to a

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNode.java
@@ -51,7 +51,7 @@ public abstract class DestructuredArgumentNode implements UndefinedVariableProvi
         }
 
         @Override
-        public Stream<Target> targets() {
+        public Stream<DefinedTarget> targets() {
           return Stream.empty();
         }
 
@@ -172,7 +172,7 @@ public abstract class DestructuredArgumentNode implements UndefinedVariableProvi
 
   public abstract void setFlavour(Target.Flavour flavour);
 
-  public abstract Stream<Target> targets();
+  public abstract Stream<DefinedTarget> targets();
 
   public abstract boolean typeCheck(Imyhat type, Consumer<String> errorHandler);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeConvertedVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeConvertedVariable.java
@@ -138,8 +138,18 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
   private final int line;
   private final String name;
   private boolean read;
-  private final Target target =
-      new Target() {
+  private final DefinedTarget target =
+      new DefinedTarget() {
+        @Override
+        public int column() {
+          return column;
+        }
+
+        @Override
+        public int line() {
+          return line;
+        }
+
         @Override
         public Flavour flavour() {
           return flavour;
@@ -225,7 +235,7 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
   }
 
   @Override
-  public Stream<Target> targets() {
+  public Stream<DefinedTarget> targets() {
     return Stream.of(target);
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeObject.java
@@ -97,7 +97,7 @@ public class DestructuredArgumentNodeObject extends DestructuredArgumentNode {
   }
 
   @Override
-  public Stream<Target> targets() {
+  public Stream<DefinedTarget> targets() {
     return fields.stream().flatMap(f -> f.second().targets());
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeStar.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeStar.java
@@ -13,12 +13,22 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
 
 public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
-  private class StarTarget implements Target {
+  private class StarTarget implements DefinedTarget {
     private final String name;
     private Imyhat type = Imyhat.BAD;
 
     private StarTarget(String name) {
       this.name = name;
+    }
+
+    @Override
+    public int column() {
+      return column;
+    }
+
+    @Override
+    public int line() {
+      return line;
     }
 
     public LoadableValue prepare(Consumer<Renderer> loader) {
@@ -126,7 +136,7 @@ public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
   }
 
   @Override
-  public Stream<Target> targets() {
+  public Stream<DefinedTarget> targets() {
     return fields.values().stream().map(x -> x);
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeTuple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeTuple.java
@@ -92,7 +92,7 @@ public class DestructuredArgumentNodeTuple extends DestructuredArgumentNode {
   }
 
   @Override
-  public Stream<Target> targets() {
+  public Stream<DefinedTarget> targets() {
     return elements.stream().flatMap(DestructuredArgumentNode::targets);
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeVariable.java
@@ -14,8 +14,18 @@ public class DestructuredArgumentNodeVariable extends DestructuredArgumentNode {
   private final String name;
   private boolean read;
   private Imyhat type = Imyhat.BAD;
-  private final Target target =
-      new Target() {
+  private final DefinedTarget target =
+      new DefinedTarget() {
+        @Override
+        public int column() {
+          return column;
+        }
+
+        @Override
+        public int line() {
+          return line;
+        }
+
         @Override
         public Flavour flavour() {
           return flavour;
@@ -96,7 +106,7 @@ public class DestructuredArgumentNodeVariable extends DestructuredArgumentNode {
   }
 
   @Override
-  public Stream<Target> targets() {
+  public Stream<DefinedTarget> targets() {
     return Stream.of(target);
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeBaseManipulated.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeBaseManipulated.java
@@ -1,0 +1,115 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public abstract class DiscriminatorNodeBaseManipulated extends DiscriminatorNode {
+  private Imyhat innerType = Imyhat.BAD;
+  private final ExpressionNode expression;
+  private final DestructuredArgumentNode name;
+
+  public DiscriminatorNodeBaseManipulated(
+      ExpressionNode expression, DestructuredArgumentNode name) {
+    this.expression = expression;
+    this.name = name;
+    name.setFlavour(Target.Flavour.STREAM);
+  }
+
+  @Override
+  public final void collectFreeVariables(Set<String> names, Predicate<Target.Flavour> predicate) {
+    expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public final void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+  }
+
+  protected abstract Imyhat convertType(Imyhat original, Consumer<String> errorHandler);
+
+  @Override
+  public final Stream<VariableInformation> dashboard() {
+    final Set<String> freeStreamVariables = new HashSet<>();
+    expression.collectFreeVariables(freeStreamVariables, Target.Flavour::isStream);
+    return name.targets()
+        .map(
+            target ->
+                new VariableInformation(
+                    target.name(),
+                    expression.type(),
+                    freeStreamVariables.stream(),
+                    VariableInformation.Behaviour.DEFINITION_BY));
+  }
+
+  @Override
+  public void render(RegroupVariablesBuilder builder) {
+    builder.addKeys(
+        name,
+        innerType.apply(TypeUtils.TO_ASM),
+        renderer -> {
+          expression.render(renderer);
+          render(renderer);
+        });
+  }
+
+  protected abstract void render(Renderer renderer);
+
+  @Override
+  public final boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
+    boolean ok = expression.resolve(defs, errorHandler);
+    if (ok) {
+      final Set<String> freeStreamVariables = new HashSet<>();
+      expression.collectFreeVariables(freeStreamVariables, Target.Flavour::isStream);
+      if (freeStreamVariables.isEmpty()) {
+        errorHandler.accept(
+            String.format(
+                "%d:%d: New variable in By does not use any stream variables.",
+                expression.line(), expression.column()));
+        ok = false;
+      }
+    }
+    switch (name.checkWildcard(errorHandler)) {
+      case NONE:
+        return ok;
+      case HAS_WILDCARD:
+        errorHandler.accept(
+            String.format(
+                "%d:%d: Wildcard not permitted in “By”.", expression.line(), expression.column()));
+        return false;
+      case BAD:
+        return false;
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  @Override
+  public final boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return expression.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  @Override
+  public final Stream<DefinedTarget> targets() {
+    return name.targets();
+  }
+
+  @Override
+  public final boolean typeCheck(Consumer<String> errorHandler) {
+    if (!expression.typeCheck(errorHandler)) {
+      return false;
+    }
+    innerType = convertType(expression.type(), errorHandler);
+    if (innerType.isBad()) {
+      return false;
+    } else {
+      return name.typeCheck(innerType, errorHandler);
+    }
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeOnlyIf.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeOnlyIf.java
@@ -1,0 +1,57 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
+import static org.objectweb.asm.Type.BOOLEAN_TYPE;
+
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+
+public class DiscriminatorNodeOnlyIf extends DiscriminatorNodeBaseManipulated {
+
+  private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
+  private static final Type A_OPTIONAL_TYPE = Type.getType(Optional.class);
+  private static final Method METHOD_OPTIONAL__GET =
+      new Method("get", A_OBJECT_TYPE, new Type[] {});
+  private static final Method METHOD_OPTIONAL__sF_PRESENT =
+      new Method("isPresent", BOOLEAN_TYPE, new Type[] {});
+  private final int column;
+  private final int line;
+  private Imyhat type = Imyhat.BAD;
+
+  public DiscriminatorNodeOnlyIf(
+      int line, int column, DestructuredArgumentNode name, ExpressionNode expression) {
+    super(expression, name);
+    this.line = line;
+    this.column = column;
+  }
+
+  @Override
+  protected Imyhat convertType(Imyhat original, Consumer<String> errorHandler) {
+    if (original instanceof Imyhat.OptionalImyhat) {
+      type = ((Imyhat.OptionalImyhat) original).inner();
+      return type;
+    }
+    errorHandler.accept(
+        String.format("%d:%d: Expected optional type but got %s.", line, column, original.name()));
+    return Imyhat.BAD;
+  }
+
+  @Override
+  protected void render(Renderer renderer) {
+    renderer.methodGen().dup();
+    renderer.methodGen().invokeVirtual(A_OPTIONAL_TYPE, METHOD_OPTIONAL__sF_PRESENT);
+    final Label end = renderer.methodGen().newLabel();
+    renderer.methodGen().ifZCmp(GeneratorAdapter.NE, end);
+    renderer.methodGen().visitInsn(Opcodes.ACONST_NULL);
+    renderer.methodGen().returnValue();
+    renderer.methodGen().mark(end);
+    renderer.methodGen().invokeVirtual(A_OPTIONAL_TYPE, METHOD_OPTIONAL__GET);
+    renderer.methodGen().unbox(type.apply(TO_ASM));
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeRename.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeRename.java
@@ -1,114 +1,22 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
-import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation;
-import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
-import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
-public class DiscriminatorNodeRename extends DiscriminatorNode {
+public class DiscriminatorNodeRename extends DiscriminatorNodeBaseManipulated {
 
-  private final ExpressionNode expression;
-  private final DefinedTarget target;
-
-  public DiscriminatorNodeRename(int line, int column, String name, ExpressionNode expression) {
-    this.expression = expression;
-    target =
-        new DefinedTarget() {
-          @Override
-          public int column() {
-            return column;
-          }
-
-          @Override
-          public int line() {
-            return line;
-          }
-
-          @Override
-          public String name() {
-            return name;
-          }
-
-          @Override
-          public Flavour flavour() {
-            return Flavour.STREAM;
-          }
-
-          @Override
-          public void read() {
-            // We don't care if discriminators are read because they are implicitly read by
-            // grouping.
-          }
-
-          @Override
-          public Imyhat type() {
-            return expression.type();
-          }
-        };
+  public DiscriminatorNodeRename(
+      int line, int column, DestructuredArgumentNode name, ExpressionNode expression) {
+    super(expression, name);
   }
 
   @Override
-  public void collectFreeVariables(Set<String> names, Predicate<Target.Flavour> predicate) {
-    expression.collectFreeVariables(names, predicate);
+  protected Imyhat convertType(Imyhat original, Consumer<String> errorHandler) {
+    return original;
   }
 
   @Override
-  public void collectPlugins(Set<Path> pluginFileNames) {
-    expression.collectPlugins(pluginFileNames);
-  }
-
-  @Override
-  public Stream<VariableInformation> dashboard() {
-    final Set<String> freeStreamVariables = new HashSet<>();
-    expression.collectFreeVariables(freeStreamVariables, Target.Flavour::isStream);
-    return Stream.of(
-        new VariableInformation(
-            target.name(),
-            expression.type(),
-            freeStreamVariables.stream(),
-            Behaviour.DEFINITION_BY));
-  }
-
-  @Override
-  public void render(RegroupVariablesBuilder builder) {
-    builder.addKey(expression.type().apply(TypeUtils.TO_ASM), target.name(), expression::render);
-  }
-
-  @Override
-  public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
-    boolean ok = expression.resolve(defs, errorHandler);
-    if (ok) {
-      final Set<String> freeStreamVariables = new HashSet<>();
-      expression.collectFreeVariables(freeStreamVariables, Target.Flavour::isStream);
-      if (freeStreamVariables.isEmpty()) {
-        errorHandler.accept(
-            String.format(
-                "%d:%d: New variable “%s” in By does not use any stream variables.",
-                target.line(), target.column(), target.name()));
-        ok = false;
-      }
-    }
-    return ok;
-  }
-
-  @Override
-  public boolean resolveDefinitions(
-      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
-    return expression.resolveDefinitions(expressionCompilerServices, errorHandler);
-  }
-
-  @Override
-  public Stream<DefinedTarget> targets() {
-    return Stream.of(target);
-  }
-
-  @Override
-  public boolean typeCheck(Consumer<String> errorHandler) {
-    return expression.typeCheck(errorHandler);
+  protected void render(Renderer renderer) {
+    // Do nothing.
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeUnivalued.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DiscriminatorNodeUnivalued.java
@@ -1,0 +1,62 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
+import static org.objectweb.asm.Type.INT_TYPE;
+
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+
+public class DiscriminatorNodeUnivalued extends DiscriminatorNodeBaseManipulated {
+  private static final Type A_ITERATOR_TYPE = Type.getType(Iterator.class);
+  private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
+  private static final Type A_SET_TYPE = Type.getType(Set.class);
+  private static final Method METHOD_ITERATOR__NEXT =
+      new Method("next", A_OBJECT_TYPE, new Type[] {});
+  private static final Method METHOD_SET__ITERATOR =
+      new Method("iterator", A_ITERATOR_TYPE, new Type[] {});
+  private static final Method METHOD_SET__SIZE = new Method("size", INT_TYPE, new Type[] {});
+  private final int column;
+  private final int line;
+  private Imyhat type = Imyhat.BAD;
+
+  public DiscriminatorNodeUnivalued(
+      int line, int column, DestructuredArgumentNode name, ExpressionNode expression) {
+    super(expression, name);
+    this.line = line;
+    this.column = column;
+  }
+
+  @Override
+  protected Imyhat convertType(Imyhat original, Consumer<String> errorHandler) {
+    if (original instanceof Imyhat.ListImyhat) {
+      type = ((Imyhat.ListImyhat) original).inner();
+      return type;
+    } else {
+      errorHandler.accept(
+          String.format("%d:%d: Expected a list type but got %s.", line, column, original.name()));
+      return Imyhat.BAD;
+    }
+  }
+
+  @Override
+  protected void render(Renderer renderer) {
+    renderer.methodGen().dup();
+    renderer.methodGen().invokeInterface(A_SET_TYPE, METHOD_SET__SIZE);
+    renderer.methodGen().push(1);
+    final Label end = renderer.methodGen().newLabel();
+    renderer.methodGen().ifICmp(GeneratorAdapter.EQ, end);
+    renderer.methodGen().visitInsn(Opcodes.ACONST_NULL);
+    renderer.methodGen().returnValue();
+    renderer.methodGen().mark(end);
+    renderer.methodGen().invokeInterface(A_SET_TYPE, METHOD_SET__ITERATOR);
+    renderer.methodGen().invokeInterface(A_ITERATOR_TYPE, METHOD_ITERATOR__NEXT);
+    renderer.methodGen().unbox(type.apply(TO_ASM));
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNode.java
@@ -111,7 +111,7 @@ public abstract class LetArgumentNode implements UndefinedVariableProvider {
   public abstract boolean resolveFunctions(
       ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler);
 
-  public abstract Stream<Target> targets();
+  public abstract Stream<DefinedTarget> targets();
 
   public abstract boolean typeCheck(Consumer<String> errorHandler);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeBaseExpression.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeBaseExpression.java
@@ -81,7 +81,7 @@ public abstract class LetArgumentNodeBaseExpression extends LetArgumentNode {
   }
 
   @Override
-  public final Stream<Target> targets() {
+  public final Stream<DefinedTarget> targets() {
     return name.targets();
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeGang.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodeGang.java
@@ -20,7 +20,7 @@ public final class LetArgumentNodeGang extends LetArgumentNode {
   private final String gangName;
   private final int line;
   // This is a list of input variable to output variable
-  private List<Pair<Target, Target>> targets;
+  private List<Pair<Target, DefinedTarget>> targets;
 
   public LetArgumentNodeGang(int line, int column, String gangName) {
     this.gangName = gangName;
@@ -51,7 +51,7 @@ public final class LetArgumentNodeGang extends LetArgumentNode {
 
   @Override
   public void collectFreeVariables(Set<String> names, Predicate<Target.Flavour> predicate) {
-    for (final Pair<Target, Target> target : targets) {
+    for (final Pair<Target, DefinedTarget> target : targets) {
       if (predicate.test(target.first().flavour())) {
         names.add(target.first().name());
       }
@@ -75,7 +75,7 @@ public final class LetArgumentNodeGang extends LetArgumentNode {
 
   @Override
   public void render(LetBuilder let) {
-    for (final Pair<Target, Target> target : targets) {
+    for (final Pair<Target, DefinedTarget> target : targets) {
       let.add(
           target.first().type().apply(TO_ASM),
           target.first().name(),
@@ -87,7 +87,7 @@ public final class LetArgumentNodeGang extends LetArgumentNode {
 
   @Override
   public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
-    final Optional<List<Pair<Target, Target>>> results =
+    final Optional<List<Pair<Target, DefinedTarget>>> results =
         TypeUtils.matchGang(
             line,
             column,
@@ -97,7 +97,17 @@ public final class LetArgumentNodeGang extends LetArgumentNode {
               unusedNames.add(inputTarget.name());
               return new Pair<>(
                   inputTarget,
-                  new Target() {
+                  new DefinedTarget() {
+                    @Override
+                    public int column() {
+                      return column;
+                    }
+
+                    @Override
+                    public int line() {
+                      return line;
+                    }
+
                     @Override
                     public Flavour flavour() {
                       return Flavour.STREAM;
@@ -141,7 +151,7 @@ public final class LetArgumentNodeGang extends LetArgumentNode {
   }
 
   @Override
-  public Stream<Target> targets() {
+  public Stream<DefinedTarget> targets() {
     return targets.stream().map(Pair::second);
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodePrefix.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LetArgumentNodePrefix.java
@@ -10,11 +10,21 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class LetArgumentNodePrefix extends LetArgumentNode {
-  private class PrefixTarget implements Target {
+  private class PrefixTarget implements DefinedTarget {
     public final Target backing;
 
     private PrefixTarget(Target backing) {
       this.backing = backing;
+    }
+
+    @Override
+    public int column() {
+      return column;
+    }
+
+    @Override
+    public int line() {
+      return line;
     }
 
     @Override
@@ -132,7 +142,7 @@ public class LetArgumentNodePrefix extends LetArgumentNode {
   }
 
   @Override
-  public Stream<Target> targets() {
+  public Stream<DefinedTarget> targets() {
     return targets.stream().map(x -> x);
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MonitorArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MonitorArgumentNode.java
@@ -115,7 +115,7 @@ public final class MonitorArgumentNode {
         & name.resolve(expressionCompilerServices, errorHandler);
   }
 
-  public Stream<Target> target() {
+  public Stream<DefinedTarget> target() {
     return name.targets();
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveArgumentNode.java
@@ -205,7 +205,7 @@ public abstract class OliveArgumentNode implements UndefinedVariableProvider {
   }
 
   /** The argument name */
-  public final Stream<Target> targets() {
+  public final Stream<DefinedTarget> targets() {
     return name.targets();
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
@@ -509,12 +509,19 @@ public final class RuntimeSupport {
    *
    * @param input the stream of input items
    * @param grouper a way to create subgroups for each outer group.
-   * @param makeKey a value for a key that is common across the bulk groups
+   * @param makeKey a value for a key that is common across the bulk groups; if it returns null, it
+   *     should be skipped
    */
   @RuntimeInterop
   public static <I, O> Stream<O> regroup(
       Stream<I> input, Grouper<I, O> grouper, Function<I, O> makeKey) {
-    final Map<O, List<I>> groups = input.collect(Collectors.groupingBy(makeKey));
+    final Map<O, List<I>> groups =
+        input
+            .map(i -> new Pair<>(makeKey.apply(i), i))
+            .filter(p -> p.first() != null)
+            .collect(
+                Collectors.groupingBy(
+                    Pair::first, Collectors.mapping(Pair::second, Collectors.toList())));
     input.close();
     return groups
         .values()
@@ -540,19 +547,26 @@ public final class RuntimeSupport {
    *     </ul>
    *
    * @param input the stream to consume
-   * @param makeKey the constructor that makes an output item for an input item
+   * @param makeKey the constructor that makes an output item for an input item; if it returns null,
+   *     it should be skipped
    * @param collector a function that adds all of the “collected” input data to an output value
    * @return the grouped output stream
    */
   @RuntimeInterop
   public static <I, O> Stream<O> regroup(
       Stream<I> input, Function<I, O> makeKey, BiConsumer<O, I> collector) {
-    final Map<O, List<I>> groups = input.collect(Collectors.groupingBy(makeKey));
+    final Map<O, List<I>> groups =
+        input
+            .map(i -> new Pair<>(makeKey.apply(i), i))
+            .filter(p -> p.first() != null)
+            .collect(
+                Collectors.groupingBy(
+                    Pair::first, Collectors.mapping(Pair::second, Collectors.toList())));
     input.close();
     return groups
         .entrySet()
         .stream()
-        .peek(e -> e.getValue().stream().forEach(x -> collector.accept(e.getKey(), x)))
+        .peek(e -> e.getValue().forEach(x -> collector.accept(e.getKey(), x)))
         .map(Entry::getKey);
   }
 

--- a/shesmu-server/src/test/resources/compiler/bad-group-by-rename.errors
+++ b/shesmu-server/src/test/resources/compiler/bad-group-by-rename.errors
@@ -1,1 +1,1 @@
-6:6: New variable “p” in By does not use any stream variables.
+6:10: New variable in By does not use any stream variables.

--- a/shesmu-server/src/test/resources/run/group-all.shesmu
+++ b/shesmu-server/src/test/resources/run/group-all.shesmu
@@ -3,7 +3,7 @@ Input test;
 
 Olive
  Group
-  By project
+  By project = Univalued [project]
   Into
     z = All library_size < 400
  Run ok With ok = z;

--- a/shesmu-server/src/test/resources/run/group-any.shesmu
+++ b/shesmu-server/src/test/resources/run/group-any.shesmu
@@ -3,7 +3,7 @@ Input test;
 
 Olive
  Group
-  By project
+  By project = OnlyIf `project`
   Into
     x = Where library_size == 307 First path,
     y = Where library_size == 300 First path,

--- a/shesmu-server/src/test/resources/run/group-by-filtered.shesmu
+++ b/shesmu-server/src/test/resources/run/group-by-filtered.shesmu
@@ -1,0 +1,9 @@
+Version 1;
+Input test;
+
+Olive
+ Group
+  By project = OnlyIf If library_size == 300 Then `project` Else ``
+  Into
+    z = Count
+ Run ok With ok = z == 1;


### PR DESCRIPTION
This makes two improvements:
- It allows the name used in renaming to destructure (_e.g._, `By {run, lane, _} = ius` is legal)
- It allows filtering out data using `OnlyIf` and `Univalued`