### PR TITLE
Show number of definitions in _Extra Definitions_ tab

### DIFF
--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -177,7 +177,7 @@ type SynchronizedFields<T> = {
  */
 export interface Tab {
   /** The header title for the tab */
-  name: DisplayElement;
+  name: UIElement;
   /** The contents the body of the tab */
   contents: UIElement;
   /** If true, this tab will be selected by default*/
@@ -1961,6 +1961,38 @@ export function singleState<T>(
   return {
     model: mapModel(model, formatter),
     ui: ui,
+  };
+}
+
+/**
+ * Create a little read circle with a number in it
+ * @param title a callback to generate a tooltip for the current count
+ */
+export function spotCounter(
+  title: (input: number) => string
+): { ui: UIElement; model: StatefulModel<number> } {
+  const element = createUiFromTag("span");
+  element.element.className = "spot";
+  return {
+    ui: element,
+    model: {
+      reload: () => {},
+      statusChanged: (input) => {
+        element.element.className = input ? "spot" : "nospot";
+        element.element.innerText = input.toString();
+        element.element.title = title(input);
+      },
+      statusFailed: (message, _retry) => {
+        element.element.className = "spot";
+        element.element.innerText = "?";
+        element.element.title = message;
+      },
+      statusWaiting: () => {
+        element.element.className = "spot";
+        element.element.innerText = "";
+        element.element.title = "Count is being refreshed";
+      },
+    },
   };
 }
 

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -292,7 +292,7 @@ function addElements(
               const element = createUiFromTag("span", result.contents);
               // Safe to discard find and reveal since only display elements should be present
               target.appendChild(element.element);
-              element.element.style.fontFamily = "mono-space";
+              element.element.style.fontFamily = "monospace";
             }
             break;
 

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -42,6 +42,7 @@ import {
   tile,
   svgFromStr,
   spotCounter,
+  link,
 } from "./html.js";
 import {
   MutableStore,
@@ -358,7 +359,12 @@ export function initialiseSimulationDashboard(
     },
     {
       name: ["Extra Definitions", spot.ui],
-      contents: group(
+      contents: [
+        link("actiondefs", "All actions known"),
+        " to the Shesmu server are available in simulation. If testing something that is not yet available or needs to be modified, the action definition can be imported here. Actions here take priority over actions from the server. If exporting actions to ",
+        mono(".actnow"),
+        " files, do not use actions definitions here or the server will not recognise them.",
+        br(),
         button("➕ Import Action", "Uploads a file containing an action.", () =>
           loadFile((name, data) =>
             importAction(fakeActionDefinitions, name.split(".")[0], data)
@@ -379,8 +385,9 @@ export function initialiseSimulationDashboard(
             ];
           })
         ),
-        fakeActionsUi
-      ),
+        br(),
+        fakeActionsUi,
+      ],
     }
   );
   const dashboardState = mapModel(

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -41,6 +41,7 @@ import {
   text,
   tile,
   svgFromStr,
+  spotCounter,
 } from "./html.js";
 import {
   MutableStore,
@@ -285,9 +286,28 @@ export function initialiseSimulationDashboard(
         ]
       )
   );
+  const spot = spotCounter((c) => {
+    switch (c) {
+      case 0:
+        return "No local action defintions";
+      case 1:
+        return "One local action defintion.";
+      default:
+        return `${c} local action definitions`;
+    }
+  });
   fakeActionDefinitions = mutableStoreWatcher(
     mutableLocalStore<FakeActionParameters>("shesmu_fake_actions"),
-    fakeActionsModel
+    combineModels(
+      fakeActionsModel,
+      mapModel(spot.model, (fakeActions) => {
+        let c = 0;
+        for (const _fa of fakeActions) {
+          c++;
+        }
+        return c;
+      })
+    )
   );
   const script = document.createElement("DIV");
   script.className = "editor";
@@ -337,7 +357,7 @@ export function initialiseSimulationDashboard(
       ),
     },
     {
-      name: "Extra Definitions",
+      name: ["Extra Definitions", spot.ui],
       contents: group(
         button("➕ Import Action", "Uploads a file containing an action.", () =>
           loadFile((name, data) =>

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -915,3 +915,20 @@ img.deadolive {
   border: 1px dotted var(--widget-highlight);
   padding: 0.5em;
 }
+
+.spot {
+  background-color: var(--widget-danger-lowlight);
+  color: var(--widget-danger-negative);
+}
+.nospot {
+  background-color: var(--widget-danger-shadow);
+  color: var(--widget-danger-lowlight);
+}
+.spot,
+.nospot {
+  font-size: 70%;
+  vertical-align: top;
+  border-radius: 50%;
+  padding: 0.2em;
+  margin: 0.2em;
+}


### PR DESCRIPTION
There have been a number of cases where someone had trouble with the simulator
because they had a fake action defintion present that was changing the results
in an unexpected way. This adds a small counter spot to the tab title to
indicate if fake action definitions are present.