### PR TITLE
Fix date formatter

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/StringNode.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
  * <p>Either a string literal or an expression that can be converted to a string literal
  */
 public abstract class StringNode {
-  private static final Pattern DATE_FORMAT = Pattern.compile("^[GyMdhHmsSEDFwWakKz]");
+  private static final Pattern DATE_FORMAT = Pattern.compile("^[GyYMdhHmsSEDFwWakKz]+");
   private static final Pattern ESCAPE = Pattern.compile("^\\\\([\\\\\"nt{}])");
   private static final Pattern LITERAL = Pattern.compile("^[^\\\\\"{]+");
   private static final Parser.ParseDispatch<StringNode> PARTS = new Parser.ParseDispatch<>();

--- a/shesmu-server/src/test/resources/run/date.shesmu
+++ b/shesmu-server/src/test/resources/run/date.shesmu
@@ -1,0 +1,4 @@
+Version 1;
+Input test;
+
+Olive Run ok With ok = "{std::date::epoch:YYYY}" == "1970";


### PR DESCRIPTION
The regular expression for date codes was missing `Y` and didn't allow multiple
repeats.