### PR TITLE
Fix _Callable Definitions_ page

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -622,7 +622,7 @@ public final class Server implements ServerConfig, ActionServices {
 
               @Override
               protected void renderContent(XMLStreamWriter writer) throws XMLStreamException {
-                definitionRepository
+                compiler
                     .oliveDefinitions()
                     .sorted(Comparator.comparing(CallableDefinition::name))
                     .forEach(
@@ -635,7 +635,18 @@ public final class Server implements ServerConfig, ActionServices {
 
                             writer.writeStartElement("table");
                             writer.writeAttribute("class", "even");
+
                             showSourceConfig(writer, oliveDefinition.filename());
+
+                            writer.writeStartElement("tr");
+                            writer.writeStartElement("td");
+                            writer.writeCharacters("Input Format");
+                            writer.writeEndElement();
+                            writer.writeStartElement("td");
+                            writer.writeCharacters(oliveDefinition.format());
+                            writer.writeEndElement();
+                            writer.writeEndElement();
+
                             writer.writeStartElement("tr");
                             writer.writeStartElement("td");
                             writer.writeCharacters("Output Format");
@@ -662,6 +673,8 @@ public final class Server implements ServerConfig, ActionServices {
                             }
                             writer.writeEndElement();
 
+                            writer.writeStartElement("table");
+                            writer.writeAttribute("class", "even");
                             TableRowWriter row = new TableRowWriter(writer);
                             oliveDefinition
                                 .outputStreamVariables(null, null)

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveDefineBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveDefineBuilder.java
@@ -143,20 +143,25 @@ public final class OliveDefineBuilder extends BaseOliveBuilder
           }
           getter.returnValue();
           getter.endMethod();
-          final GeneratorAdapter signerCheck =
-              new GeneratorAdapter(
-                  Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
-                  new Method(
-                      String.format("%s %s Signer Check", method.getName(), variable.name()),
-                      Type.getMethodDescriptor(Type.BOOLEAN_TYPE)),
-                  null,
-                  null,
-                  owner.classVisitor);
-          signerCheck.visitCode();
-          signerCheck.push(signedVariables.contains(variable.name()));
-          signerCheck.returnValue();
-          signerCheck.endMethod();
         });
+    initialFormat
+        .baseStreamVariables()
+        .forEach(
+            variable -> {
+              final GeneratorAdapter signerCheck =
+                  new GeneratorAdapter(
+                      Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                      new Method(
+                          String.format("%s %s Signer Check", method.getName(), variable.name()),
+                          Type.getMethodDescriptor(Type.BOOLEAN_TYPE)),
+                      null,
+                      null,
+                      owner.classVisitor);
+              signerCheck.visitCode();
+              signerCheck.push(signedVariables.contains(variable.name()));
+              signerCheck.returnValue();
+              signerCheck.endMethod();
+            });
   }
 
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -341,6 +341,11 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
   }
 
   @Override
+  protected void setPurity(ClauseStreamOrder state) {
+    // Do nothing.
+  }
+
+  @Override
   public boolean skipCheckUnusedDeclarations() {
     return false;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
@@ -18,12 +18,11 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
   private final int column;
   private final boolean export;
   private String inputFormat;
+  private boolean isRoot;
   private final int line;
   private final String name;
   private List<Target> outputStreamVariables;
-
   private final List<OliveParameter> parameters;
-
   private boolean resolveLock;
 
   public OliveNodeDefinition(
@@ -84,14 +83,14 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
   }
 
   @Override
-  public Stream<OliveTable> dashboard() {
-    return Stream.empty();
-  }
-
-  @Override
   public void collectSignables(
       Set<String> signableNames, Consumer<SignableVariableCheck> addSignableCheck) {
     signableNames.addAll(this.signableNames);
+  }
+
+  @Override
+  public Stream<OliveTable> dashboard() {
+    return Stream.empty();
   }
 
   @Override
@@ -110,7 +109,7 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
   }
 
   public boolean isRoot() {
-    return clauses().stream().noneMatch(OliveClauseNodeGroup.class::isInstance);
+    return isRoot;
   }
 
   @Override
@@ -203,11 +202,6 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
   }
 
   @Override
-  public boolean skipCheckUnusedDeclarations() {
-    return export;
-  }
-
-  @Override
   public boolean resolveTypes(
       OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler) {
     return parameters
@@ -215,6 +209,16 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
             .filter(p -> p.resolveTypes(oliveCompilerServices, errorHandler))
             .count()
         == parameters.size();
+  }
+
+  @Override
+  protected void setPurity(ClauseStreamOrder state) {
+    isRoot = state != ClauseStreamOrder.TRANSFORMED;
+  }
+
+  @Override
+  public boolean skipCheckUnusedDeclarations() {
+    return export;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRefill.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRefill.java
@@ -279,6 +279,11 @@ public final class OliveNodeRefill extends OliveNodeWithClauses {
   }
 
   @Override
+  protected void setPurity(ClauseStreamOrder state) {
+    // Do nothing.
+  }
+
+  @Override
   public boolean skipCheckUnusedDeclarations() {
     return false;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeRun.java
@@ -287,6 +287,11 @@ public final class OliveNodeRun extends OliveNodeWithClauses {
   }
 
   @Override
+  protected void setPurity(ClauseStreamOrder state) {
+    // Do nothing.
+  }
+
+  @Override
   public boolean skipCheckUnusedDeclarations() {
     return false;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeWithClauses.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeWithClauses.java
@@ -42,6 +42,7 @@ public abstract class OliveNodeWithClauses extends OliveNode {
     if (state == ClauseStreamOrder.PURE || state == ClauseStreamOrder.ALMOST_PURE) {
       collectArgumentSignableVariables();
     }
+    setPurity(state);
     return state != ClauseStreamOrder.BAD;
   }
 
@@ -98,6 +99,8 @@ public abstract class OliveNodeWithClauses extends OliveNode {
   /** Do any further non-variable definition resolution specific to this class */
   protected abstract boolean resolveDefinitionsExtra(
       OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler);
+
+  protected abstract void setPurity(ClauseStreamOrder state);
 
   public abstract boolean skipCheckUnusedDeclarations();
 


### PR DESCRIPTION
It was reading from the plugin source, not the compiler, so it was not showing
callable definitions exported by olives, which is the only source for callable
definitions.