### PR TITLE
Clear counts for `.actnow` files when deleted

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/StaticActions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/StaticActions.java
@@ -36,7 +36,9 @@ public class StaticActions implements LoadedConfiguration {
 
     @Override
     public void stop() {
-      // Do nothing.
+      // Reset counts for this file
+      processedCount.labels(fileName().toString()).set(0);
+      totalCount.labels(fileName().toString()).set(0);
     }
 
     @Override


### PR DESCRIPTION
This sets the counts for `.actnow` files to zero, to avoid alert confusion if a
broken `.actnow` file is deleted.