### PR TITLE
Fix table menu filter lifetime

### DIFF
--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -2063,27 +2063,26 @@ export function dropdownTable<T, S>(
   );
   const container = createUiFromTag("span", activeElement.ui, " ▼");
   container.element.className = "dropdown";
-  const searchFilters: ((keywords: string[]) => void)[] = [];
-  const inputFilter = inputSearch((input) => {
-    const keywords = input
-      .toLowerCase()
-      .split(/\W+/)
-      .filter((s) => s);
-    for (const searchFilter of searchFilters) {
-      searchFilter(keywords);
-    }
-  });
   container.element.addEventListener(
     "click",
     popup(
       "tablemenu",
       true,
-      (close) =>
-        items.length == 0
+      (close) => {
+        const searchFilters: ((keywords: string[]) => void)[] = [];
+        return items.length == 0
           ? "No items."
           : [
               "Filter: ",
-              inputFilter,
+              inputSearch((input) => {
+                const keywords = input
+                  .toLowerCase()
+                  .split(/\W+/)
+                  .filter((s) => s);
+                for (const searchFilter of searchFilters) {
+                  searchFilter(keywords);
+                }
+              }),
               br(),
               items.map(({ value, label, children }) => {
                 const groupLabel = createUiFromTag("p", label);
@@ -2147,7 +2146,8 @@ export function dropdownTable<T, S>(
                 });
                 return block;
               }),
-            ],
+            ];
+      },
       () => {}
     )
   );


### PR DESCRIPTION
The table menu used on the _Olives_ page has incorrectly scoped state. The
filter box is recycled between dropdowns of the menu, but the effects of the
filter are not, causing it to look like it should be filtered even though it
isn't. This adjust the scope of that information to disappear when the dropdown
is closed.