### PR TITLE
Allow ignoring unused variables in simulation

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
@@ -102,6 +102,7 @@ public abstract class Compiler {
         signatures,
         exportConsumer,
         dashboardOutput,
+        false,
         false);
   }
   /**
@@ -122,7 +123,8 @@ public abstract class Compiler {
       Supplier<Stream<SignatureDefinition>> signatures,
       ExportConsumer exportConsumer,
       Consumer<FileTable> dashboardOutput,
-      boolean allowDuplicates) {
+      boolean allowDuplicates,
+      boolean allowUnused) {
     final AtomicReference<ProgramNode> program = new AtomicReference<>();
     final String hash;
     try {
@@ -149,7 +151,8 @@ public abstract class Compiler {
                 this::errorHandler,
                 constants,
                 signatures,
-                allowDuplicates)) {
+                allowDuplicates,
+                allowUnused)) {
       final Instant compileTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
       if (dashboardOutput != null && skipRender) {
         dashboardOutput.accept(program.get().dashboard(path, hash, "Bytecode not available."));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
@@ -175,7 +175,8 @@ public class ProgramNode {
       Consumer<String> errorHandler,
       Supplier<Stream<ConstantDefinition>> constants,
       Supplier<Stream<SignatureDefinition>> signatures,
-      boolean allowDuplicates) {
+      boolean allowDuplicates,
+      boolean allowUnused) {
 
     inputFormatDefinition = inputFormatDefinitions.apply(input);
     if (inputFormatDefinition == null) {
@@ -347,8 +348,9 @@ public class ProgramNode {
     // Check for unused definitions
     ok =
         ok
-            && olives.stream().filter(olive -> olive.checkUnusedDeclarations(errorHandler)).count()
-                == olives.size();
+            && (olives.stream().filter(olive -> olive.checkUnusedDeclarations(errorHandler)).count()
+                    == olives.size()
+                || allowUnused);
     return ok;
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/HotloadingCompiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/HotloadingCompiler.java
@@ -69,7 +69,8 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
           new String(Files.readAllBytes(fileName), StandardCharsets.UTF_8),
           exportConsumer,
           dashboardConsumer,
-          registerImport);
+          registerImport,
+          false);
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -81,7 +82,8 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
       String contents,
       LiveExportConsumer exportConsumer,
       Consumer<FileTable> dashboardConsumer,
-      Consumer<ImportVerifier> registerImport) {
+      Consumer<ImportVerifier> registerImport,
+      boolean allowUnused) {
     try {
       errors.clear();
       final Compiler compiler =
@@ -304,7 +306,8 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
             }
           },
           dashboardConsumer,
-          false)) {
+          false,
+          allowUnused)) {
         final ActionGenerator generator = load(ActionGenerator.class, "dyn.shesmu.Program");
         for (final Consumer<ActionGenerator> export : exports) {
           export.accept(generator);


### PR DESCRIPTION
Requiring all variables be used is cumbersome when developing; this change
allows variables to be unused during development. It also changes the
simulation UI to remember whether to wait for fresh data or use cached data and
presents all of these options in a more consistent way. It also drops the
`/checkhtml` endpoint, which was a sadder version of the simulator that is no
longer used.