### PR TITLE
Replace deprecated `keyCode`

### DIFF
--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -1683,6 +1683,18 @@ export function buttonIcon(
 }
 
 /**
+ * Check if a control/command key is pressed
+ * @param e the event
+ * @param key the letter to check for
+ */
+export function checkKey(e: KeyboardEvent, key: string): boolean {
+  return (
+    (window.navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey) &&
+    e.key === key
+  );
+}
+
+/**
  * Display a panel that requires the user to enter a random substitution code.
  */
 export function checkRandomPermutation(
@@ -2953,7 +2965,7 @@ export function setRootDashboard(
   window.addEventListener("keydown", (e) => {
     if (
       findOverride &&
-      (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) &&
+      (e.key == "F3" || e.key == "Find" || checkKey(e, "f")) &&
       findOverride()
     ) {
       e.preventDefault();

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -18,6 +18,7 @@ import {
   button,
   buttonAccessory,
   buttonClose,
+  checkKey,
   collapsible,
   dialog,
   dropdown,
@@ -764,10 +765,7 @@ export function initialiseSimulationDashboard(
     "keydown",
     (e) => {
       // Map Ctrl-S or Command-S to download/save
-      if (
-        (window.navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey) &&
-        e.keyCode == 83
-      ) {
+      if (checkKey(e, "s")) {
         e.preventDefault();
         saveFile(editor.getValue(), "text/plain", fileName);
       }


### PR DESCRIPTION
The keyboard event's `keyCode` property has been superceded by `key`. This
replaces the uses.