### PR TITLE
Improve type safety of algebraic types comparisons

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeComparison.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeComparison.java
@@ -81,7 +81,13 @@ public class ExpressionNodeComparison extends ExpressionNode {
   public boolean typeCheck(Consumer<String> errorHandler) {
     final boolean ok = left.typeCheck(errorHandler) & right.typeCheck(errorHandler);
     if (ok) {
-      if (!left.type().isSame(right.type())) {
+      // This logic is a bit funky because in the case of an algebraic type FOO
+      // == BAR should be an invalid comparison, but because they are both ADT,
+      // they are considered mergable (isSame). So, we check that either side
+      // is a subset, so if x is FOO or BAR, then x == FOO || FOO == x is
+      // valid, but x == BAZ || BAZ == x is not.
+      if (!left.type().isAssignableFrom(right.type())
+          && !right.type().isAssignableFrom(left.type())) {
         typeError(left.type(), right.type(), errorHandler);
         return false;
       }

--- a/shesmu-server/src/test/resources/compiler/bad-algebraic-compare.errors
+++ b/shesmu-server/src/test/resources/compiler/bad-algebraic-compare.errors
@@ -1,0 +1,1 @@
+5:14: Expected FOO, but got BAR.

--- a/shesmu-server/src/test/resources/compiler/bad-algebraic-compare.shesmu
+++ b/shesmu-server/src/test/resources/compiler/bad-algebraic-compare.shesmu
@@ -1,0 +1,5 @@
+Version 1;
+Input test;
+
+Export Function x(boolean x)
+  x && FOO == BAR;


### PR DESCRIPTION
When doing a comparison (`==`, `!=`) of an algebraic type, `FOO == BAR` should
be an invalid comparison, but because they are both ADT, they are considered
mergable (`Imyhat.isSame`). This change the check such that one side must a
subset of the other, so if `x` is `FOO | BAR`, then `x == FOO` or `FOO == x` is
valid, but `x == BAZ` and `BAZ == x` are not.