### PR TITLE
Persist state to local storage after deleting

### DIFF
--- a/shesmu-server-ui/src/io.ts
+++ b/shesmu-server-ui/src/io.ts
@@ -281,9 +281,11 @@ export function mutableLocalStore<T>(
   return {
     clear(): void {
       original = {};
+      localStorage.setItem(storageKey, JSON.stringify(original));
     },
     delete(key: string): void {
       delete original[key];
+      localStorage.setItem(storageKey, JSON.stringify(original));
     },
     get(key: string): T | undefined {
       return original[key];


### PR DESCRIPTION
Fixes a bug where deleting entries did not trigger a write back to local
storage. This affected _Extra Definitions_ in the simulator and the saved
searches on the _Actions_ page.