### PR TITLE
Change SVG figures

### DIFF
--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -3426,12 +3426,20 @@ export function subscribedState<T>(
 
 export function svgFromStr(data: string): UIElement {
   const svg = new window.DOMParser().parseFromString(data, "image/svg+xml");
-  return {
-    element: document.adoptNode(svg.documentElement),
-    reveal: null,
-    find: null,
-    type: "ui",
-  };
+  return [
+    buttonAccessory(
+      { type: "icon", icon: "download" },
+      "Download diagram.",
+      () => saveFile(data, "image/svg+xml", "diagram.svg")
+    ),
+    br(),
+    {
+      element: document.adoptNode(svg.documentElement),
+      reveal: null,
+      find: null,
+      type: "ui",
+    },
+  ];
 }
 /**
  * Display a table from the supplied items.

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/MetroDiagram.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/MetroDiagram.java
@@ -452,7 +452,9 @@ public class MetroDiagram {
       writer.writeAttribute("text-anchor", "end");
       writer.writeAttribute("x", Long.toString(SVG_COUNT_START));
       writer.writeAttribute(
-          "y", Long.toString(topPadding + SVG_ROW_HEIGHT * row + SVG_TEXT_BASELINE));
+          "y",
+          Long.toString(
+              topPadding + SVG_ROW_HEIGHT * row + SVG_TEXT_BASELINE + SVG_ROW_HEIGHT / 2));
       writer.writeCharacters(Long.toString(count));
       writer.writeEndElement();
     }


### PR DESCRIPTION
* Add a button to download SVG diagrams
  This works on both the _Olives_ page and the simulator.
* Move counts down in metro diagrams
 The counts in the metro diagrams are the number of output records and this can be difficult to recognise. This shifts all the counts down by a half row so that the count is between the clause that produced and the clause that consumed it.
