### PR TITLE
Update saved searches

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -123,7 +123,7 @@ type SearchDefinition = [string, ActionFilter[]];
 /**
  * The format of searches provided by the server
  */
-type ServerSearches = { [name: string]: ActionFilter[] };
+export type ServerSearches = { [name: string]: ActionFilter[] };
 /**
  * The status of an action
  */

--- a/shesmu-server-ui/src/actionfilters.ts
+++ b/shesmu-server-ui/src/actionfilters.ts
@@ -1271,7 +1271,7 @@ function searchAdvanced(
   };
   return {
     buttons: [
-      button(
+      buttonAccessory(
         [{ type: "icon", icon: "mouse" }, "Basic"],
         "Switch to basic query interface. Current query will be lost.",
         () => {
@@ -1310,7 +1310,7 @@ function searchAdvanced(
           }
         }
       ),
-      buttonAccessory(
+      button(
         [{ type: "icon", icon: "funnel" }, "Add Filter"],
         "Add a filter to limit the actions displayed.",
         () => {
@@ -1630,6 +1630,18 @@ function searchBasic(
   return {
     buttons: [
       buttonAccessory(
+        [{ type: "icon", icon: "keyboard-fill" }, "Advanced"],
+        "Switch to advanced query interface. Query will be saved, but cannot be converted back.",
+        () =>
+          promiseModel(synchronizer).statusChanged(
+            fetchAsPromise("printquery", {
+              type: "and",
+              filters: createFilters(current),
+            })
+          )
+      ),
+
+      button(
         [{ type: "icon", icon: "funnel" }, "Add Filter"],
         "Add a filter to limit the actions displayed.",
         () =>
@@ -1703,18 +1715,6 @@ function searchBasic(
               ].concat(current.regex || []);
               searchModel.statusChanged({ ...current });
             }
-          )
-      ),
-
-      button(
-        [{ type: "icon", icon: "keyboard-fill" }, "Advanced"],
-        "Switch to advanced query interface. Query will be saved, but cannot be converted back.",
-        () =>
-          promiseModel(synchronizer).statusChanged(
-            fetchAsPromise("printquery", {
-              type: "and",
-              filters: createFilters(current),
-            })
           )
       ),
       buttonAccessory(

--- a/shesmu-server-ui/src/actionfilters.ts
+++ b/shesmu-server-ui/src/actionfilters.ts
@@ -663,7 +663,8 @@ export function createSearch(
   const [baseModel, queryModel] = mergingModel(
     filterModel(model, "Missing base search."),
     (left: ActionFilter[] | null, right: ActionFilter[] | null) =>
-      left ? left.concat(right || []) : null
+      left ? left.concat(right || []) : null,
+    false
   );
   let search: SearchPlatform | undefined;
   synchronizer.listen((query, internal) => {

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -3981,7 +3981,8 @@ export function tree<T>(
       const ui = treeSplitPaths(paths, 0, allChildren);
       expand = combineModels(...allChildren);
       return ui;
-    }
+    },
+    true
   );
   return {
     ui,

--- a/shesmu-server-ui/src/io.ts
+++ b/shesmu-server-ui/src/io.ts
@@ -29,6 +29,7 @@ import { PrometheusAlert, AlertFilter } from "./alert.js";
 import { TypeResponse, ValueResponse } from "./definitions.js";
 import { SimulationRequest, SimulationResponse } from "./simulation.js";
 import { Stat } from "./stats.js";
+import { ServerSearches } from "./action.js";
 
 /**
  * The update information provided by interrogating the server
@@ -66,6 +67,7 @@ interface ShesmuRequestType {
   printquery: ActionFilter;
   purge: ActionFilter[];
   queryalerts: AlertFilter<RegExp>;
+  savedsearches: null;
   simulate: SimulationRequest;
   stats: ActionFilter[];
   tags: ActionFilter[];
@@ -87,6 +89,7 @@ interface ShesmuResponseType {
   printquery: string;
   purge: number;
   queryalerts: PrometheusAlert[];
+  savedsearches: ServerSearches;
   simulate: SimulationResponse;
   stats: Stat[];
   tags: string[];

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -527,12 +527,10 @@ public final class Server implements ServerConfig, ActionServices {
 
               @Override
               public Stream<Header> headers() {
-                String savedSearches;
                 String savedSearch;
                 String locations;
                 String userFilter;
                 try {
-                  savedSearches = RuntimeSupport.MAPPER.writeValueAsString(savedSearches());
                   locations = RuntimeSupport.MAPPER.writeValueAsString(activeLocations());
                   savedSearch =
                       RuntimeSupport.MAPPER.writeValueAsString(
@@ -544,7 +542,6 @@ public final class Server implements ServerConfig, ActionServices {
                               parameters.getOrDefault("filters", "null")));
                 } catch (JsonProcessingException e) {
                   e.printStackTrace();
-                  savedSearches = "{}";
                   savedSearch = "null";
                   locations = "[]";
                   userFilter = "'{}'";
@@ -556,8 +553,6 @@ public final class Server implements ServerConfig, ActionServices {
                             + "initialiseActionDash"
                             + "} from \"./action.js\";"
                             + "initialiseActionDash("
-                            + savedSearches
-                            + ", "
                             + locations
                             + ", "
                             + savedSearch


### PR DESCRIPTION
* Refresh searches from server on _Actions_ page
  The searches provided by the server are populated at page load time. Since searches can be updated based on changes in JIRA, this changes the _Actions_ page to reload the searches every 15 minutes. This also updates related icons to be more consistent.
* Change emphasis in action search
  This places the mode button before the _Add Filter_ button and makes the _Add Filter_ button the visually intense button instead of the mode button.
* Add declaration for `savedsearches` endpoint
  This endpoint is already available; make it visible to the TypeScript UI.
* Delay merging models until values are available on both sides
 Change the `mergingModel` to be delayed until both values have emitted one value.
* Add a timer/counter UI element
