### PR TITLE
Improve import action definitions

### DIFF
--- a/plugin-niassa+pinery/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
+++ b/plugin-niassa+pinery/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
@@ -186,6 +186,8 @@ async function processWdlObj(parameters, resolver) {
     name.split(/\./).forEach((n, i, arr) => {
       if (i == arr.length - 1) {
         f[n] = inner;
+      } else if (f.hasOwnProperty(n)) {
+        f = f[n].fields;
       } else {
         const nextFields = {};
         f[n] = { is: "object", fields: nextFields };

--- a/shesmu-server-ui/src/actions.d.ts
+++ b/shesmu-server-ui/src/actions.d.ts
@@ -5,6 +5,10 @@ import { FakeActionDefinition } from "./simulation.js";
 declare module "actions" {
   export const actionRender: Map<string, (a: Action) => UIElement>;
   export const specialImports: ((
-    data: string
-  ) => null | FakeActionDefinition)[];
+    data: string,
+    typeProcessor: {
+      wdl: (typeName: string) => Promise<string>;
+      shesmu: (typeName: string) => Promise<string>;
+    }
+  ) => Promise<null | FakeActionDefinition>)[];
 }

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -19,14 +19,12 @@ import {
   butter,
   button,
   buttonAccessory,
-  buttonClose,
   checkKey,
   collapsible,
   dialog,
   dropdown,
   group,
   header,
-  inputCheckbox,
   inputText,
   inputTextArea,
   italic,
@@ -279,7 +277,26 @@ export function initialiseSimulationDashboard(
                   ),
                 })
             ),
-            button(
+            buttonAccessory(
+              [{ type: "icon", icon: "download" }, "Download"],
+              "Download action definition.",
+              () =>
+                saveFile(
+                  JSON.stringify({
+                    name: name,
+                    parameters: Object.entries(declaration).map(
+                      ([paramName, parameter]) => ({
+                        name: paramName,
+                        required: parameter.required,
+                        type: parameter.type,
+                      })
+                    ),
+                  }),
+                  "application/json",
+                  name + ".actiondef"
+                )
+            ),
+            buttonAccessory(
               [{ type: "icon", icon: "pencil" }, "Rename"],
               "Rename action definition.",
               () =>
@@ -304,8 +321,10 @@ export function initialiseSimulationDashboard(
                   ];
                 })
             ),
-            buttonClose("Delete action definition.", () =>
-              fakeActionDefinitions.delete(name)
+            buttonAccessory(
+              [{ type: "icon", icon: "trash" }, "Delete"],
+              "Delete action definition.",
+              () => fakeActionDefinitions.delete(name)
             ),
           ],
         ]

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/core/actions/fake/renderer.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/core/actions/fake/renderer.js
@@ -2,7 +2,7 @@ actionRender.set("fake", a =>
   [title(a, `Fake ${a.name}`)].concat(jsonParameters(a))
 );
 
-specialImports.push(data => {
+specialImports.push(async (data, resolver) => {
   try {
     const json = JSON.parse(data);
     if (json.hasOwnProperty("name") && json.hasOwnProperty("parameters")) {


### PR DESCRIPTION
* Improve extra definitions buttons
  Make the styling consistent and add a download button.
* Handle more complex action definitions in simulation
  The uploading of fake action definition is limited by parsing complex types. This provides a service so that definition loaders can parse WDL and Shesmu human-friendly types into the descriptors the simulator needs. This allows handling the complex `wdl_outputs` type for Niassa action definitions.
