### PR TITLE
Improve type parsing and WDL outputs

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/InputLimsKeyDeserializer.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/InputLimsKeyDeserializer.java
@@ -24,8 +24,7 @@ import java.util.regex.Pattern;
  * one
  */
 public class InputLimsKeyDeserializer extends JsonDeserializer<InputLimsKeyProvider> {
-  private static final Parser.ParseDispatch<CustomLimsEntryType> DISPATCH =
-      new Parser.ParseDispatch<>();
+  static final Parser.ParseDispatch<CustomLimsEntryType> DISPATCH = new Parser.ParseDispatch<>();
   private static final Parser.ParseDispatch<Either<Imyhat, CustomLimsEntryType>> FIELD =
       new Parser.ParseDispatch<>();
   private static final Parser.ParseDispatch<CustomLimsEntryType> INNER_DISPATCH =

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WdlOutputType.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WdlOutputType.java
@@ -1,3 +1,32 @@
 package ca.on.oicr.gsi.shesmu.niassa;
 
-public abstract class WdlOutputType {}
+import ca.on.oicr.gsi.shesmu.plugin.Parser;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.TypeParser;
+import java.util.concurrent.atomic.AtomicReference;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices
+public final class WdlOutputType implements TypeParser {
+
+  @Override
+  public String description() {
+    return "Niassa-type for WDL-ouputs";
+  }
+
+  @Override
+  public String format() {
+    return "niassa::wdl_output";
+  }
+
+  @Override
+  public Imyhat parse(String outputType) {
+    final AtomicReference<CustomLimsEntryType> output = new AtomicReference<>();
+    final Parser parser =
+        Parser.start(outputType, (line, column, message) -> {})
+            .whitespace()
+            .dispatch(InputLimsKeyDeserializer.DISPATCH, output::set)
+            .whitespace();
+    return parser.finished() ? output.get().type() : Imyhat.BAD;
+  }
+}

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/TypeParser.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/TypeParser.java
@@ -1,0 +1,19 @@
+package ca.on.oicr.gsi.shesmu.plugin.types;
+
+/** A service for converting a string containing a type into a Shesmu type */
+public interface TypeParser {
+  /** The name of the type format in a human-friendly format. */
+  String description();
+  /**
+   * A namespaced ID for the type format
+   *
+   * <p>This will be the name used in the REST API
+   */
+  String format();
+  /**
+   * Parse a type string provided by the user
+   *
+   * <p>If conversion fails, return {@link Imyhat#BAD}.
+   */
+  Imyhat parse(String type);
+}

--- a/shesmu-server-ui/src/actions.d.ts
+++ b/shesmu-server-ui/src/actions.d.ts
@@ -6,9 +6,6 @@ declare module "actions" {
   export const actionRender: Map<string, (a: Action) => UIElement>;
   export const specialImports: ((
     data: string,
-    typeProcessor: {
-      wdl: (typeName: string) => Promise<string>;
-      shesmu: (typeName: string) => Promise<string>;
-    }
+    typeResolver: (format: string, typeName: string) => Promise<string>
   ) => Promise<null | FakeActionDefinition>)[];
 }

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -189,24 +189,17 @@ export interface SimulationResponse {
 }
 export type TypeInfo = string | { [name: string]: TypeInfo };
 
-function typeFetcher(format: string): (format: string) => Promise<string> {
-  return (type: string) =>
-    fetchAsPromise("type", { value: type, format: format }).then(
-      (v) => v.descriptor
-    );
-}
-
 async function importAction(
   store: MutableStore<string, FakeActionParameters>,
   name: string | null,
   data: string
 ): Promise<void> {
-  const resolver = {
-    wdl: typeFetcher("1"),
-    shesmu: typeFetcher(""),
-  };
   for (const importReads of specialImports) {
-    const result = await importReads(data, resolver);
+    const result = await importReads(data, (format, type) =>
+      fetchAsPromise("type", { value: type, format: format }).then(
+        (v) => v.descriptor
+      )
+    );
     if (result) {
       if (result.errors.length) {
         dialog(() => result.errors.map((e) => text(e)));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -13,7 +13,6 @@ import ca.on.oicr.gsi.shesmu.compiler.description.OliveTable;
 import ca.on.oicr.gsi.shesmu.compiler.description.Produces;
 import ca.on.oicr.gsi.shesmu.core.StandardDefinitions;
 import ca.on.oicr.gsi.shesmu.plugin.FrontEndIcon;
-import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.SourceLocation;
 import ca.on.oicr.gsi.shesmu.plugin.action.Action;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionCommand;
@@ -30,6 +29,7 @@ import ca.on.oicr.gsi.shesmu.plugin.filter.*;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonArray;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.TypeParser;
 import ca.on.oicr.gsi.shesmu.plugin.wdl.WdlInputType;
 import ca.on.oicr.gsi.shesmu.runtime.CompiledGenerator;
 import ca.on.oicr.gsi.shesmu.runtime.OliveRunInfo;
@@ -38,6 +38,7 @@ import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import ca.on.oicr.gsi.shesmu.server.*;
 import ca.on.oicr.gsi.shesmu.server.ActionProcessor.Filter;
 import ca.on.oicr.gsi.shesmu.server.plugins.AnnotatedInputFormatDefinition;
+import ca.on.oicr.gsi.shesmu.server.plugins.BaseHumanTypeParser;
 import ca.on.oicr.gsi.shesmu.server.plugins.JarHashRepository;
 import ca.on.oicr.gsi.shesmu.server.plugins.PluginManager;
 import ca.on.oicr.gsi.shesmu.util.NameLoader;
@@ -72,7 +73,6 @@ import java.time.Instant;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -194,6 +194,7 @@ public final class Server implements ServerConfig, ActionServices {
   private final AutoUpdatingDirectory<SavedSearch> savedSearches;
   private final HttpServer server;
   private final StaticActions staticActions;
+  private Map<String, TypeParser> typeParsers = new TreeMap<>();
   public final String version;
   private final Executor wwwExecutor =
       new ThreadPoolExecutor(
@@ -353,6 +354,128 @@ public final class Server implements ServerConfig, ActionServices {
               }
             },
             inputSource);
+
+    addTypeParser(
+        new TypeParser() {
+          @Override
+          public String description() {
+            return "Descriptor";
+          }
+
+          @Override
+          public String format() {
+            return "shesmu::descriptor";
+          }
+
+          @Override
+          public Imyhat parse(String type) {
+            return Imyhat.parse(type);
+          }
+        });
+
+    addTypeParser(
+        new TypeParser() {
+          @Override
+          public String description() {
+            return "JSON-enhanced Descriptor";
+          }
+
+          @Override
+          public String format() {
+            return "shesmu::json_descriptor";
+          }
+
+          @Override
+          public Imyhat parse(String type) {
+            try {
+              return RuntimeSupport.MAPPER.readValue(type, Imyhat.class);
+            } catch (Exception e) {
+              return Imyhat.BAD;
+            }
+          }
+        });
+
+    addTypeParser(
+        new TypeParser() {
+          @Override
+          public String description() {
+            return "WDL Type (Pairs as objects)";
+          }
+
+          @Override
+          public String format() {
+            return "shesmu::wdl::objects";
+          }
+
+          @Override
+          public Imyhat parse(String type) {
+            return WdlInputType.parseString(type, true);
+          }
+        });
+    addTypeParser(
+        new TypeParser() {
+          @Override
+          public String description() {
+            return "WDL Type (Pairs as tuples)";
+          }
+
+          @Override
+          public String format() {
+            return "shesmu::wdl::tuples";
+          }
+
+          @Override
+          public Imyhat parse(String type) {
+            return WdlInputType.parseString(type, false);
+          }
+        });
+    addTypeParser(
+        new BaseHumanTypeParser(definitionRepository, InputFormatDefinition.DUMMY) {
+          @Override
+          public String description() {
+            return "Human-friendly";
+          }
+
+          @Override
+          public String format() {
+            return "shesmu::olive";
+          }
+
+          @Override
+          public Imyhat typeForName(String name) {
+            return null;
+          }
+        });
+
+    AnnotatedInputFormatDefinition.formats()
+        .sorted(Comparator.comparing(InputFormatDefinition::name))
+        .forEach(
+            format ->
+                addTypeParser(
+                    new BaseHumanTypeParser(definitionRepository, format) {
+                      final Map<String, Imyhat> predefinedTypes =
+                          InputFormatDefinition.predefinedTypes(
+                              definitionRepository.signatures(), format);
+
+                      @Override
+                      public String description() {
+                        return "Human-friendly with types from " + format.name();
+                      }
+
+                      @Override
+                      public String format() {
+                        return "shesmu::olive+" + format.name();
+                      }
+
+                      @Override
+                      public Imyhat typeForName(String name) {
+                        return predefinedTypes.get(name);
+                      }
+                    }));
+
+    for (final TypeParser parser : ServiceLoader.load(TypeParser.class)) {
+      addTypeParser(parser);
+    }
 
     add(
         "/",
@@ -1034,41 +1157,17 @@ public final class Server implements ServerConfig, ActionServices {
                 writer.writeStartElement("select");
                 writer.writeAttribute("id", "format");
 
-                writer.writeStartElement("option");
-                writer.writeAttribute("value", "0");
-                writer.writeCharacters("Descriptor");
-                writer.writeEndElement();
-                writer.writeStartElement("option");
-                writer.writeAttribute("value", "3");
-                writer.writeCharacters("JSON-enhanced Descriptor");
-                writer.writeEndElement();
-                writer.writeStartElement("option");
-                writer.writeAttribute("value", "1");
-                writer.writeCharacters("WDL Type (Pairs as tuples)");
-                writer.writeEndElement();
-                writer.writeStartElement("option");
-                writer.writeAttribute("value", "2");
-                writer.writeCharacters("WDL Type (Pairs as objects)");
-                writer.writeEndElement();
-                writer.writeStartElement("option");
-                writer.writeAttribute("value", "");
-                writer.writeCharacters("Human-friendly");
-                writer.writeEndElement();
-
-                AnnotatedInputFormatDefinition.formats()
-                    .sorted(Comparator.comparing(InputFormatDefinition::name))
-                    .forEach(
-                        format -> {
-                          try {
-                            writer.writeStartElement("option");
-                            writer.writeAttribute("value", format.name());
-                            writer.writeCharacters(
-                                "Human-friendly with types from " + format.name());
-                            writer.writeEndElement();
-                          } catch (XMLStreamException e) {
-                            throw new RuntimeException(e);
-                          }
-                        });
+                for (final TypeParser parser :
+                    typeParsers
+                        .values()
+                        .stream()
+                        .sorted(Comparator.comparing(TypeParser::description))
+                        .collect(Collectors.toList())) {
+                  writer.writeStartElement("option");
+                  writer.writeAttribute("value", parser.format());
+                  writer.writeCharacters(parser.description());
+                  writer.writeEndElement();
+                }
 
                 writer.writeEndElement();
                 writer.writeEndElement();
@@ -1894,74 +1993,28 @@ public final class Server implements ServerConfig, ActionServices {
         t -> {
           final TypeParseRequest request =
               RuntimeSupport.MAPPER.readValue(t.getRequestBody(), TypeParseRequest.class);
-          Imyhat type;
           t.getResponseHeaders().set("Content-type", "application/json");
-          if (request.getFormat() == null || request.getFormat().equals("0")) {
-            type = Imyhat.parse(request.getValue());
-          } else if (request.getFormat().equals("1")) {
-            type = WdlInputType.parseString(request.getValue(), false);
-          } else if (request.getFormat().equals("2")) {
-            type = WdlInputType.parseString(request.getValue(), true);
-          } else if (request.getFormat().equals("3")) {
-            type = RuntimeSupport.MAPPER.readValue(request.getValue(), Imyhat.class);
-          } else {
-            Optional<Function<String, Imyhat>> existingTypes =
-                request.getFormat().isEmpty()
-                    ? Optional.of(n -> null)
-                    : AnnotatedInputFormatDefinition.formats()
-                        .filter(format -> format.name().equals(request.getFormat()))
-                        .findAny()
-                        .map(
-                            f ->
-                                InputFormatDefinition.predefinedTypes(
-                                        definitionRepository.signatures(), f)
-                                    ::get);
-            type =
-                existingTypes
-                    .flatMap(
-                        types -> {
-                          AtomicReference<ImyhatNode> node = new AtomicReference<>();
-                          Parser parser =
-                              Parser.start(request.getValue(), (l, c, m) -> {})
-                                  .whitespace()
-                                  .then(ImyhatNode::parse, node::set)
-                                  .whitespace();
-                          if (parser.isGood()) {
-                            return Optional.of(
-                                node.get()
-                                    .render(
-                                        new ExpressionCompilerServices() {
-                                          private final NameLoader<FunctionDefinition> functions =
-                                              new NameLoader<>(
-                                                  definitionRepository.functions(),
-                                                  FunctionDefinition::name);
+          final Imyhat type =
+              typeParsers
+                  .getOrDefault(
+                      request.getFormat(),
+                      new TypeParser() {
+                        @Override
+                        public String description() {
+                          return "Hates everything";
+                        }
 
-                                          @Override
-                                          public FunctionDefinition function(String name) {
-                                            return functions.get(name);
-                                          }
+                        @Override
+                        public String format() {
+                          return "shesmu::bad";
+                        }
 
-                                          @Override
-                                          public Imyhat imyhat(String name) {
-                                            return types.apply(name);
-                                          }
-
-                                          @Override
-                                          public InputFormatDefinition inputFormat(String format) {
-                                            return CompiledGenerator.SOURCES.get(format);
-                                          }
-
-                                          @Override
-                                          public InputFormatDefinition inputFormat() {
-                                            return InputFormatDefinition.DUMMY;
-                                          }
-                                        },
-                                        m -> {}));
-                          }
-                          return Optional.empty();
-                        })
-                    .orElse(Imyhat.BAD);
-          }
+                        @Override
+                        public Imyhat parse(String type) {
+                          return Imyhat.BAD;
+                        }
+                      })
+                  .parse(request.getValue());
           if (type.isBad()) {
             t.sendResponseHeaders(400, 0);
             try (OutputStream os = t.getResponseBody()) {}
@@ -2238,6 +2291,10 @@ public final class Server implements ServerConfig, ActionServices {
             RuntimeSupport.MAPPER.writeValue(os, node);
           }
         });
+  }
+
+  private void addTypeParser(TypeParser parser) {
+    typeParsers.put(parser.format(), parser);
   }
 
   public void constantDefsJson(ArrayNode array) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/BaseHumanTypeParser.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/BaseHumanTypeParser.java
@@ -1,0 +1,65 @@
+package ca.on.oicr.gsi.shesmu.server.plugins;
+
+import ca.on.oicr.gsi.shesmu.compiler.ExpressionCompilerServices;
+import ca.on.oicr.gsi.shesmu.compiler.ImyhatNode;
+import ca.on.oicr.gsi.shesmu.compiler.definitions.*;
+import ca.on.oicr.gsi.shesmu.plugin.Parser;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.TypeParser;
+import ca.on.oicr.gsi.shesmu.runtime.CompiledGenerator;
+import ca.on.oicr.gsi.shesmu.util.NameLoader;
+import java.util.concurrent.atomic.AtomicReference;
+
+public abstract class BaseHumanTypeParser implements TypeParser {
+  private final DefinitionRepository definitionRepository;
+  private final InputFormatDefinition inputFormat;
+
+  public BaseHumanTypeParser(
+      DefinitionRepository definitionRepository, InputFormatDefinition inputFormat) {
+    this.inputFormat = inputFormat;
+    this.definitionRepository = definitionRepository;
+  }
+
+  @Override
+  public final Imyhat parse(String input) {
+
+    final AtomicReference<ImyhatNode> node = new AtomicReference<>();
+    final Parser parser =
+        Parser.start(input, (l, c, m) -> {})
+            .whitespace()
+            .then(ImyhatNode::parse, node::set)
+            .whitespace();
+    if (parser.isGood()) {
+      return node.get()
+          .render(
+              new ExpressionCompilerServices() {
+                private final NameLoader<FunctionDefinition> functions =
+                    new NameLoader<>(definitionRepository.functions(), FunctionDefinition::name);
+
+                @Override
+                public FunctionDefinition function(String name) {
+                  return functions.get(name);
+                }
+
+                @Override
+                public Imyhat imyhat(String name) {
+                  return typeForName(name);
+                }
+
+                @Override
+                public InputFormatDefinition inputFormat(String format) {
+                  return CompiledGenerator.SOURCES.get(format);
+                }
+
+                @Override
+                public InputFormatDefinition inputFormat() {
+                  return inputFormat;
+                }
+              },
+              m -> {});
+    }
+    return Imyhat.BAD;
+  }
+
+  protected abstract Imyhat typeForName(String name);
+}


### PR DESCRIPTION
When importing files in the front end, the type conversion is handled by the
back end. This creates a `TypeParser` service that allows plugins to provide
custom type parsing for the front end, including the special Niassa
`wdl_outputs` type handling.