### PR TITLE
Fix cast class error with join temporary

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseLeftJoin.java
@@ -361,7 +361,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
                     .map(
                         v ->
                             v.name().contains(Parser.NAMESPACE_SEPARATOR)
-                                ? v
+                                ? Target.softWrap(v)
                                 : new PrefixedTarget(v))),
             true);
 
@@ -392,7 +392,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
                               if (v instanceof InputVariable) {
                                 return Stream.of(new PrefixedVariable((InputVariable) v));
                               } else if (v.name().contains(Parser.NAMESPACE_SEPARATOR)) {
-                                return Stream.of(v);
+                                return Stream.of(Target.wrap(v));
                               } else {
                                 return Stream.of(new PrefixedTarget(v));
                               }

--- a/shesmu-server/src/test/resources/run/leftjoin-call2.shesmu
+++ b/shesmu-server/src/test/resources/run/leftjoin-call2.shesmu
@@ -1,0 +1,11 @@
+Version 1;
+Input test;
+
+Define foo()
+ Where project == "the_foo_study";
+
+Olive
+ Let l = library_size
+ LeftJoin l To Call foo() library_size
+   x = Where std::signature::sha1 != "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709" Count
+ Run ok With ok = x == 1;


### PR DESCRIPTION
This fixes a bytecode generation bug causing invalid cast when a signature is
used on the right-hand side of a `LeftJoin`. This bug keeps popping up in this
code and it is difficult because the join has several similar but distinct
paths. In this case, I believe the issue is that the signature was already
being copied into the join temporary, but the caller was trying to recomputed
the signature on the join temporary (rather than the original value).