### PR TITLE
Pull more job status information from Cromwell

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CromwellCall.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CromwellCall.java
@@ -1,12 +1,16 @@
 package ca.on.oicr.gsi.shesmu.niassa;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Collections;
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CromwellCall {
   private int attempt;
   private String backend;
   private String callRoot;
+  private String executionStatus;
+  private List<CromwellFailure> failures = Collections.emptyList();
   private String jobId;
   private String shardIndex;
   private String stderr;
@@ -22,6 +26,14 @@ public class CromwellCall {
 
   public String getCallRoot() {
     return callRoot;
+  }
+
+  public String getExecutionStatus() {
+    return executionStatus;
+  }
+
+  public List<CromwellFailure> getFailures() {
+    return failures;
   }
 
   public String getJobId() {
@@ -50,6 +62,14 @@ public class CromwellCall {
 
   public void setCallRoot(String callRoot) {
     this.callRoot = callRoot;
+  }
+
+  public void setExecutionStatus(String executionStatus) {
+    this.executionStatus = executionStatus;
+  }
+
+  public void setFailures(List<CromwellFailure> failures) {
+    this.failures = failures;
   }
 
   public void setJobId(String jobId) {

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CromwellFailure.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/CromwellFailure.java
@@ -1,0 +1,26 @@
+package ca.on.oicr.gsi.shesmu.niassa;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CromwellFailure {
+  private List<CromwellFailure> causedBy;
+  private String message;
+
+  public List<CromwellFailure> getCausedBy() {
+    return causedBy;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setCausedBy(List<CromwellFailure> causedBy) {
+    this.causedBy = causedBy;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -1034,6 +1034,8 @@ public final class WorkflowAction extends Action {
                           logEntry.put("shardIndex", log.getShardIndex());
                           logEntry.put("stderr", log.getStderr());
                           logEntry.put("stdout", log.getStdout());
+                          logEntry.put("executionStatus", log.getExecutionStatus());
+                          logEntry.putPOJO("failures", log.getFailures());
                         }));
       } catch (InitialCachePopulationException e) {
         // This data is nice to have, so just be kind of sad if it's not available.

--- a/plugin-niassa+pinery/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
+++ b/plugin-niassa+pinery/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
@@ -17,6 +17,14 @@ const maybeJsonVisibleText = (input) => {
   }
 };
 
+function cromwellFailure(failures) {
+  return failures.map((f) =>
+    f.causedBy.length
+      ? collapsible(f.message, cromwellFailure(f.causedBy))
+      : text(f.message)
+  );
+}
+
 actionRender.set("niassa", (a) => [
   title(a, `Workflow ${a.workflowName} (${a.workflowAccession})`),
   table(
@@ -126,10 +134,12 @@ actionRender.set("niassa", (a) => [
       ["Task", (x) => x.task],
       ["Attempt", (x) => x.attempt.toString()],
       ["Scatter", (x) => (x.shardIndex < 0 ? "N/A" : x.shardIndex.toString())],
+      ["Status", (x) => x.executionStatus || "Unknown"],
       ["Backend", (x) => x.backend || "Unknown"],
       ["Job ID", (x) => x.jobId || "Unknown"],
       ["Standard Error", (x) => (x.stderr ? breakSlashes(x.stderr) : "N/A")],
-      ["Standard Output", (x) => (x.stdout ? breakSlashes(x.stdout) : "N/A")]
+      ["Standard Output", (x) => (x.stdout ? breakSlashes(x.stdout) : "N/A")],
+      ["Failures", (x) => cromwellFailure(x.failures)]
     )
   ),
   collapsible(


### PR DESCRIPTION
Try to fetch failure information from Cromwell, to make it easier for pipeline
lead to diagnose failed runs.