### PR TITLE
Search fixes

### DIFF
--- a/shesmu-server-ui/src/actionfilters.ts
+++ b/shesmu-server-ui/src/actionfilters.ts
@@ -1077,7 +1077,7 @@ function renderFilters(
                   formatTimeSpan(range.end - range.start),
                 ]
               : blank(),
-            timeRangeAnchor("— ", range.start, " ⇥")
+            timeRangeAnchor("— ", range.end, " ⇥")
           )
         );
       }

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -1902,17 +1902,14 @@ export function dateEditor(
   const enabled = inputCheckbox("Unbounded", !initial);
   const selected = typeof initial == "number" ? new Date(initial) : new Date();
   const year = inputNumber(selected.getFullYear(), 1970, null);
-  const initialMonth: [number, string] = [
-    selected.getMonth(),
-    months[selected.getMonth()] || "Unknown",
-  ];
+  const initialMonth: number = selected.getMonth();
   const monthModel = temporaryState(initialMonth);
   const month = dropdown(
-    ([_month, name]: [number, string]) => name,
+    (m: number) => months[m],
     (m) => m == initialMonth,
     monthModel,
     null,
-    ...months.entries()
+    ...months.keys()
   );
   const day = inputNumber(selected.getDate(), 1, 31);
   const hour = inputNumber(selected.getHours(), 0, 23);
@@ -1935,7 +1932,7 @@ export function dateEditor(
         ? null
         : new Date(
             year.value,
-            monthModel.get()[0],
+            monthModel.get(),
             day.value,
             hour.value,
             minute.value,

--- a/shesmu-server-ui/src/stats.ts
+++ b/shesmu-server-ui/src/stats.ts
@@ -274,11 +274,11 @@ function renderStat(
               formatTimeSpan(boundaries[end] - boundaries[start]) +
               " (" +
               boundaryLabels[start].ago +
-              +" / " +
+              " / " +
               boundaryLabels[start].absolute +
               " to " +
               boundaryLabels[end].ago +
-              +" / " +
+              " / " +
               boundaryLabels[end].absolute +
               ")"
             );


### PR DESCRIPTION
* Fix display of time ranges in basic search
* Fix formatting of stats ranges
  An errant `+` turned a string into `NaN`, resulting in a terrible display.
* Fix month selector
  The month selector did not read the month of the original date in a useful way.
