### PR TITLE
Improve advanced search UI

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Parser.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Parser.java
@@ -447,7 +447,7 @@ public abstract class Parser {
       if (isEmpty()) {
         return true;
       } else {
-        errorConsumer.raise(line(), column(), "Junk at end of file.");
+        errorConsumer.raise(line(), column(), "Junk at end of input.");
       }
     }
     errorConsumer.write();

--- a/shesmu-server-ui/src/actionfilters.ts
+++ b/shesmu-server-ui/src/actionfilters.ts
@@ -1220,10 +1220,13 @@ function searchAdvanced(
         statusChanged: (response: ParseQueryResponse | null) => {
           if (response?.formatted) {
             search.value = response.formatted;
+            searchState.statusChanged("ok");
+          } else {
+            searchState.statusChanged("bad");
           }
         },
-        statusFailed: () => {},
-        statusWaiting: () => {},
+        statusFailed: () => searchState.statusChanged("bad"),
+        statusWaiting: () => searchState.statusChanged("busy"),
       }
     ),
     (output: StatefulModel<ParseQueryResponse | null>) =>
@@ -1240,7 +1243,11 @@ function searchAdvanced(
     }
   );
 
-  const search = inputSearchBar(filter, searchModel);
+  const [search, searchState] = inputSearchBar(
+    "Action query: ",
+    filter,
+    searchModel
+  );
 
   searchModel.statusChanged(filter);
   const updateFromClick = (...filters: ActionFilter[]) => {
@@ -1425,9 +1432,7 @@ function searchAdvanced(
       ),
     ],
     entryBar: [
-      "Action query: ",
       search.ui,
-      br(),
       collapsible(
         "Help",
         paragraph(

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -2916,7 +2916,7 @@ export function paginatedList<T>(
  * Create a mutable section of UI.
  */
 export function pane(
-  mode: "blank" | "small" | "large"
+  mode: "blank" | "small" | "medium" | "large"
 ): {
   ui: ComplexElement<HTMLElement>;
   model: StatefulModel<UIElement>;
@@ -2953,6 +2953,7 @@ export function pane(
             update(blank());
             break;
           case "small":
+          case "medium":
             update(throbberSmall());
             break;
           case "large":
@@ -2968,6 +2969,7 @@ export function pane(
           case "small":
             update(img("dead.svg", "deadolive"));
             break;
+          case "medium":
           case "large":
             update([
               img("dead.svg", "deadolive"),
@@ -3388,7 +3390,7 @@ export function singleState<T>(
   formatter: (input: T) => UIElement,
   hideErrors?: boolean
 ): { model: StatefulModel<T>; ui: UIElement } {
-  const { ui, model } = pane(hideErrors ? "blank" : "small");
+  const { ui, model } = pane(hideErrors ? "blank" : "medium");
   return {
     model: mapModel(model, formatter),
     ui: ui,

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -978,3 +978,33 @@ img.deadolive {
   height: 2ex;
   background-color: var(--widget-lowlight);
 }
+
+input.ok {
+  box-shadow: none;
+}
+input.bad {
+  box-shadow: 0px 0px 0.5em var(--widget-danger-highlight);
+}
+input.busy {
+  animation: busythrob 3s infinite;
+}
+input.dirty {
+  box-shadow: 0px 0px 0.5em var(--widget-lowlight);
+}
+@keyframes busythrob {
+  0% {
+    box-shadow: 0px 0px 0.2em var(--widget-lowlight);
+  }
+  50% {
+    box-shadow: 0px 0px 0.5em var(--widget-highlight);
+  }
+  100% {
+    box-shadow: 0px 0px 0.2em var(--widget-lowlight);
+  }
+}
+
+.rigid {
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  white-space: nowrap;
+}

--- a/shesmu-server/src/test/resources/compiler/bad-junkatend.errors
+++ b/shesmu-server/src/test/resources/compiler/bad-junkatend.errors
@@ -1,1 +1,1 @@
-8:1: Junk at end of file.
+8:1: Junk at end of input.


### PR DESCRIPTION
* Change parser error message
  This was confusing when parsing WDL inputs and advanced queries.
* Make single panels show error information
  Adds a new panel display format that includes error messages but uses a small throbber.
* Improve advanced search UI feedback
  This changes the advanced search input box to provide a visual indicator of the query's status and some indication that _Enter_ should be pressed to update.
