### PR TITLE
Remove the confusing CSS `close` class

### DIFF
--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -1673,7 +1673,7 @@ export function buttonIcon(
   callback: ClickHandler
 ): UIElement {
   const button = createUiFromTag("span", icon);
-  button.element.className = "close";
+  button.element.className = "iconbutton";
   button.element.title = title;
   button.element.addEventListener("click", (e) => {
     e.stopPropagation();
@@ -1859,19 +1859,25 @@ export function collapsibleWithDefault(
     return null;
   }
   const showHide = createUiFromTag("p", title);
-  showHide.element.className = openAtStart ? "collapse open" : "collapse close";
+  showHide.element.className = openAtStart
+    ? "collapse expanded"
+    : "collapse collapsed";
   showHide.element.addEventListener("click", (e) => {
     e.stopPropagation();
-    const visible = showHide.element.classList.contains("close");
+    const visible = showHide.element.classList.contains("collapsed");
 
-    showHide.element.className = visible ? "collapse open" : "collapse close";
+    showHide.element.className = visible
+      ? "collapse expanded"
+      : "collapse collapsed";
   });
   return {
     ui: [showHide, contents],
     model: {
       reload: () => {},
       statusChanged: (input) => {
-        showHide.element.className = input ? "collapse open" : "collapse close";
+        showHide.element.className = input
+          ? "collapse expanded"
+          : "collapse collapsed";
       },
       statusFailed: (_message, _error) => {},
       statusWaiting: () => {},
@@ -1957,7 +1963,7 @@ export function dialog(
   afterClose?: () => void
 ): void {
   const modal = document.createElement("div");
-  modal.className = "modal close";
+  modal.className = "modal dialog";
 
   const dialog = document.createElement("div");
   modal.appendChild(dialog);

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -3013,11 +3013,11 @@ export function popup(
         : { x: e.pageX, y: e.pageY };
     inner.element.style.left = `${Math.min(
       x,
-      document.body.clientWidth - inner.element.offsetWidth - 10
+      document.body.offsetWidth - inner.element.offsetWidth - 10
     )}px`;
     inner.element.style.top = `${Math.min(
       y,
-      document.body.clientHeight - inner.element.offsetHeight - 10
+      document.body.offsetHeight - inner.element.offsetHeight - 10
     )}px`;
 
     inner.element.addEventListener("click", (e) => e.stopPropagation());

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -276,15 +276,15 @@ a.button.danger:visited {
   margin-right: 1em;
 }
 
-.collapse.close:before {
+.collapse.collapsed:before {
   content: "▶";
 }
 
-.collapse.open:before {
+.collapse.expanded:before {
   content: "▼";
 }
 
-.collapse.close + * {
+.collapse.collapsed + * {
   display: none;
 }
 
@@ -682,12 +682,12 @@ a.button.danger:visited {
   min-width: 25vw;
 }
 
-.filters > span > span.close {
+.filters > span > span.iconbutton {
   float: right;
 }
 
-.filters > span > span.close,
-.filterlist > div > span.close {
+.filters > span > span.iconbutton,
+.filterlist > div > span.iconbutton {
   margin: 0.3em;
 }
 
@@ -748,7 +748,7 @@ a.button.danger:visited {
   background-color: rgba(0, 0, 0, 0.4);
 }
 
-.modal.close > div {
+.modal.dialog > div {
   background-color: var(--dialog-background);
   margin: 5vh auto;
   padding: 20px;
@@ -759,7 +759,7 @@ a.button.danger:visited {
   box-shadow: 0.2em 0.2em 5px 0px rgba(0, 0, 0, 0.2);
 }
 
-.modal.close > div > :first-child {
+.modal.dialog > div > :first-child {
   font-size: 150%;
   top: 0px;
   right: 0px;
@@ -767,11 +767,11 @@ a.button.danger:visited {
   cursor: pointer;
 }
 
-.modal.close > div > :first-child:hover {
+.modal.dialog > div > :first-child:hover {
   color: var(--widget-danger-lowlight);
 }
 
-.modal.close > div > :nth-child(2) {
+.modal.dialog > div > :nth-child(2) {
   overflow: auto;
   max-height: 85vh;
 }
@@ -952,7 +952,7 @@ img.deadolive {
   padding-left: 1em;
 }
 
-.close {
+.iconbutton {
   cursor: pointer;
   white-space: nowrap;
 }


### PR DESCRIPTION
This class is doing multiple independent things, except when there is
unfortunate overlap. The goal is to split it into 3 use cases:

- `iconbutton`: for when it was used for a close button
- `dialog`: for when it was used as a closable dialog box
- `collpased`: for when it was used for accordion sections