### PR TITLE
Add expression to extract capture groups from a regular expression

### DIFF
--- a/language.md
+++ b/language.md
@@ -661,6 +661,18 @@ regular expression.
 _flags_ sets the behaviour of the regular expression. For details, see [regular
 expression flags](#regexflags).
 
+- _expr_` =~ /`_re_`/`_flags_
+
+Matches _expr_, which must be a string, against the provided regular
+expression and returns a tuple of the values of each capture group. Since
+individual capture groups may be missing, this returns an optional tuple of
+optional strings. If the outer optional is the missing value, then the regular
+expression failed to match. If any element of the tuple is the missing value,
+then that capture group did not match.
+
+_flags_ sets the behaviour of the regular expression. For details, see [regular
+expression flags](#regexflags).
+
 ### Disjunction
 #### Addition
 - _expr_ `+` _expr_

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -429,6 +429,20 @@ public abstract class ExpressionNode implements Renderable {
           });
     }
     COMPARISON.addSymbol(
+        "=~",
+        (p, o) -> {
+          final AtomicReference<Pair<String, Integer>> regex = new AtomicReference<>();
+          final Parser result =
+              p.whitespace().regex(REGEX, regexParser(regex), "Regular expression.").whitespace();
+          if (result.isGood()) {
+            o.accept(
+                left ->
+                    new ExpressionNodeRegexBinding(
+                        p.line(), p.column(), left, regex.get().first(), regex.get().second()));
+          }
+          return result;
+        });
+    COMPARISON.addSymbol(
         "~",
         (p, o) -> {
           final AtomicReference<Pair<String, Integer>> regex = new AtomicReference<>();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeRegexBinding.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeRegexBinding.java
@@ -1,0 +1,155 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
+import ca.on.oicr.gsi.shesmu.plugin.Tuple;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+
+public class ExpressionNodeRegexBinding extends ExpressionNode {
+
+  private static final Type A_MATCHER_TYPE = Type.getType(Matcher.class);
+  private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
+  private static final Type A_OPTIONAL_TYPE = Type.getType(Optional.class);
+  private static final Type A_PATTERN_TYPE = Type.getType(Pattern.class);
+  private static final Type A_TUPLE_TYPE = Type.getType(Tuple.class);
+  private static final Method CTOR_TUPLE =
+      new Method("<init>", Type.VOID_TYPE, new Type[] {Type.getType(Object[].class)});
+  private static final Method METHOD_MATCHER__GROUP =
+      new Method("group", Type.getType(String.class), new Type[] {Type.INT_TYPE});
+  private static final Method METHOD_MATCHER__MATCHES =
+      new Method("matches", Type.BOOLEAN_TYPE, new Type[] {});
+  private static final Method METHOD_OPTIONAL__EMPTY =
+      new Method("empty", A_OPTIONAL_TYPE, new Type[] {});
+  private static final Method METHOD_OPTIONAL__OF =
+      new Method("of", A_OPTIONAL_TYPE, new Type[] {A_OBJECT_TYPE});
+  private static final Method METHOD_OPTIONAL__OF_NULLABLE =
+      new Method("ofNullable", A_OPTIONAL_TYPE, new Type[] {A_OBJECT_TYPE});
+  private static final Method METHOD_PATTERN__MATCHER =
+      new Method("matcher", A_MATCHER_TYPE, new Type[] {Type.getType(CharSequence.class)});
+  int captureCount = 0;
+  private final ExpressionNode expression;
+  private final int flags;
+  private final String regex;
+
+  public ExpressionNodeRegexBinding(
+      int line, int column, ExpressionNode expression, String regex, int flags) {
+    super(line, column);
+    this.expression = expression;
+    this.regex = regex;
+    this.flags = flags;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    expression.collectFreeVariables(names, predicate);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    expression.collectPlugins(pluginFileNames);
+  }
+
+  @Override
+  public void render(Renderer renderer) {
+    renderer.mark(line());
+
+    // Match the regex
+    renderer.regex(regex, flags);
+    expression.render(renderer);
+    renderer.methodGen().invokeVirtual(A_PATTERN_TYPE, METHOD_PATTERN__MATCHER);
+    renderer.methodGen().dup();
+
+    // Check if it matches
+    renderer.methodGen().invokeVirtual(A_MATCHER_TYPE, METHOD_MATCHER__MATCHES);
+
+    final Label empty = renderer.methodGen().newLabel();
+    final Label end = renderer.methodGen().newLabel();
+    renderer.methodGen().ifZCmp(GeneratorAdapter.EQ, empty);
+
+    // If it matches, convert the capture groups
+    final int matcher = renderer.methodGen().newLocal(A_MATCHER_TYPE);
+    renderer.methodGen().storeLocal(matcher);
+
+    renderer.methodGen().newInstance(A_TUPLE_TYPE);
+    renderer.methodGen().dup();
+    renderer.methodGen().push(captureCount);
+    renderer.methodGen().newArray(A_OBJECT_TYPE);
+    for (int i = 0; i < captureCount; i++) {
+      renderer.methodGen().dup();
+      renderer.methodGen().push(i);
+      renderer.methodGen().loadLocal(matcher);
+      renderer.methodGen().push(i + 1);
+      renderer.methodGen().invokeVirtual(A_MATCHER_TYPE, METHOD_MATCHER__GROUP);
+      renderer.methodGen().invokeStatic(A_OPTIONAL_TYPE, METHOD_OPTIONAL__OF_NULLABLE);
+      renderer.methodGen().arrayStore(A_OBJECT_TYPE);
+    }
+    renderer.methodGen().invokeConstructor(A_TUPLE_TYPE, CTOR_TUPLE);
+    renderer.methodGen().invokeStatic(A_OPTIONAL_TYPE, METHOD_OPTIONAL__OF);
+    renderer.methodGen().goTo(end);
+
+    // Otherwise, empty an empty optional
+    renderer.methodGen().mark(empty);
+    renderer.methodGen().pop();
+    renderer.methodGen().invokeStatic(A_OPTIONAL_TYPE, METHOD_OPTIONAL__EMPTY);
+    renderer.methodGen().mark(end);
+  }
+
+  @Override
+  public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
+    return expression.resolve(defs, errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return expression.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return captureCount > 0
+        ? Imyhat.tuple(
+                Collections.nCopies(captureCount, Imyhat.STRING.asOptional())
+                    .stream()
+                    .toArray(Imyhat[]::new))
+            .asOptional()
+        : Imyhat.BAD;
+  }
+
+  @Override
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    boolean patternOk = true;
+    try {
+      captureCount = Pattern.compile(regex).matcher("").groupCount();
+      if (captureCount == 0) {
+        errorHandler.accept(String.format("%d:%d: No capture groups found.", line(), column()));
+        patternOk = false;
+      }
+    } catch (PatternSyntaxException e) {
+      errorHandler.accept(
+          String.format("%d:%d: %s", line(), column(), e.getMessage().split("\n")[0]));
+      patternOk = false;
+    }
+
+    final boolean ok = expression.typeCheck(errorHandler);
+    if (ok) {
+      if (expression.type().isSame(Imyhat.STRING)) {
+        return patternOk;
+      }
+      typeError(Imyhat.STRING, expression.type(), errorHandler);
+    }
+    return false;
+  }
+}

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
@@ -118,7 +118,7 @@ ace.define(
             "path",
             "string",
           ].join("|"),
-          "keyword.operator": "`|~|:|<=?|>=?|==|\\|\\||-|!=?|/|\\*|&&|\\?",
+          "keyword.operator": "`|~|:|<=?|>=?|==|=~|\\|\\||-|!=?|/|\\*|&&|\\?",
           "constant.language":
             "False|True|json_signature|sha1_signature|signature_names|\\d+[kMG]i?|\\d+(weeks|days|hours|mins)|Date\\s*\\d\\d\\d\\d-\\d\\d-\\d\\d\\(T\\d\\d\\:\\d\\d:\\d\\d\\(Z|[+-]\\d\\d\\(:\\d\\d)?))?|[A-Z][A-Z_0-9]+",
         },

--- a/shesmu-server/src/test/resources/compiler/bad-regex-capture.errors
+++ b/shesmu-server/src/test/resources/compiler/bad-regex-capture.errors
@@ -1,0 +1,1 @@
+5:13: No capture groups found.

--- a/shesmu-server/src/test/resources/compiler/bad-regex-capture.shesmu
+++ b/shesmu-server/src/test/resources/compiler/bad-regex-capture.shesmu
@@ -1,0 +1,5 @@
+Version 1;
+Input test;
+
+Define standard_fastq(string s)
+  Where s =~ /abc/;

--- a/shesmu-server/src/test/resources/run/regex-binding.shesmu
+++ b/shesmu-server/src/test/resources/run/regex-binding.shesmu
@@ -1,0 +1,8 @@
+Version 1;
+Input test;
+Timeout 100;
+
+Function r(string input) input =~ /a(.)c/i;
+
+Olive
+ Run ok With ok = r("abc") == `{`"b"`}` && r("aba") == ``;

--- a/vim/syntax.vim
+++ b/vim/syntax.vim
@@ -107,7 +107,7 @@ syn keyword shesmuBool False True
 syn keyword shesmuConstant json_signature
 syn keyword shesmuConstant sha1_signature
 syn keyword shesmuConstant signature_names
-syn match shesmuOperators '\(`\|\~\|:\|<=\=\|>=\=\|==\|||\|-\|!=\=\|/\|\*\|&&\|?\)' display
+syn match shesmuOperators '\(`\|\~\|:\|<=\=\|>=\=\|==\|=~\|||\|-\|!=\=\|/\|\*\|&&\|?\)' display
 syn keyword shesmuType boolean date float integer json path string
 syn match shesmuConstant "\<\d\+\>" display
 syn match shesmuConstant "\<\d\+[kMG]i\=\>" display


### PR DESCRIPTION
This adds an expression to pull capture groups as a tuple if a regular
expression matches. This does them positionally, because Java does not provide
an API to get information about named capture groups.