### PR TITLE
Show the base search on the actions page

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -1,6 +1,5 @@
 import {
   ClickHandler,
-  DisplayElement,
   IconName,
   UIElement,
   blank,
@@ -51,7 +50,12 @@ import {
   mergingModel,
   mutableStoreWatcher,
 } from "./util.js";
-import { ActionFilter, BasicQuery, createSearch } from "./actionfilters.js";
+import {
+  ActionFilter,
+  BasicQuery,
+  createSearch,
+  renderFilters,
+} from "./actionfilters.js";
 import {
   fetchJsonWithBusyDialog,
   loadFile,
@@ -775,6 +779,12 @@ export function initialiseActionDash(
           ]
         : blank()
   );
+  const {
+    ui: baseSearchUi,
+    model: baseSearchModel,
+  } = singleState(([_, filters]: [string, ActionFilter[]]) =>
+    tile(["filters"], renderFilters(filters, filenameFormatter))
+  );
   const { model: searchModel, ui: searchSelector } = singleState(
     (searches: SearchDefinition[]): UIElement =>
       dropdown(
@@ -782,6 +792,7 @@ export function initialiseActionDash(
         ([name, _filters]) => name == savedSynchonizer.get(),
         combineModels(
           deleteModel,
+          baseSearchModel,
           mapModel(model, ([_name, filters]) => filters)
         ),
         {
@@ -915,6 +926,7 @@ export function initialiseActionDash(
       helpArea("action")
     ),
     tile([], refreshButton(combinedActionsModel.reload), buttons, bulkCommands),
+    tile([], collapsible("Base Search Filter", baseSearchUi, br())),
     tile([], entryBar),
     tabsUi
   );


### PR DESCRIPTION
Add a panel to display the base search (the one selected from the drop down)
filters. This was dropped for two reasons:

- in the reimplementation, it was more practical to have code to only draw the
  `BasicQuery` object rather than `ActionFilter` since that required reverse
  engineering the `BasicQuery` context from the `ActionFilter`, which was hard.
- I was the only one who ever looked at it

I want to see that information and it is simpler to have a separate rendering
for the base filters that is much simpler, since it's not editable.

In the refactor, the display logic for `BasicQuery` kept the old name of
`renderFilters`. This changes that to a more accurate `renderQuery` and adds a
new `renderFilters`.