### PR TITLE
Utilities for future improvements

### DIFF
--- a/shesmu-server-ui/src/definitions.ts
+++ b/shesmu-server-ui/src/definitions.ts
@@ -555,7 +555,7 @@ function prettyKind(kind: Definition["kind"]): string {
   }
 }
 
-function parseDescriptor<T>(
+export function parseDescriptor<T>(
   type: string,
   transformer: TypeTransformer<T>
 ): [T, string] {

--- a/shesmu-server-ui/src/util.ts
+++ b/shesmu-server-ui/src/util.ts
@@ -208,6 +208,16 @@ export function copyLocation(location: SourceLocation): SourceLocation {
     hash: location.hash,
   };
 }
+
+export function countIterable<T>(items: Iterable<T> | null): number {
+  let c = 0;
+  if (items != null) {
+    for (const _fa of items) {
+      c++;
+    }
+  }
+  return c;
+}
 /**
  * Show a duration as a human-friendly approximation
  * @param duration the duration in milliseconds


### PR DESCRIPTION
These are small changes to support future changes.

* Add a "reducing" model
  This stateful model has a number of slots all holding different values and allows a `Array.reduce` operation to compute a new value over the slots.
* Add function to count length of iterable
* Make type descriptor parser exported
