### PR TITLE
Fix incorrect tag regular expression search

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -1315,7 +1315,7 @@ public final class ActionProcessor
 
       @Override
       protected boolean check(Action action, Information info) {
-        return info.tags.stream().anyMatch(predicate);
+        return Stream.concat(info.tags.stream(), action.tags()).anyMatch(predicate);
       }
     };
   }


### PR DESCRIPTION
Regular expression searching on tags was missing results. There are two sets of
tags: ones applied by the olive and ones the action can spontaneously generate.
The original code was only checking the first and not the second. This change
has it check both.