### PR TITLE
Encode URL parameters in a Firefox-friendly way

### DIFF
--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -2711,7 +2711,13 @@ export function makeUrl<R extends keyof ShesmuLinks>(
     "?" +
     Object.entries(parameters)
       .map(
-        ([key, value]) => key + "=" + encodeURIComponent(JSON.stringify(value))
+        ([key, value]) =>
+          key +
+          "=" +
+          btoa(JSON.stringify(value))
+            .replace(/=/g, "")
+            .replace(/\+/g, "-")
+            .replace(/\//g, "_")
       )
       .join("&")
   );


### PR DESCRIPTION
Shesmu currently JSON encodes data it holds in the URL. Firefox has a
long-standing bug where it tries to prettify escape characters, but then they
are not send back correctly to the server
<https://bugzilla.mozilla.org/show_bug.cgi?id=1163959>. To avoid this problem,
this changes the URL encoding to be base64url-encoded JSON-encoded data, which
is always URL-safe and not pretty printable by Firefox. This maintains the
ability to process existing URLs.