### PR TITLE
Fix bug preventing importing `.niassawf` files in simulation

### DIFF
--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -276,6 +276,7 @@ export function initialiseSimulationDashboard(
               () =>
                 saveFile(
                   JSON.stringify({
+                    kind: "action",
                     name: name,
                     parameters: Object.entries(declaration).map(
                       ([paramName, parameter]) => ({

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/core/actions/fake/renderer.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/core/actions/fake/renderer.js
@@ -5,8 +5,30 @@ actionRender.set("fake", a =>
 specialImports.push(async (data, resolver) => {
   try {
     const json = JSON.parse(data);
-    if (json.hasOwnProperty("name") && json.hasOwnProperty("parameters")) {
-      return { name: json.name, parameters: json.parameters, errors: [] };
+    if (
+      json.hasOwnProperty("name") &&
+      json.hasOwnProperty("parameters") &&
+      json.hasOwnProperty("kind") &&
+      json.kind == "action"
+    ) {
+      const parameters = {};
+      for (const p of json.parameters) {
+        if (
+          !p.hasOwnProperty("name") ||
+          !p.hasOwnProperty("required") ||
+          !p.hasOwnProperty("type")
+        ) {
+          return null;
+        }
+        parameters[p.name] = {
+          required: p.required,
+          type: await resolver(
+            "shesmu::json_descriptor",
+            JSON.stringify(p.type)
+          )
+        };
+      }
+      return { name: json.name, parameters: parameters, errors: [] };
     }
   } catch (e) {}
   return null;


### PR DESCRIPTION
The fake action importer was incorrectly recognizing `.niassawf` files as its
own and importing them in a way that produced broken behaviour. This changes
the import process to check for `"kind": "action"`, which was added as part of
the new definitions page and then it validates all of the parameters as it
reads them. This also adds this property to exported actions so they round-trip
correctly.