### PR TITLE
Fix `Dump` in join operations

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveBuilder.java
@@ -291,6 +291,22 @@ public final class OliveBuilder extends BaseOliveBuilder {
                         Stream.of(
                             new LoadableValue() {
                               @Override
+                              public String name() {
+                                return "Olive Services";
+                              }
+
+                              @Override
+                              public Type type() {
+                                return A_OLIVE_SERVICES_TYPE;
+                              }
+
+                              @Override
+                              public void accept(Renderer renderer) {
+                                loadOliveServices(renderer.methodGen());
+                              }
+                            },
+                            new LoadableValue() {
+                              @Override
                               public void accept(Renderer renderer) {
                                 loadAccessor(renderer);
                               }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
@@ -174,6 +174,11 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
   }
 
   @Override
+  public Stream<LoadableValue> requiredCaptures(RootBuilder builder) {
+    return Stream.empty();
+  }
+
+  @Override
   public NameDefinitions resolve(
       OliveCompilerServices oliveCompilerServices,
       NameDefinitions defs,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
@@ -100,7 +100,7 @@ public class OliveClauseNodeReject extends OliveClauseNode {
         oliveBuilder.filter(
             line,
             column,
-            Stream.concat(
+            Stream.of(
                     Stream.of(
                         new LoadableValue() {
 
@@ -119,7 +119,9 @@ public class OliveClauseNodeReject extends OliveClauseNode {
                             return A_OLIVE_SERVICES_TYPE;
                           }
                         }),
+                    handlers.stream().flatMap(handler -> handler.requiredCaptures(builder)),
                     oliveBuilder.loadableValues().filter(v -> freeVariables.contains(v.name())))
+                .flatMap(Function.identity())
                 .toArray(LoadableValue[]::new));
 
     renderer.methodGen().visitCode();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
@@ -130,7 +130,7 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
             column,
             type,
             copySignatures,
-            Stream.concat(
+            Stream.of(
                     Stream.of(
                         new LoadableValue() {
 
@@ -149,7 +149,9 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
                             return A_OLIVE_SERVICES_TYPE;
                           }
                         }),
+                    handlers.stream().flatMap(handler -> handler.requiredCaptures(builder)),
                     oliveBuilder.loadableValues().filter(v -> freeVariables.contains(v.name())))
+                .flatMap(Function.identity())
                 .toArray(LoadableValue[]::new));
 
     flattenBuilder.add(name::render);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveDefineBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveDefineBuilder.java
@@ -45,6 +45,8 @@ public final class OliveDefineBuilder extends BaseOliveBuilder
     }
   }
 
+  public static final LoadableValue OLIVE_SERVICES_LOADABLE_VALUE =
+      new ParameterLoadableValue(1, "Olive Services", A_OLIVE_SERVICES_TYPE);
   public static final LoadableValue ACTION_NAME_LOADABLE_VALUE =
       new ParameterLoadableValue(3, ACTION_NAME, A_OPTIONAL_TYPE);
   public static final LoadableValue SIGNER_ACCESSOR_LOADABLE_VALUE =
@@ -184,6 +186,7 @@ public final class OliveDefineBuilder extends BaseOliveBuilder
                 parameters.stream(),
                 Stream.of(
                     ACTION_NAME_LOADABLE_VALUE,
+                    OLIVE_SERVICES_LOADABLE_VALUE,
                     SIGNER_ACCESSOR_LOADABLE_VALUE,
                     SOURCE_LOCATION_FILE_LOADABLE_VALUE,
                     SOURCE_LOCATION_LINE_LOADABLE_VALUE,
@@ -237,6 +240,7 @@ public final class OliveDefineBuilder extends BaseOliveBuilder
     return Stream.of(
             Stream.of(
                 ACTION_NAME_LOADABLE_VALUE,
+                OLIVE_SERVICES_LOADABLE_VALUE,
                 SIGNER_ACCESSOR_LOADABLE_VALUE,
                 SOURCE_LOCATION_FILE_LOADABLE_VALUE,
                 SOURCE_LOCATION_LINE_LOADABLE_VALUE,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -253,6 +253,11 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
   }
 
   @Override
+  public Stream<LoadableValue> requiredCaptures(RootBuilder builder) {
+    return Stream.empty();
+  }
+
+  @Override
   public void render(
       RootBuilder builder, Function<String, CallableDefinitionRenderer> definitions) {
     final Set<String> captures = new HashSet<>();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RejectNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RejectNode.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 public interface RejectNode {
   void collectFreeVariables(Set<String> freeVariables);
@@ -10,6 +11,8 @@ public interface RejectNode {
   void collectPlugins(Set<Path> pluginFileNames);
 
   void render(RootBuilder builder, Renderer renderer);
+
+  Stream<LoadableValue> requiredCaptures(RootBuilder builder);
 
   NameDefinitions resolve(
       OliveCompilerServices oliveCompilerServices,


### PR DESCRIPTION
The dumpers are scoped to the olive, so when a `Dump` is included indirectly
throught a `Join` operation using a `Define`, the output from the dump
operation goes nowhere useful. This triggers dumper generation at the time of
olive creation so that the dumpers from `Define` will be attached to the
calling olive.