### PR TITLE
Allow setting a `Label` on clauses

### DIFF
--- a/language.md
+++ b/language.md
@@ -189,7 +189,9 @@ Adds the elements in the result of _expr_, which must be a list of strings, to
 the tags associated with this actions.
 
 ## Clauses
-An olive can have many clauses that filter and reshape the data.
+An olive can have many clauses that filter and reshape the data. All clauses
+can be preceded with `Label "`_text_`"` to have _text_ appear in the dataflow
+diagram instead of the name of the clause.
 
 - `Dump` _expr1_[`,` _expr2_[`,` ...]] `To` _dumper_
 - `Dump All To` _dumper_

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Check.java
@@ -466,8 +466,8 @@ public final class Check extends Compiler {
       }
 
       @Override
-      public Stream<OliveClauseRow> dashboardInner(int line, int column) {
-        return null;
+      public Stream<OliveClauseRow> dashboardInner(Optional<String> label, int line, int column) {
+        return Stream.empty();
       }
 
       @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CallableDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CallableDefinition.java
@@ -17,7 +17,7 @@ public interface CallableDefinition {
   void collectSignables(
       Set<String> signableNames, Consumer<SignableVariableCheck> addSignableCheck);
 
-  Stream<OliveClauseRow> dashboardInner(int line, int column);
+  Stream<OliveClauseRow> dashboardInner(Optional<String> label, int line, int column);
 
   Path filename();
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseDump.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseDump.java
@@ -24,11 +24,13 @@ public abstract class OliveClauseNodeBaseDump extends OliveClauseNode implements
   private final String dumper;
   private List<Imyhat> dumperTypes;
 
+  private final Optional<String> label;
   private final int line;
   private final String selfName;
 
-  public OliveClauseNodeBaseDump(int line, int column, String dumper) {
+  public OliveClauseNodeBaseDump(Optional<String> label, int line, int column, String dumper) {
     super();
+    this.label = label;
     this.line = line;
     this.column = column;
     this.dumper = dumper;
@@ -57,7 +59,7 @@ public abstract class OliveClauseNodeBaseDump extends OliveClauseNode implements
   public final Stream<OliveClauseRow> dashboard() {
     return Stream.of(
         new OliveClauseRow(
-            "Dump",
+            label.orElse("Dump"),
             line(),
             column(),
             false,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseJoin.java
@@ -23,17 +23,20 @@ public abstract class OliveClauseNodeBaseJoin extends OliveClauseNode {
   private final ExpressionNode innerKey;
   private List<? extends Target> innerVariables;
   private final List<Consumer<JoinBuilder>> joins = new ArrayList<>();
+  private final Optional<String> label;
   private final int line;
   private final ExpressionNode outerKey;
   private final JoinSourceNode source;
 
   public OliveClauseNodeBaseJoin(
+      Optional<String> label,
       int line,
       int column,
       JoinSourceNode source,
       ExpressionNode outerKey,
       ExpressionNode innerKey) {
     super();
+    this.label = label;
     this.line = line;
     this.column = column;
     this.source = source;
@@ -62,7 +65,7 @@ public abstract class OliveClauseNodeBaseJoin extends OliveClauseNode {
   public final Stream<OliveClauseRow> dashboard() {
     return Stream.of(
         new OliveClauseRow(
-            syntax(),
+            label.orElse(syntax()),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseLeftJoin.java
@@ -93,6 +93,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
   private final ExpressionNode innerKey;
   private List<? extends Target> innerVariables;
   private final List<Consumer<JoinBuilder>> joins = new ArrayList<>();
+  private final Optional<String> label;
   protected final int line;
   private final ExpressionNode outerKey;
   private final JoinSourceNode source;
@@ -100,6 +101,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
   private final Optional<ExpressionNode> where;
 
   public OliveClauseNodeBaseLeftJoin(
+      Optional<String> label,
       int line,
       int column,
       JoinSourceNode source,
@@ -108,6 +110,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
       ExpressionNode innerKey,
       List<GroupNode> children,
       Optional<ExpressionNode> where) {
+    this.label = label;
     this.line = line;
     this.column = column;
     this.source = source;
@@ -159,7 +162,7 @@ public abstract class OliveClauseNodeBaseLeftJoin extends OliveClauseNode {
     where.ifPresent(w -> w.collectFreeVariables(whereInputs, Flavour::isStream));
     return Stream.of(
         new OliveClauseRow(
-            syntax(),
+            label.orElse(syntax()),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeCall.java
@@ -15,11 +15,14 @@ public class OliveClauseNodeCall extends OliveClauseNode {
 
   private final List<ExpressionNode> arguments;
   private final int column;
+  private final Optional<String> label;
   private final int line;
   private final String name;
   private CallableDefinition target;
 
-  public OliveClauseNodeCall(int line, int column, String name, List<ExpressionNode> arguments) {
+  public OliveClauseNodeCall(
+      Optional<String> label, int line, int column, String name, List<ExpressionNode> arguments) {
+    this.label = label;
     this.line = line;
     this.column = column;
     this.name = name;
@@ -43,7 +46,7 @@ public class OliveClauseNodeCall extends OliveClauseNode {
 
   @Override
   public Stream<OliveClauseRow> dashboard() {
-    return target.dashboardInner(line, column);
+    return target.dashboardInner(label, line, column);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
@@ -5,6 +5,7 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
@@ -15,8 +16,9 @@ public final class OliveClauseNodeDump extends OliveClauseNodeBaseDump implement
 
   private final List<ExpressionNode> columns;
 
-  public OliveClauseNodeDump(int line, int column, String dumper, List<ExpressionNode> columns) {
-    super(line, column, dumper);
+  public OliveClauseNodeDump(
+      Optional<String> label, int line, int column, String dumper, List<ExpressionNode> columns) {
+    super(label, line, column, dumper);
     this.columns = columns;
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDumpAll.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDumpAll.java
@@ -12,8 +12,8 @@ import java.util.stream.Stream;
 public final class OliveClauseNodeDumpAll extends OliveClauseNodeBaseDump implements RejectNode {
   private List<Target> columns;
 
-  public OliveClauseNodeDumpAll(int line, int column, String dumper) {
-    super(line, column, dumper);
+  public OliveClauseNodeDumpAll(Optional<String> label, int line, int column, String dumper) {
+    super(label, line, column, dumper);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeFlatten.java
@@ -20,12 +20,18 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
   private final int column;
   private final ExpressionNode expression;
   private List<Target> incoming;
+  private final Optional<String> label;
   private final int line;
   private final DestructuredArgumentNode name;
   private Imyhat unrollType;
 
   public OliveClauseNodeFlatten(
-      int line, int column, DestructuredArgumentNode name, ExpressionNode expression) {
+      Optional<String> label,
+      int line,
+      int column,
+      DestructuredArgumentNode name,
+      ExpressionNode expression) {
+    this.label = label;
     this.line = line;
     this.column = column;
     this.name = name;
@@ -56,7 +62,7 @@ public class OliveClauseNodeFlatten extends OliveClauseNode {
     expression.collectFreeVariables(inputs, Target.Flavour::isStream);
     return Stream.of(
         new OliveClauseRow(
-            "Flatten",
+            label.orElse("Flatten"),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroup.java
@@ -65,15 +65,18 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
   private final List<GroupNode> children;
   protected final int column;
   private final List<DiscriminatorNode> discriminators;
+  private final Optional<String> label;
   protected final int line;
   private final Optional<ExpressionNode> where;
 
   public OliveClauseNodeGroup(
+      Optional<String> label,
       int line,
       int column,
       List<GroupNode> children,
       List<DiscriminatorNode> discriminators,
       Optional<ExpressionNode> where) {
+    this.label = label;
     this.line = line;
     this.column = column;
     this.children = children;
@@ -114,7 +117,7 @@ public final class OliveClauseNodeGroup extends OliveClauseNode {
     where.ifPresent(w -> w.collectFreeVariables(whereInputs, Flavour::isStream));
     return Stream.of(
         new OliveClauseRow(
-            "Group",
+            label.orElse("Group"),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeGroupWithGrouper.java
@@ -48,6 +48,7 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
   private final GrouperDefinition grouper;
   private final String grouperName;
   private final List<ExpressionNode> inputExpressions = new ArrayList<>();
+  private final Optional<String> label;
   protected final int line;
   private List<String> outputNames;
   private final List<Pair<String, ExpressionNode>> rawInputExpressions;
@@ -55,6 +56,7 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
   private final Optional<ExpressionNode> where;
 
   public OliveClauseNodeGroupWithGrouper(
+      Optional<String> label,
       int line,
       int column,
       String grouperName,
@@ -63,6 +65,7 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
       List<GroupNode> children,
       List<DiscriminatorNode> discriminators,
       Optional<ExpressionNode> where) {
+    this.label = label;
     this.line = line;
     this.column = column;
     this.grouperName = grouperName;
@@ -119,7 +122,7 @@ public final class OliveClauseNodeGroupWithGrouper extends OliveClauseNode {
     }
     return Stream.of(
         new OliveClauseRow(
-            "Group Using " + grouperName,
+            label.orElse("Group Using " + grouperName),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeIntersectionJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeIntersectionJoin.java
@@ -7,12 +7,13 @@ import java.util.Optional;
 public class OliveClauseNodeIntersectionJoin extends OliveClauseNodeBaseJoin {
 
   public OliveClauseNodeIntersectionJoin(
+      Optional<String> label,
       int line,
       int column,
       JoinSourceNode source,
       ExpressionNode outerKey,
       ExpressionNode innerKey) {
-    super(line, column, source, outerKey, innerKey);
+    super(label, line, column, source, outerKey, innerKey);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
@@ -6,12 +6,13 @@ import java.util.Optional;
 public class OliveClauseNodeJoin extends OliveClauseNodeBaseJoin {
 
   public OliveClauseNodeJoin(
+      Optional<String> label,
       int line,
       int column,
       JoinSourceNode source,
       ExpressionNode outerKey,
       ExpressionNode innerKey) {
-    super(line, column, source, outerKey, innerKey);
+    super(label, line, column, source, outerKey, innerKey);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftIntersectionJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftIntersectionJoin.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public final class OliveClauseNodeLeftIntersectionJoin extends OliveClauseNodeBaseLeftJoin {
 
   public OliveClauseNodeLeftIntersectionJoin(
+      Optional<String> label,
       int line,
       int column,
       JoinSourceNode source,
@@ -16,7 +17,7 @@ public final class OliveClauseNodeLeftIntersectionJoin extends OliveClauseNodeBa
       ExpressionNode innerKey,
       List<GroupNode> children,
       Optional<ExpressionNode> where) {
-    super(line, column, source, outerKey, variablePrefix, innerKey, children, where);
+    super(label, line, column, source, outerKey, variablePrefix, innerKey, children, where);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLeftJoin.java
@@ -7,6 +7,7 @@ import java.util.*;
 public final class OliveClauseNodeLeftJoin extends OliveClauseNodeBaseLeftJoin {
 
   public OliveClauseNodeLeftJoin(
+      Optional<String> label,
       int line,
       int column,
       JoinSourceNode source,
@@ -15,7 +16,7 @@ public final class OliveClauseNodeLeftJoin extends OliveClauseNodeBaseLeftJoin {
       ExpressionNode innerKey,
       List<GroupNode> children,
       Optional<ExpressionNode> where) {
-    super(line, column, source, outerKey, variablePrefix, innerKey, children, where);
+    super(label, line, column, source, outerKey, variablePrefix, innerKey, children, where);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeLet.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -19,10 +20,13 @@ public class OliveClauseNodeLet extends OliveClauseNode {
 
   private final List<LetArgumentNode> arguments;
   private final int column;
+  private final Optional<String> label;
   private final int line;
 
-  public OliveClauseNodeLet(int line, int column, List<LetArgumentNode> arguments) {
+  public OliveClauseNodeLet(
+      Optional<String> label, int line, int column, List<LetArgumentNode> arguments) {
     super();
+    this.label = label;
     this.line = line;
     this.column = column;
     this.arguments = arguments;
@@ -53,7 +57,7 @@ public class OliveClauseNodeLet extends OliveClauseNode {
   public Stream<OliveClauseRow> dashboard() {
     return Stream.of(
         new OliveClauseRow(
-            "Let",
+            label.orElse("Let"),
             line,
             column,
             arguments.stream().anyMatch(LetArgumentNode::filters),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
@@ -28,18 +29,22 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
   private static final Method METHOD_CHILD__INC = new Method("inc", Type.VOID_TYPE, new Type[] {});
   private static final Method METHOD_GAUGE__LABELS =
       new Method("labels", Type.getType(Object.class), new Type[] {Type.getType(String[].class)});
+
   private final int column;
-
   private final String help;
-
+  private final Optional<String> label;
   private final List<MonitorArgumentNode> labels;
-
   private final int line;
-
   private final String metricName;
 
   public OliveClauseNodeMonitor(
-      int line, int column, String metricName, String help, List<MonitorArgumentNode> labels) {
+      Optional<String> label,
+      int line,
+      int column,
+      String metricName,
+      String help,
+      List<MonitorArgumentNode> labels) {
+    this.label = label;
     this.line = line;
     this.column = column;
     this.metricName = metricName;
@@ -71,7 +76,7 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
   public Stream<OliveClauseRow> dashboard() {
     return Stream.of(
         new OliveClauseRow(
-            "Monitor",
+            label.orElse("Monitor"),
             line,
             column,
             false,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodePick.java
@@ -23,12 +23,19 @@ public class OliveClauseNodePick extends OliveClauseNode {
   private final List<PickNode> discriminators;
   private List<Target> discriminatorVariables;
   private final ExpressionNode extractor;
+  private final Optional<String> label;
   private final int line;
 
   private final boolean max;
 
   public OliveClauseNodePick(
-      int line, int column, boolean max, ExpressionNode extractor, List<PickNode> discriminators) {
+      Optional<String> label,
+      int line,
+      int column,
+      boolean max,
+      ExpressionNode extractor,
+      List<PickNode> discriminators) {
+    this.label = label;
     this.line = line;
     this.column = column;
     this.max = max;
@@ -57,7 +64,7 @@ public class OliveClauseNodePick extends OliveClauseNode {
     extractor.collectFreeVariables(inputs, Flavour::isStream);
     return Stream.of(
         new OliveClauseRow(
-            "Pick " + (max ? "Max" : "Min"),
+            label.orElse("Pick " + (max ? "Max" : "Min")),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
@@ -11,6 +11,7 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
@@ -25,11 +26,17 @@ public class OliveClauseNodeReject extends OliveClauseNode {
   private final int column;
   private final ExpressionNode expression;
   private final List<RejectNode> handlers;
+  private final Optional<String> label;
   private final int line;
 
   public OliveClauseNodeReject(
-      int line, int column, ExpressionNode expression, List<RejectNode> handlers) {
+      Optional<String> label,
+      int line,
+      int column,
+      ExpressionNode expression,
+      List<RejectNode> handlers) {
     super();
+    this.label = label;
     this.line = line;
     this.column = column;
     this.expression = expression;
@@ -58,7 +65,7 @@ public class OliveClauseNodeReject extends OliveClauseNode {
     expression.collectFreeVariables(inputs, Flavour::isStream);
     return Stream.of(
         new OliveClauseRow(
-            "Reject",
+            label.orElse("Reject"),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeRequire.java
@@ -33,17 +33,20 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
   private final ExpressionNode expression;
   private final List<RejectNode> handlers;
   private List<Target> incoming;
+  private final Optional<String> label;
   private final int line;
   private final DestructuredArgumentNode name;
   private Imyhat type = Imyhat.BAD;
 
   public OliveClauseNodeRequire(
+      Optional<String> label,
       int line,
       int column,
       DestructuredArgumentNode name,
       ExpressionNode expression,
       List<RejectNode> handlers) {
     super();
+    this.label = label;
     this.line = line;
     this.column = column;
     this.name = name;
@@ -74,7 +77,7 @@ public class OliveClauseNodeRequire extends OliveClauseNode {
     expression.collectFreeVariables(inputs, Flavour::isStream);
     return Stream.of(
         new OliveClauseRow(
-            "Require",
+            label.orElse("Require"),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeWhere.java
@@ -8,6 +8,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.VariableInformation.Behaviour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
@@ -18,9 +19,12 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
 
   private final int column;
   private final ExpressionNode expression;
+  private final Optional<String> label;
   private final int line;
 
-  public OliveClauseNodeWhere(int line, int column, ExpressionNode expression) {
+  public OliveClauseNodeWhere(
+      Optional<String> label, int line, int column, ExpressionNode expression) {
+    this.label = label;
     this.line = line;
     this.column = column;
     this.expression = expression;
@@ -47,7 +51,7 @@ public class OliveClauseNodeWhere extends OliveClauseNode {
     expression.collectFreeVariables(inputs, Flavour::isStream);
     return Stream.of(
         new OliveClauseRow(
-            "Where",
+            label.orElse("Where"),
             line,
             column,
             true,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeDefinition.java
@@ -94,7 +94,7 @@ public final class OliveNodeDefinition extends OliveNodeWithClauses implements C
   }
 
   @Override
-  public Stream<OliveClauseRow> dashboardInner(int line, int column) {
+  public Stream<OliveClauseRow> dashboardInner(Optional<String> label, int line, int column) {
     return clauses().stream().flatMap(OliveClauseNode::dashboard);
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
@@ -266,10 +266,11 @@ public class CompiledGenerator implements DefinitionRepository {
           }
 
           @Override
-          public Stream<OliveClauseRow> dashboardInner(int line, int column) {
+          public Stream<OliveClauseRow> dashboardInner(
+              Optional<String> label, int line, int column) {
             return Stream.of(
                 new OliveClauseRow(
-                    name,
+                    label.orElse(name),
                     line,
                     column,
                     true,

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
@@ -60,6 +60,7 @@ ace.define(
             "IntersectionJoin",
             "Into",
             "Join",
+            "Label",
             "Labels",
             "LeftIntersectionJoin",
             "LeftJoin",

--- a/shesmu-server/src/test/resources/run/dump.shesmu
+++ b/shesmu-server/src/test/resources/run/dump.shesmu
@@ -2,5 +2,5 @@ Version 1;
 Input test;
 
 Olive
- Dump workflow To somefile
+ Label "hello" Dump workflow To somefile
  Run ok With ok = True;

--- a/shesmu-server/src/test/resources/run/leftjoin.shesmu
+++ b/shesmu-server/src/test/resources/run/leftjoin.shesmu
@@ -3,6 +3,6 @@ Input test;
 
 Olive
  Let p = project
- LeftJoin True To inner_test True
+ Label "figure out the stuff" LeftJoin True To inner_test True
     ls = Where p != "" List l
  Run ok With ok = (For l In ls: Count) == 2;

--- a/shesmu-server/src/test/resources/run/require.shesmu
+++ b/shesmu-server/src/test/resources/run/require.shesmu
@@ -5,7 +5,7 @@ Olive
  Description "something, something"
  Tag foo
  Tag bar
- Require x = If path == '/foo1' Then `"hi"` Else `` OnReject
+ Label "deal with rejection" Require x = If path == '/foo1' Then `"hi"` Else `` OnReject
    Dump workflow To somefile
  Resume
  Run ok With ok = x == "hi";

--- a/vim/syntax.vim
+++ b/vim/syntax.vim
@@ -55,6 +55,7 @@ syn keyword shesmuKeyword InputType
 syn keyword shesmuKeyword IntersectionJoin
 syn keyword shesmuKeyword Into
 syn keyword shesmuKeyword Join
+syn keyword shesmuKeyword Label
 syn keyword shesmuKeyword Labels
 syn keyword shesmuKeyword LeftIntersectionJoin
 syn keyword shesmuKeyword LeftJoin


### PR DESCRIPTION
This is meant to improve the data flow diagrams by allow custom labels instead
of the keywords. This will allow something like "active projects" instead of
"Where" to appear in the diagrams.