### PR TITLE
Create object assignment shorthand

### DIFF
--- a/language.md
+++ b/language.md
@@ -890,7 +890,7 @@ Instead of an expression to create a single element in a tuple, a `...`_expr_
 can be used to insert all the elements in a tuple inline into the new tuple.
 
 #### Named Tuple Literal
-- `{`_field_` = `_expr_`, `_field_` = `_expr_`, `...`}`
+- `{`_field_` = `_expr_`, `_field_` = `_expr_`, =` _name_ `... [`;` _var_ ...]`}`
 
 Creates a new named tuple with the fields as specified. The type of the named
 tuple is determined based on the elements.
@@ -898,6 +898,11 @@ tuple is determined based on the elements.
 Instead of _field_` = `_expr_, a `...`_expr_ can be used and this will copy all
 the elements in _expr_, which must be an object. If some fields are to be
 excluded, use the form: `...`_expr_ `Without` _field1_ _field2_ ...
+
+A field can also be created from a variable of the same name by placing the a
+name after a `;`. For example `{ a = 1; b }` is short hand for `{ a = 1, b = b
+}`. Named fields can be ommited if there are none (_i.e._, `{; b, c}` is the
+short hand for `{b = b, c = c}`).
 
 #### Synthetic Tuple
 - `{@`_name_`}`

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ObjectElementNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ObjectElementNode.java
@@ -30,8 +30,6 @@ public abstract class ObjectElementNode {
   }
 
   public static Parser parse(Parser parser, Consumer<ObjectElementNode> output) {
-    final AtomicReference<ObjectElementNode> value = new AtomicReference<>();
-
     final Parser restResult = parser.whitespace().symbol("...");
     if (restResult.isGood()) {
       final AtomicReference<ExpressionNode> expression = new AtomicReference<>();

--- a/shesmu-server/src/test/resources/run/algebraic2.shesmu
+++ b/shesmu-server/src/test/resources/run/algebraic2.shesmu
@@ -4,4 +4,4 @@ Input test;
 Function x(string p)
   If p == "the_foo_study" Then OK Else SOMETHING {v = False};
 
-Olive Run ok With ok = Match x(project) When OK Then True When SOMETHING {v = v} Then v;
+Olive Run ok With ok = Match x(project) When OK Then True When SOMETHING {; v} Then v;

--- a/shesmu-server/src/test/resources/run/empty-bsm.shesmu
+++ b/shesmu-server/src/test/resources/run/empty-bsm.shesmu
@@ -1,6 +1,6 @@
 Version 1;
 Input test;
 
-Function x(integer a) `{x = ``, a = a}` As json; # This is what we're really testing, but we just need to generate valid bytecode
+Function x(integer a) `{x = ``; a}` As json; # This is what we're really testing, but we just need to generate valid bytecode
 
 Olive Run ok With ok = "{x(3)}" == "\{\"a\":3,\"x\":null}";

--- a/shesmu-server/src/test/resources/run/list-sort-destruct-convert3.shesmu
+++ b/shesmu-server/src/test/resources/run/list-sort-destruct-convert3.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For {x = a, y As json = b} In [ { a = True, b = 1}, { a = False, b = 2} ]: Where y == (1 As json) First x Default False);
+ Run ok With ok = (For { y As json = b; a } In [ { a = True, b = 1}, { a = False, b = 2} ]: Where y == (1 As json) First a Default False);

--- a/tutorial.md
+++ b/tutorial.md
@@ -680,6 +680,11 @@ Destructuring also works on objects:
 
     For {x = n, y = l} In [{n = 1, l = "a"}, {n = 2, l = "b"}]: Where x > 5 Count
 
+Since field names are often the best name to use for a variable, a shorthand
+assignment is available:
+
+    For {; n, l} In [{n = 1, l = "a"}, {n = 2, l = "b"}]: Where n > 5 Count
+
 For objects, fields can be omitted:
 
     For {x = n} In [{n = 1, l = "a"}, {n = 2, l = "b"}]: Where x > 5 Count


### PR DESCRIPTION
Since is it common to create fields from variables with the same name, this
adds a short hand to copy a variable into an object using `{ = a }`, which is
equivalent to `{ a = a }`. This also works for destructuring assignment.