### PR TITLE
Allow dumpers to have column names

### DIFF
--- a/language.md
+++ b/language.md
@@ -193,11 +193,17 @@ An olive can have many clauses that filter and reshape the data. All clauses
 can be preceded with `Label "`_text_`"` to have _text_ appear in the dataflow
 diagram instead of the name of the clause.
 
-- `Dump` _expr1_[`,` _expr2_[`,` ...]] `To` _dumper_
+- `Dump` [`Label` _name1_] _expr1_[`,` [`Label` _name2_] _expr2_[`,` ...]] `To` _dumper_
 - `Dump All To` _dumper_
 
 Exports data to a dumper for debugging analysis. The expressions can be of any
-time. If `All` is used, all variables are dumped in alphabetical order.
+type. If `All` is used, all variables are dumped in alphabetical order. In
+output some output formats (_e.g._, TSV) column order is preserved. Column
+names can be provided with the `Label` prefix to provide a name. If no column
+name is provided, Shesmu will attempt to infer an "obvious" column name (the
+variable name if a variable or a simple transformation of a variable). If no
+column name is obvious and none is provided, Shesmu will create an arbitrary
+name.
 
 This may be used in `Reject` and `Require` clauses. This does not reshape the data.
 

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/TsvDumperFileType.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/TsvDumperFileType.java
@@ -47,7 +47,7 @@ public class TsvDumperFileType extends PluginFileType<TsvDumperFileType.DumperCo
     }
 
     @Override
-    public Stream<Dumper> findDumper(String name, Imyhat... types) {
+    public Stream<Dumper> findDumper(String name, String[] columns, Imyhat... types) {
       final Path path = paths.get(name);
       return path == null
           ? Stream.empty()
@@ -58,7 +58,15 @@ public class TsvDumperFileType extends PluginFileType<TsvDumperFileType.DumperCo
                 {
                   Optional<PrintStream> output;
                   try {
-                    output = Optional.of(new PrintStream(path.toFile()));
+                    final PrintStream stream = new PrintStream(path.toFile());
+                    for (int it = 0; it < columns.length; it++) {
+                      if (it > 0) {
+                        stream.print("\t");
+                      }
+                      stream.print(columns[it]);
+                    }
+                    stream.println();
+                    output = Optional.of(stream);
                   } catch (final FileNotFoundException e) {
                     e.printStackTrace();
                     output = Optional.empty();

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFile.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFile.java
@@ -45,9 +45,10 @@ public abstract class PluginFile implements RequiredServices {
    * Find a dumper
    *
    * @param name the dumper to find
+   * @param columns
    * @return the dumper if found, or an empty stream if none is available
    */
-  public Stream<Dumper> findDumper(String name, Imyhat... types) {
+  public Stream<Dumper> findDumper(String name, String[] columns, Imyhat... types) {
     return Stream.empty();
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFileType.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFileType.java
@@ -113,9 +113,10 @@ public abstract class PluginFileType<T extends PluginFile> {
    * Find a dumper
    *
    * @param name the dumper to find
+   * @param columns
    * @return the dumper if found, or an empty stream if none is available
    */
-  public Stream<Dumper> findDumper(String name, Imyhat... types) {
+  public Stream<Dumper> findDumper(String name, String[] columns, Imyhat... types) {
     return Stream.empty();
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/dumper/Dumper.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/dumper/Dumper.java
@@ -13,8 +13,8 @@ public interface Dumper {
    *
    * <p>This may be called multiple times in error conditions.
    */
-  public void stop();
+  void stop();
 
   /** Write the provided values to the output. */
-  public void write(Object... values);
+  void write(Object... values);
 }

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -493,20 +493,28 @@ export function renderResponse(response: SimulationResponse | null): Tab[] {
       });
     }
     if (response.dumpers && Object.entries(response.dumpers).length) {
-      const dumpState = singleState((input: [string, any[][]] | null) =>
-        input && input[1].length > 0
-          ? renderJsonTable<any[]>(
-              name + ".dump.json",
-              input[1],
-              ...Array.from(input[1][0].keys()).map(
-                (i) =>
-                  [`Column ${i + 1}`, (row) => row[i]] as [
-                    string,
-                    (input: any[]) => any
-                  ]
-              )
-            )
-          : ["Olive provided no records to ", mono(name), " dumper."]
+      const dumpState = singleState(
+        (input: [string, RefillerRecord[]] | null) => {
+          if (input) {
+            return input[1].length > 0
+              ? renderJsonTable<RefillerRecord>(
+                  input[0] + ".dump.json",
+                  input[1],
+                  ...Object.keys(input[1][0])
+                    .sort((a, b) => a.localeCompare(b))
+                    .map(
+                      (name) =>
+                        [name, (row: RefillerRecord) => row[name]] as [
+                          string,
+                          (row: RefillerRecord) => any
+                        ]
+                    )
+                )
+              : ["Olive provided no records to ", mono(input[0]), " dumper."];
+          } else {
+            return "Please select a dumper.";
+          }
+        }
       );
       tabList.push({
         name: "Dumpers",

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -27,7 +27,7 @@ import ca.on.oicr.gsi.shesmu.plugin.files.AutoUpdatingDirectory;
 import ca.on.oicr.gsi.shesmu.plugin.files.FileWatcher;
 import ca.on.oicr.gsi.shesmu.plugin.filter.*;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;
-import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonArray;
+import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonObject;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.plugin.types.TypeParser;
 import ca.on.oicr.gsi.shesmu.plugin.wdl.WdlInputType;
@@ -293,9 +293,9 @@ public final class Server implements ServerConfig, ActionServices {
               }
 
               @Override
-              public Dumper findDumper(String name, Imyhat... types) {
+              public Dumper findDumper(String name, String[] columns, Imyhat... types) {
                 return pluginManager
-                    .findDumper(name, types)
+                    .findDumper(name, columns, types)
                     .orElseGet(
                         () ->
                             jsonDumpers.containsKey(name)
@@ -315,9 +315,10 @@ public final class Server implements ServerConfig, ActionServices {
 
                                   @Override
                                   public void write(Object... values) {
-                                    final ArrayNode row = output.addArray();
+                                    final ObjectNode row = output.addObject();
                                     for (int i = 0; i < types.length; i++) {
-                                      types[i].accept(new PackJsonArray(row), values[i]);
+                                      types[i].accept(
+                                          new PackJsonObject(row, columns[i]), values[i]);
                                     }
                                   }
                                 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DumperDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DumperDefinition.java
@@ -1,0 +1,35 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class DumperDefinition {
+  private final List<Pair<String, Imyhat>> columns = new ArrayList<>();
+  private final String name;
+
+  public DumperDefinition(String name) {
+    this.name = name;
+  }
+
+  void add(String name, Imyhat type) {
+    columns.add(new Pair<>(name, type));
+  }
+
+  public void create(RootBuilder builder, Renderer renderer) {
+    builder.createDumper(name, renderer, columns);
+  }
+
+  boolean isFresh() {
+    return columns.isEmpty();
+  }
+
+  int size() {
+    return columns.size();
+  }
+
+  Imyhat type(int index) {
+    return columns.get(index).second();
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -933,6 +933,11 @@ public abstract class ExpressionNode implements Renderable {
     return column;
   }
 
+  /** Provides a name that can be used for dump columns, if possible */
+  public Optional<String> dumpColumnName() {
+    return Optional.empty();
+  }
+
   public final int line() {
     return line;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeActionName.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeActionName.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -11,6 +12,11 @@ public class ExpressionNodeActionName extends ExpressionNode {
 
   public ExpressionNodeActionName(int line, int column) {
     super(line, column);
+  }
+
+  @Override
+  public Optional<String> dumpColumnName() {
+    return Optional.of("Action Name");
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeAlgebraicGangTuple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeAlgebraicGangTuple.java
@@ -51,6 +51,11 @@ public class ExpressionNodeAlgebraicGangTuple extends ExpressionNode {
   }
 
   @Override
+  public Optional<String> dumpColumnName() {
+    return Optional.of(String.format("{@%s}", gangName));
+  }
+
+  @Override
   public void render(Renderer renderer) {
     renderer.methodGen().newInstance(A_ALGEBRAIC_VALUE_TYPE);
     renderer.methodGen().dup();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeDictionaryGet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeDictionaryGet.java
@@ -12,7 +12,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.objectweb.asm.Type;
-import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
 public class ExpressionNodeDictionaryGet extends ExpressionNode {
@@ -113,11 +112,6 @@ public class ExpressionNodeDictionaryGet extends ExpressionNode {
       new Method("get", A_OBJECT_TYPE, new Type[] {Type.INT_TYPE});
   private static final Method METHOD_MAP__GET_OR_DEFAULT =
       new Method("getOrDefault", A_OBJECT_TYPE, new Type[] {A_OBJECT_TYPE, A_OBJECT_TYPE});
-
-  private static void renderLoad(GeneratorAdapter method, int index) {
-    method.push(index);
-    method.invokeVirtual(A_TUPLE_TYPE, METHOD_TUPLE__GET);
-  }
 
   private Access access = Access.BAD;
   private final ExpressionNode expression;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObjectGet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeObjectGet.java
@@ -57,6 +57,11 @@ public class ExpressionNodeObjectGet extends ExpressionNode {
   }
 
   @Override
+  public Optional<String> dumpColumnName() {
+    return expression.dumpColumnName().map(s -> s + "." + field);
+  }
+
+  @Override
   public void render(Renderer renderer) {
     expression.render(renderer);
     renderer.mark(line());

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalOf.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalOf.java
@@ -161,6 +161,11 @@ public class ExpressionNodeOptionalOf extends ExpressionNode {
   }
 
   @Override
+  public Optional<String> dumpColumnName() {
+    return item.dumpColumnName();
+  }
+
+  @Override
   public void render(Renderer renderer) {
     // Okay, we are going to build two radically different kinds of code. If we have an optional
     // with no captures, we just compute the value and stick it in an optional

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalUnbox.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalUnbox.java
@@ -30,6 +30,11 @@ public class ExpressionNodeOptionalUnbox extends ExpressionNode {
   }
 
   @Override
+  public Optional<String> dumpColumnName() {
+    return expression.dumpColumnName();
+  }
+
+  @Override
   public void render(Renderer renderer) {
     renderer.mark(line());
     renderer.loadTarget(target);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTupleGet.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTupleGet.java
@@ -172,6 +172,11 @@ public class ExpressionNodeTupleGet extends ExpressionNode {
   }
 
   @Override
+  public Optional<String> dumpColumnName() {
+    return expression.dumpColumnName().map(s -> s + "[" + index + "]");
+  }
+
+  @Override
   public void render(Renderer renderer) {
     expression.render(renderer);
     renderer.mark(line());

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeVariable.java
@@ -44,6 +44,11 @@ public class ExpressionNodeVariable extends ExpressionNode {
   }
 
   @Override
+  public Optional<String> dumpColumnName() {
+    return Optional.of(name);
+  }
+
+  @Override
   public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     if (predicate.test(target.flavour())) {
       names.add(name);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDump.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
@@ -14,28 +15,29 @@ import java.util.stream.Stream;
 
 public final class OliveClauseNodeDump extends OliveClauseNodeBaseDump implements RejectNode {
 
-  private final List<ExpressionNode> columns;
+  private final List<Pair<Optional<String>, ExpressionNode>> columns;
 
   public OliveClauseNodeDump(
-      Optional<String> label, int line, int column, String dumper, List<ExpressionNode> columns) {
+            Optional<String> label, int line, int column, String dumper, List<Pair<Optional<String>, ExpressionNode>> columns) {
     super(label, line, column, dumper);
     this.columns = columns;
   }
 
   @Override
   public void collectFreeVariables(Set<String> freeVariables) {
-    columns.forEach(column -> column.collectFreeVariables(freeVariables, Flavour::needsCapture));
+    columns.forEach(
+        column -> column.second().collectFreeVariables(freeVariables, Flavour::needsCapture));
   }
 
   @Override
   public void collectPlugins(Set<Path> pluginFileNames) {
-    columns.forEach(column -> column.collectPlugins(pluginFileNames));
+    columns.forEach(column -> column.second().collectPlugins(pluginFileNames));
   }
 
   @Override
   protected Predicate<String> captureVariable() {
     final Set<String> freeVariables = new HashSet<>();
-    columns.forEach(e -> e.collectFreeVariables(freeVariables, Flavour::needsCapture));
+    columns.forEach(e -> e.second().collectFreeVariables(freeVariables, Flavour::needsCapture));
     return freeVariables::contains;
   }
 
@@ -47,18 +49,23 @@ public final class OliveClauseNodeDump extends OliveClauseNodeBaseDump implement
   @Override
   protected Stream<String> columnInputs(int index) {
     final Set<String> inputs = new TreeSet<>();
-    columns.get(index).collectFreeVariables(inputs, Flavour::isStream);
+    columns.get(index).second().collectFreeVariables(inputs, Flavour::isStream);
     return inputs.stream();
   }
 
   @Override
-  public Imyhat columnType(int index) {
-    return columns.get(index).type();
+  public Pair<String, Imyhat> columnDefinition(int index) {
+    final Pair<Optional<String>, ExpressionNode> column = columns.get(index);
+    return new Pair<>(
+        column
+            .first()
+            .orElse(column.second().dumpColumnName().orElse(String.format("Column %d", index + 1))),
+        column.second().type());
   }
 
   @Override
   protected void renderColumn(int index, Renderer renderer) {
-    columns.get(index).render(renderer);
+    columns.get(index).second().render(renderer);
   }
 
   @Override
@@ -67,7 +74,8 @@ public final class OliveClauseNodeDump extends OliveClauseNodeBaseDump implement
       NameDefinitions defs,
       Consumer<String> errorHandler) {
     return defs.fail(
-        columns.stream().filter(e -> e.resolve(defs, errorHandler)).count() == columns.size());
+        columns.stream().filter(e -> e.second().resolve(defs, errorHandler)).count()
+            == columns.size());
   }
 
   @Override
@@ -75,13 +83,14 @@ public final class OliveClauseNodeDump extends OliveClauseNodeBaseDump implement
       OliveCompilerServices oliveCompilerServices, Consumer<String> errorHandler) {
     return columns
             .stream()
-            .filter(e -> e.resolveDefinitions(oliveCompilerServices, errorHandler))
+            .filter(e -> e.second().resolveDefinitions(oliveCompilerServices, errorHandler))
             .count()
         == columns.size();
   }
 
   @Override
   public boolean typeCheckExtra(Consumer<String> errorHandler) {
-    return (columns.stream().filter(e -> e.typeCheck(errorHandler)).count() == columns.size());
+    return (columns.stream().filter(e -> e.second().typeCheck(errorHandler)).count()
+        == columns.size());
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDumpAll.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDumpAll.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
@@ -42,8 +43,9 @@ public final class OliveClauseNodeDumpAll extends OliveClauseNodeBaseDump implem
   }
 
   @Override
-  public Imyhat columnType(int index) {
-    return columns.get(index).type();
+  public Pair<String, Imyhat> columnDefinition(int index) {
+    final Target target = columns.get(index);
+    return new Pair<>(target.name(), target.type());
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveCompilerServices.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveCompilerServices.java
@@ -3,8 +3,6 @@ package ca.on.oicr.gsi.shesmu.compiler;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
-import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
-import java.util.List;
 import java.util.stream.Stream;
 
 public interface OliveCompilerServices extends ExpressionCompilerServices, ConstantRetriever {
@@ -20,5 +18,5 @@ public interface OliveCompilerServices extends ExpressionCompilerServices, Const
 
   Stream<SignatureDefinition> signatures();
 
-  List<Imyhat> upsertDumper(String dumper);
+  DumperDefinition upsertDumper(String dumper);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ProgramNode.java
@@ -196,7 +196,7 @@ public class ProgramNode {
     // Find and resolve olive “Define” and “Matches”
     final OliveCompilerServices compilerServices =
         new OliveCompilerServices() {
-          final Map<String, List<Imyhat>> dumpers = new HashMap<>();
+          final Map<String, DumperDefinition> dumpers = new HashMap<>();
           final Set<String> metricNames = new HashSet<>();
 
           @Override
@@ -281,8 +281,8 @@ public class ProgramNode {
           }
 
           @Override
-          public List<Imyhat> upsertDumper(String dumper) {
-            return dumpers.computeIfAbsent(dumper, k -> new ArrayList<>());
+          public DumperDefinition upsertDumper(String dumper) {
+            return dumpers.computeIfAbsent(dumper, DumperDefinition::new);
           }
         };
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/MonitoredOliveServices.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/MonitoredOliveServices.java
@@ -127,8 +127,8 @@ public final class MonitoredOliveServices implements OliveServices, AutoCloseabl
   }
 
   @Override
-  public Dumper findDumper(String name, Imyhat... types) {
-    return backing.findDumper(name, types);
+  public Dumper findDumper(String name, String[] columns, Imyhat... types) {
+    return backing.findDumper(name, columns, types);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/OliveServices.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/OliveServices.java
@@ -18,7 +18,7 @@ public interface OliveServices {
       String hash)
       throws Exception;
 
-  Dumper findDumper(String name, Imyhat... types);
+  Dumper findDumper(String name, String[] columns, Imyhat... types);
 
   boolean isOverloaded(String... services);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -894,7 +894,7 @@ public final class ActionProcessor
   }
 
   @Override
-  public Dumper findDumper(String name, Imyhat... types) {
+  public Dumper findDumper(String name, String[] columns, Imyhat... types) {
     return null;
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/MasterRunner.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/MasterRunner.java
@@ -83,8 +83,8 @@ public class MasterRunner {
             }
 
             @Override
-            public Dumper findDumper(String name, Imyhat... types) {
-              return services.findDumper(name, types);
+            public Dumper findDumper(String name, String[] columns, Imyhat... types) {
+              return services.findDumper(name, columns, types);
             }
 
             @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SimulateRequest.java
@@ -18,7 +18,6 @@ import ca.on.oicr.gsi.shesmu.plugin.action.ActionServices;
 import ca.on.oicr.gsi.shesmu.plugin.cache.InitialCachePopulationException;
 import ca.on.oicr.gsi.shesmu.plugin.dumper.Dumper;
 import ca.on.oicr.gsi.shesmu.plugin.functions.FunctionParameter;
-import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonArray;
 import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonObject;
 import ca.on.oicr.gsi.shesmu.plugin.refill.Refiller;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
@@ -649,7 +648,7 @@ public class SimulateRequest {
                       }
 
                       @Override
-                      public Dumper findDumper(String name, Imyhat... types) {
+                      public Dumper findDumper(String name, String[] columns, Imyhat... types) {
                         return new Dumper() {
                           private final ArrayNode dump = dumpers.putArray(name);
 
@@ -660,9 +659,9 @@ public class SimulateRequest {
 
                           @Override
                           public void write(Object... values) {
-                            final ArrayNode row = dump.addArray();
+                            final ObjectNode row = dump.addObject();
                             for (int i = 0; i < types.length; i++) {
-                              types[i].accept(new PackJsonArray(row), values[i]);
+                              types[i].accept(new PackJsonObject(row, columns[i]), values[i]);
                             }
                           }
                         };

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
@@ -751,8 +751,8 @@ public final class PluginManager
                 : customSource.stream().flatMap(s -> s.fetch(readStale)));
       }
 
-      public Stream<Dumper> findDumper(String name, Imyhat... types) {
-        return instance.findDumper(name, types);
+      public Stream<Dumper> findDumper(String name, String[] columns, Imyhat... types) {
+        return instance.findDumper(name, columns, types);
       }
 
       public Stream<FunctionDefinition> functions() {
@@ -1072,10 +1072,10 @@ public final class PluginManager
           configuration.stream().flatMap(f -> f.fetch(format, readStale)));
     }
 
-    public Stream<Dumper> findDumper(String name, Imyhat... types) {
+    public Stream<Dumper> findDumper(String name, String[] columns, Imyhat... types) {
       return Stream.concat(
-          fileFormat.findDumper(name, types),
-          configuration.stream().flatMap(f -> f.findDumper(name, types)));
+          fileFormat.findDumper(name, columns, types),
+          configuration.stream().flatMap(f -> f.findDumper(name, columns, types)));
     }
 
     public final Stream<FunctionDefinition> functions() {
@@ -1896,10 +1896,11 @@ public final class PluginManager
    * Find a dumper
    *
    * @param name the dumper to find
+   * @param columns
    * @return the dumper if found, or an empty optional if none is available
    */
-  public Optional<Dumper> findDumper(String name, Imyhat... types) {
-    return formatTypes.stream().flatMap(f -> f.findDumper(name, types)).findFirst();
+  public Optional<Dumper> findDumper(String name, String[] columns, Imyhat... types) {
+    return formatTypes.stream().flatMap(f -> f.findDumper(name, columns, types)).findFirst();
   }
 
   @Override

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
@@ -85,7 +85,10 @@ public class RunTest {
     }
 
     @Override
-    public Dumper findDumper(String name, Imyhat... types) {
+    public Dumper findDumper(String name, String[] columns, Imyhat... types) {
+      if (columns.length != types.length) {
+        bad++;
+      }
       return new Dumper() {
         @Override
         public void stop() {
@@ -94,7 +97,9 @@ public class RunTest {
 
         @Override
         public void write(Object... values) {
-          // Do nothing.
+          if (values.length != types.length) {
+            bad++;
+          }
         }
       };
     }

--- a/shesmu-server/src/test/resources/run/dump.shesmu
+++ b/shesmu-server/src/test/resources/run/dump.shesmu
@@ -2,5 +2,5 @@ Version 1;
 Input test;
 
 Olive
- Label "hello" Dump workflow To somefile
+ Label "hello" Dump workflow, Label p project, 3 To somefile
  Run ok With ok = True;


### PR DESCRIPTION
Dumpers require the original source to have meaningful column names, which is
frustrating during debugging and export. This changes the dumpers to have named
columns (similar to refillers). Olive writers can either choose a column name
or use an automatically inferred one.

This also fixes a bug in the simulation UI where the incorrect name was used
for the file name when downloading dumper output.