### PR TITLE
Attempt to fix LIMS key locking

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/AnalysisState.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/AnalysisState.java
@@ -157,6 +157,13 @@ public class AnalysisState implements Comparable<AnalysisState> {
             .collect(Collectors.toCollection(TreeSet::new));
   }
 
+  public void addSeenLimsKeys(Set<Pair<String, String>> seenLimsKeys) {
+    limsKeys
+        .stream()
+        .map(l -> new Pair<>(l.first().getProvider(), l.first().getVersion()))
+        .forEach(seenLimsKeys::add);
+  }
+
   /** Check how much this analysis record matches the data provided */
   public <L extends LimsKey> WorkflowRunMatch compare(
       LongStream workflowAccessions,


### PR DESCRIPTION
There is an unhandled error condition where if the data being downloaded
produces an exception while processing, this will trigger the LIMS key locks to
be released even though the cache is still stale as it was never updated due to
the exception. This takes a more secure approach of downloading all the data
and then only releasing LIMS key locks for LIMS keys it sees in the data. The
streaming approach was meant to limit memory usage and while this approach will
use more memory, it should only duplicate the cost of the container (_i.e._,
the array list) rather than a duplicate cost of the objects themselves, so it
is still considerably less memory-intensive than the previous non-streaming
approach.