### PR TITLE
Deal with Niassa's IUS attributes being a lie

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/AnalysisState.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/AnalysisState.java
@@ -101,13 +101,22 @@ public class AnalysisState implements Comparable<AnalysisState> {
     knownSignatures =
         workflowRun == null
             ? source
-                .stream()
-                .flatMap(
-                    ap ->
-                        ap.getIusAttributes()
-                            .getOrDefault("signature", Collections.emptySortedSet())
-                            .stream())
-                .collect(Collectors.toSet())
+                    .stream()
+                    .anyMatch(
+                        ap ->
+                            ap.getIusLimsKeys().size()
+                                > 1) // If there are multiple LIMS keys per record, then the IUS
+                // attributes will contain the signatures of only one of them,
+                // which is useless, so pretend like we have no signature
+                ? Collections.emptySet()
+                : source
+                    .stream()
+                    .flatMap(
+                        ap ->
+                            ap.getIusAttributes()
+                                .getOrDefault("signature", Collections.emptySortedSet())
+                                .stream())
+                    .collect(Collectors.toSet())
             : workflowRun
                 .getIus()
                 .stream()


### PR DESCRIPTION
While the type for Niassa's IUS attribute looks like it combines the attributes of any IUSes associated with a file, in fact, it does not. This is really bad when multiple LIMS keys are associated with a single file. This change tries to forcibly disable signatures on these runs and lets the actions fall into HALP state.
