### PR TITLE
Allow advanced searches to reference saves searches

### DIFF
--- a/shesmu-server-ui/src/actionfilters.ts
+++ b/shesmu-server-ui/src/actionfilters.ts
@@ -1746,6 +1746,13 @@ function searchAdvanced(
           " | ",
           mono("utc"),
           ")?"
+        ),
+        paragraph(
+          "Existing saved search: ",
+          mono('known:"'),
+          italic("name"),
+          mono('"'),
+          " Only searches stored on the server will work."
         )
       ),
     ],

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -2136,6 +2136,12 @@ public final class Server implements ServerConfig, ActionServices {
           final ArrayNode errors = response.putArray("errors");
           ActionFilter.parseQuery(
                   input,
+                  name ->
+                      savedSearches
+                          .stream()
+                          .filter(s -> s.name().equals(name))
+                          .findAny()
+                          .map(s -> ActionFilterBuilder.JSON.and(s.filters())),
                   ((line, column, errorMessage) -> {
                     final ObjectNode error = errors.addObject();
                     error.put("line", line);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SavedSearch.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/SavedSearch.java
@@ -6,6 +6,7 @@ import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public class SavedSearch implements WatchedFileListener {
   private final Path filename;
@@ -13,6 +14,14 @@ public class SavedSearch implements WatchedFileListener {
 
   public SavedSearch(Path filename) {
     this.filename = filename;
+  }
+
+  public Stream<ActionFilter> filters() {
+    return Stream.of(filters);
+  }
+
+  public String name() {
+    return RuntimeSupport.removeExtension(filename, ".search");
   }
 
   public void start() {}
@@ -31,7 +40,7 @@ public class SavedSearch implements WatchedFileListener {
 
   public void write(ObjectNode searches) {
     if (filters != null && filters.length > 0) {
-      searches.putPOJO(RuntimeSupport.removeExtension(filename, ".search"), filters);
+      searches.putPOJO(name(), filters);
     }
   }
 }


### PR DESCRIPTION
This makes it possible to use a search already know to the server as part of an
advanced search query.

While this might be useful on its own, it's more intended to allow other tools
to handle human-provided queries with known searches through a simple API.