### PR TITLE
Date functions

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -641,10 +641,10 @@ export function encodeSearch(filters: ActionFilter[]): string {
   return (
     "shesmusearch:" +
     btoa(
-      JSON.stringify(filters).replace(
-        /[\u007F-\uFFFF]/g,
-        (chr) => "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
-      )
+      JSON.stringify(filters).replace(/[\u007F-\uFFFF]/g, (chr) => {
+        const padded = "0000" + chr.charCodeAt(0).toString(16);
+        return "\\u" + padded.substring(padded.length - 4);
+      })
     )
   );
 }

--- a/shesmu-server-ui/src/definitions.ts
+++ b/shesmu-server-ui/src/definitions.ts
@@ -561,25 +561,25 @@ export function parseDescriptor<T>(
 ): [T, string] {
   switch (type.charAt(0)) {
     case "b":
-      return [transformer.b, type.substr(1)];
+      return [transformer.b, type.substring(1)];
     case "d":
-      return [transformer.d, type.substr(1)];
+      return [transformer.d, type.substring(1)];
     case "f":
-      return [transformer.f, type.substr(1)];
+      return [transformer.f, type.substring(1)];
     case "i":
-      return [transformer.i, type.substr(1)];
+      return [transformer.i, type.substring(1)];
     case "j":
-      return [transformer.j, type.substr(1)];
+      return [transformer.j, type.substring(1)];
     case "p":
-      return [transformer.p, type.substr(1)];
+      return [transformer.p, type.substring(1)];
     case "s":
-      return [transformer.s, type.substr(1)];
+      return [transformer.s, type.substring(1)];
     case "a": {
-      const [inner, remainder] = parseDescriptor(type.substr(1), transformer);
+      const [inner, remainder] = parseDescriptor(type.substring(1), transformer);
       return [transformer.a(inner), remainder];
     }
     case "m": {
-      const [key, keyRemainder] = parseDescriptor(type.substr(1), transformer);
+      const [key, keyRemainder] = parseDescriptor(type.substring(1), transformer);
       const [value, valueRemainder] = parseDescriptor(
         keyRemainder,
         transformer
@@ -587,7 +587,7 @@ export function parseDescriptor<T>(
       return [transformer.m(key, value), valueRemainder];
     }
     case "q": {
-      const [inner, remainder] = parseDescriptor(type.substr(1), transformer);
+      const [inner, remainder] = parseDescriptor(type.substring(1), transformer);
       return [transformer.q(inner), remainder];
     }
     case "t":
@@ -601,7 +601,7 @@ export function parseDescriptor<T>(
       );
     case "u": {
       let match;
-      if ((match = /^([0-9]*)([^0-9].*)$/.exec(type.substr(1))) === null) {
+      if ((match = /^([0-9]*)([^0-9].*)$/.exec(type.substring(1))) === null) {
         throw new Error("Malformed descriptor");
       }
       let rest = match[2];

--- a/shesmu-server-ui/src/definitions.ts
+++ b/shesmu-server-ui/src/definitions.ts
@@ -628,7 +628,7 @@ function parseComplex<T, E extends T | null>(
   whenEmpty: () => E
 ): [T | E, string] {
   let match;
-  if ((match = /^([0-9]*)([^0-9].*)$/.exec(type.substr(1))) === null) {
+  if ((match = /^([0-9]*)([^0-9].*|)$/.exec(type.substring(1))) === null) {
     throw new Error("Malformed descriptor");
   }
   let rest = match[2];

--- a/shesmu-server-ui/src/parser.ts
+++ b/shesmu-server-ui/src/parser.ts
@@ -444,7 +444,7 @@ export function u(unionTypes: { [type: string]: Parser | null }): Parser {
     if (match) {
       if (unionTypes.hasOwnProperty(match[1])) {
         const result = (unionTypes[match[1]] || nullParser)(
-          input.substr(match[0].length)
+          input.substring(match[0].length)
         );
         if (result.good) {
           return {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/StandardDefinitions.java
@@ -27,7 +27,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.Month;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -113,6 +115,130 @@ public final class StandardDefinitions implements DefinitionRepository {
             "toEpochMilli",
             "Get the number of milliseconds since the UNIX epoch for this date.",
             Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "utc_year"),
+            RuntimeSupport.class,
+            "utcYear",
+            "Get the year in the UTC time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "local_year"),
+            RuntimeSupport.class,
+            "localYear",
+            "Get the year in the server's time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "utc_day_of_year"),
+            RuntimeSupport.class,
+            "utcDayOfYear",
+            "Get the day of the year in the UTC time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "local_day_of_year"),
+            RuntimeSupport.class,
+            "localDayOfYear",
+            "Get the day of the year in the server's time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "utc_day_of_month"),
+            RuntimeSupport.class,
+            "utcDayOfMonth",
+            "Get the day of the month in the UTC time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "local_day_of_month"),
+            RuntimeSupport.class,
+            "localDayOfMonth",
+            "Get the day of the month in the server's time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "utc_hour_of_day"),
+            RuntimeSupport.class,
+            "utcHour",
+            "Get the hour of the day in the UTC time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "local_hour_of_day"),
+            RuntimeSupport.class,
+            "localHour",
+            "Get the hour of the day in the server's time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "utc_minute_of_hour"),
+            RuntimeSupport.class,
+            "utcMinute",
+            "Get the minute of the hour in the UTC time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "local_minute_of_hour"),
+            RuntimeSupport.class,
+            "localMinute",
+            "Get the minute of the hour in the server's time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "utc_second_of_minute"),
+            RuntimeSupport.class,
+            "utcSecond",
+            "Get the second of the minute in the UTC time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "local_second_of_minute"),
+            RuntimeSupport.class,
+            "localSecond",
+            "Get the second of the minute in the server's time zone.",
+            Imyhat.INTEGER,
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "utc_month"),
+            RuntimeSupport.class,
+            "utcMonth",
+            "Get the month in the UTC time zone.",
+            Stream.of(Month.values())
+                .map(d -> Imyhat.algebraicTuple(d.name()))
+                .reduce(Imyhat::unify)
+                .get(),
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "local_month"),
+            RuntimeSupport.class,
+            "localMonth",
+            "Get the month in the server time zone.",
+            Stream.of(Month.values())
+                .map(d -> Imyhat.algebraicTuple(d.name()))
+                .reduce(Imyhat::unify)
+                .get(),
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "utc_day_of_week"),
+            RuntimeSupport.class,
+            "utcDayOfWeek",
+            "Get the day of the week in the UTC time zone.",
+            Stream.of(DayOfWeek.values())
+                .map(d -> Imyhat.algebraicTuple(d.name()))
+                .reduce(Imyhat::unify)
+                .get(),
+            new FunctionParameter("date", Imyhat.DATE)),
+        FunctionDefinition.staticMethod(
+            String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "local_day_of_week"),
+            RuntimeSupport.class,
+            "localDayOfWeek",
+            "Get the day of the week in the server time zone.",
+            Stream.of(DayOfWeek.values())
+                .map(d -> Imyhat.algebraicTuple(d.name()))
+                .reduce(Imyhat::unify)
+                .get(),
             new FunctionParameter("date", Imyhat.DATE)),
         FunctionDefinition.staticMethod(
             String.join(Parser.NAMESPACE_SEPARATOR, "std", "date", "from_seconds"),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
@@ -423,6 +423,46 @@ public final class RuntimeSupport {
   }
 
   @RuntimeInterop
+  public static long localDayOfMonth(Instant time) {
+    return time.atZone(ZoneId.systemDefault()).getDayOfMonth();
+  }
+
+  @RuntimeInterop
+  public static AlgebraicValue localDayOfWeek(Instant time) {
+    return new AlgebraicValue(time.atZone(ZoneId.systemDefault()).getDayOfWeek().name());
+  }
+
+  @RuntimeInterop
+  public static long localDayOfYear(Instant time) {
+    return time.atZone(ZoneId.systemDefault()).getDayOfYear();
+  }
+
+  @RuntimeInterop
+  public static long localHour(Instant time) {
+    return time.atZone(ZoneId.systemDefault()).getHour();
+  }
+
+  @RuntimeInterop
+  public static long localMinute(Instant time) {
+    return time.atZone(ZoneId.systemDefault()).getMinute();
+  }
+
+  @RuntimeInterop
+  public static AlgebraicValue localMonth(Instant time) {
+    return new AlgebraicValue(time.atZone(ZoneId.systemDefault()).getMonth().name());
+  }
+
+  @RuntimeInterop
+  public static long localSecond(Instant time) {
+    return time.atZone(ZoneId.systemDefault()).getSecond();
+  }
+
+  @RuntimeInterop
+  public static long localYear(Instant time) {
+    return time.atZone(ZoneId.systemDefault()).getYear();
+  }
+
+  @RuntimeInterop
   public static <T> Optional<T> merge(Optional<T> left, Supplier<Optional<T>> right) {
     return left.isPresent() ? left : right.get();
   }
@@ -740,6 +780,7 @@ public final class RuntimeSupport {
     }
   }
 
+  @RuntimeInterop
   public static Optional<Instant> utcDateTime(
       long year, long month, long day, long hours, long minutes, long seconds, long nanos) {
     try {
@@ -752,6 +793,46 @@ public final class RuntimeSupport {
     } catch (Exception e) {
       return Optional.empty();
     }
+  }
+
+  @RuntimeInterop
+  public static long utcDayOfMonth(Instant time) {
+    return time.atZone(ZoneId.of("Z")).getDayOfMonth();
+  }
+
+  @RuntimeInterop
+  public static AlgebraicValue utcDayOfWeek(Instant time) {
+    return new AlgebraicValue(time.atZone(ZoneId.of("Z")).getDayOfWeek().name());
+  }
+
+  @RuntimeInterop
+  public static long utcDayOfYear(Instant time) {
+    return time.atZone(ZoneId.of("Z")).getDayOfYear();
+  }
+
+  @RuntimeInterop
+  public static long utcHour(Instant time) {
+    return time.atZone(ZoneId.of("Z")).getHour();
+  }
+
+  @RuntimeInterop
+  public static long utcMinute(Instant time) {
+    return time.atZone(ZoneId.of("Z")).getMinute();
+  }
+
+  @RuntimeInterop
+  public static AlgebraicValue utcMonth(Instant time) {
+    return new AlgebraicValue(time.atZone(ZoneId.of("Z")).getMonth().name());
+  }
+
+  @RuntimeInterop
+  public static long utcSecond(Instant time) {
+    return time.atZone(ZoneId.of("Z")).getSecond();
+  }
+
+  @RuntimeInterop
+  public static long utcYear(Instant time) {
+    return time.atZone(ZoneId.of("Z")).getYear();
   }
 
   @RuntimeInterop


### PR DESCRIPTION
- Fix parsing of type descriptors: An algebraic type descriptor can be `u1FOOt0` and the older parsing logic expect that there will be data after `t0`, triggering a failure to parse a correct type signature. This adjust the regular expression processing the descriptor to handle this case.
- Replace `substr` with `substring`: The method `substr` is deprecated and `substring` does exactly the same thing for these purposes.
- Add date functions: The goal is to deprecate the string conversion for dates. It is both hard to use and cannot be ported to ECMAScript. This creates a number of useful date functions that can serve the same purpose.
