### PR TITLE
Track olive execution CPU time

### DIFF
--- a/shesmu-server-ui/src/olive.ts
+++ b/shesmu-server-ui/src/olive.ts
@@ -111,6 +111,8 @@ interface ScriptFile extends SourceLocation {
   format: string;
   /** The disassembled bytecode */
   bytecode: string;
+  /** The CPU time in milliseconds the olive ran for */
+  cpuTime: number | null;
   /**
    * Whether the olive is paused
    */
@@ -123,7 +125,7 @@ interface ScriptFile extends SourceLocation {
    * The number of rows of input ingested by the script when last run
    */
   inputCount: number | null;
-  /**The time, in nanoseconds, the olive ran for*/
+  /**The wallclock time, in milliseconds, the olive ran for*/
   runtime: number | null;
   /** The last time the olive was run, in milliseconds since the UNIX epoch. */
   lastRun: number | null;
@@ -197,6 +199,14 @@ function overview(file: ScriptFile, olive: Olive | null) {
       {
         contents:
           file.runtime == null ? "Unknown" : formatTimeSpan(file.runtime),
+      }
+    ),
+    tableRow(
+      null,
+      { contents: "CPU Time" },
+      {
+        contents:
+          file.cpuTime == null ? "Unknown" : formatTimeSpan(file.cpuTime),
       }
     ),
     tableRow(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -2628,6 +2628,11 @@ public final class Server implements ServerConfig, ActionServices {
                       ? null
                       : TimeUnit.NANOSECONDS.toMillis(fileTable.first().runtime().getNano()));
               fileNode.put(
+                  "cpuTime",
+                  fileTable.first() == null || fileTable.first().cpuTime() == null
+                      ? null
+                      : TimeUnit.NANOSECONDS.toMillis(fileTable.first().cpuTime().getNano()));
+              fileNode.put(
                   "lastRun",
                   fileTable.first() == null ? null : fileTable.first().lastRun().toEpochMilli());
               final ArrayNode olivesNode = fileNode.putArray("olives");

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/OliveRunInfo.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/OliveRunInfo.java
@@ -8,14 +8,21 @@ public class OliveRunInfo {
   private final Instant lastRun;
   private final boolean ok;
   private final Duration runtime;
+  private final Duration cpuTime;
   private final String status;
 
-  public OliveRunInfo(boolean ok, String status, Long inputCount, Instant lastRun) {
+  public OliveRunInfo(
+      boolean ok, String status, Long inputCount, Instant lastRun, Duration cpuTime) {
     this.ok = ok;
     this.status = status;
     this.inputCount = inputCount;
     this.lastRun = lastRun;
     this.runtime = Duration.between(lastRun, Instant.now());
+    this.cpuTime = cpuTime;
+  }
+
+  public Duration cpuTime() {
+    return cpuTime;
   }
 
   public Long inputCount() {


### PR DESCRIPTION
The wall clock time for an olive is currently tracked. This add the CPU time of
the thread that executed the olive. This change also reorders some constants.