### PR TITLE
Fix SSH connection pool

### DIFF
--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SshConnectionPool.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SshConnectionPool.java
@@ -1,11 +1,14 @@
 package ca.on.oicr.gsi.shesmu.sftp;
 
+import ca.on.oicr.gsi.prometheus.LatencyHistogram;
 import ca.on.oicr.gsi.shesmu.sftp.SshConnectionPool.PooledSshConnection;
+import io.prometheus.client.Counter;
 import java.io.IOError;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import net.schmizz.sshj.SSHClient;
@@ -13,7 +16,7 @@ import net.schmizz.sshj.sftp.SFTPClient;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 
 public class SshConnectionPool implements Supplier<PooledSshConnection>, AutoCloseable {
-  private final class ConnectionInfo {
+  private static final class ConnectionInfo {
     private final long epoch = Instant.now().toEpochMilli();
     private final String host;
     private final int port;
@@ -27,17 +30,19 @@ public class SshConnectionPool implements Supplier<PooledSshConnection>, AutoClo
   }
 
   public final class PooledSshConnection implements AutoCloseable {
+    private Long acquisition = System.nanoTime();
     private final SSHClient client;
-    private final long epoch;
+    private final ConnectionInfo info;
     private final SFTPClient sftp;
 
     public PooledSshConnection(ConnectionInfo info) throws IOException {
-      this.epoch = info.epoch;
+      this.info = info;
       client = new SSHClient();
       client.addHostKeyVerifier(new PromiscuousVerifier());
       client.connect(info.host, info.port);
       client.authPublickey(info.user);
       sftp = client.newSFTPClient();
+      createdConnections.labels(info.host, Integer.toString(info.port), info.user).inc();
     }
 
     public SSHClient client() {
@@ -46,12 +51,20 @@ public class SshConnectionPool implements Supplier<PooledSshConnection>, AutoClo
 
     @Override
     public void close() {
+      if (acquisition != null) {
+        connectionLife.observe(acquisition, info.host, Integer.toString(info.port), info.user);
+        acquisition = null;
+      }
       if (client.isConnected()) {
-        connections.add(this);
+        connections.offerLast(this);
+      } else {
+        destroy();
       }
     }
 
     private void destroy() {
+      maxConnections.release();
+      destroyedConnections.labels(info.host, Integer.toString(info.port), info.user).inc();
       try {
         client.close();
       } catch (IOException e) {
@@ -64,8 +77,24 @@ public class SshConnectionPool implements Supplier<PooledSshConnection>, AutoClo
     }
   }
 
-  private AtomicReference<ConnectionInfo> connectionInfo = new AtomicReference<>();
+  private static final LatencyHistogram connectionLife =
+      new LatencyHistogram(
+          "shesmu_ssh_pool_conn_lifespan",
+          "The length of time a connection is used",
+          "host",
+          "port",
+          "user");
+  private static final Counter createdConnections =
+      Counter.build("shesmu_ssh_pool_conn_created", "The number of SSH connections created")
+          .labelNames("host", "port", "user")
+          .register();
+  private static final Counter destroyedConnections =
+      Counter.build("shesmu_ssh_pool_conn_destroyed", "The number of SSH connections destroyed")
+          .labelNames("host", "port", "user")
+          .register();
+  private final AtomicReference<ConnectionInfo> connectionInfo = new AtomicReference<>();
   private final Deque<PooledSshConnection> connections = new ConcurrentLinkedDeque<>();
+  private final Semaphore maxConnections = new Semaphore(100);
 
   @Override
   public void close() {
@@ -84,20 +113,31 @@ public class SshConnectionPool implements Supplier<PooledSshConnection>, AutoClo
   public PooledSshConnection get() {
     final ConnectionInfo info = connectionInfo.get();
     if (info == null) {
-      throw new IllegalStateException("Connection pool is not initalised");
+      throw new IllegalStateException("Connection pool is not initialised");
     }
     PooledSshConnection connection;
-    while ((connection = connections.pollLast()) != null) {
-      if (connection.epoch < info.epoch) {
-        connection.destroy();
-      } else {
-        return connection;
+    while (true) {
+      while ((connection = connections.pollLast()) != null) {
+        if (connection.info.epoch < info.epoch) {
+          connection.destroy();
+        } else {
+          connection.acquisition = System.nanoTime();
+          return connection;
+        }
       }
-    }
-    try {
-      return new PooledSshConnection(info);
-    } catch (IOException e) {
-      throw new IOError(e);
+      if (maxConnections.tryAcquire()) {
+        try {
+          return new PooledSshConnection(info);
+        } catch (IOException e) {
+          throw new IOError(e);
+        }
+      } else {
+        try {
+          Thread.sleep(50);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Track connection pool usage and set a maximum limit for the number of
connections that can be opened. If the maximum is reached, the thread will
sleep until a connection becomes available.