### PR TITLE
Degrade stats based on time

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -726,7 +726,7 @@ export function initialiseActionDash(
   const { actions: actionUi, bulkCommands, model: actionModel } = actionDisplay(
     exportSearches
   );
-  const { ui: statsUi, model: statsModel } = actionStats(
+  const { ui: statsUi, toolbar: statsToolbar, model: statsModel } = actionStats(
     (...limits) => addPropertySearch(...limits),
     (typeName, start, end, ...limits) =>
       addRangeSearch(typeName, start, end, ...limits),
@@ -965,7 +965,13 @@ export function initialiseActionDash(
       ),
       helpArea("action")
     ),
-    tile([], refreshButton(combinedActionsModel.reload), buttons, bulkCommands),
+    tile(
+      [],
+      refreshButton(combinedActionsModel.reload),
+      buttons,
+      bulkCommands,
+      statsToolbar
+    ),
     tile([], collapsible("Base Search Filter", baseSearchUi, br())),
     tile([], entryBar),
     tabsUi

--- a/shesmu-server-ui/src/io.ts
+++ b/shesmu-server-ui/src/io.ts
@@ -76,7 +76,7 @@ export interface ShesmuRequestType {
   savedsearches: null;
   simulate: SimulationRequest;
   "simulate-existing": ExistingSimulationRequest;
-  stats: ActionFilter[];
+  stats: { filters: ActionFilter[]; wait: boolean };
   tags: ActionFilter[];
   type: { value: string; format: string };
 }

--- a/shesmu-server-ui/src/olive.ts
+++ b/shesmu-server-ui/src/olive.ts
@@ -278,7 +278,7 @@ export function initialiseOliveDash(
     "toolbar",
     "main"
   );
-  const { ui: statsUi, model: statsModel } = actionStats(
+  const { ui: statsUi, toolbar: statsToolbar, model: statsModel } = actionStats(
     (...limits) => search.addPropertySearch(...limits),
     (typeName, start, end, ...limits) =>
       search.addRangeSearch(typeName, start, end, ...limits),
@@ -556,6 +556,7 @@ export function initialiseOliveDash(
       refreshButton(model.reload),
       pauseOliveButton,
       pauseFileButton,
+      statsToolbar,
       bulkCommands,
       helpArea("olive")
     ),

--- a/shesmu-server-ui/src/pause.ts
+++ b/shesmu-server-ui/src/pause.ts
@@ -91,7 +91,7 @@ export function initialisePauseDashboard(pauses: Pauses) {
     tabs(
       { contents: stats.ui, name: "Overview" },
       {
-        contents: [actions.bulkCommands, br(), actions.actions],
+        contents: [stats.toolbar, actions.bulkCommands, br(), actions.actions],
         name: "Actions",
       }
     )

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/StatsRequest.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/StatsRequest.java
@@ -1,0 +1,24 @@
+package ca.on.oicr.gsi.shesmu;
+
+import ca.on.oicr.gsi.shesmu.plugin.filter.ActionFilter;
+
+public class StatsRequest {
+  private ActionFilter[] filters;
+  private boolean wait;
+
+  public ActionFilter[] getFilters() {
+    return filters;
+  }
+
+  public boolean isWait() {
+    return wait;
+  }
+
+  public void setFilters(ActionFilter[] filters) {
+    this.filters = filters;
+  }
+
+  public void setWait(boolean wait) {
+    this.wait = wait;
+  }
+}


### PR DESCRIPTION
When viewing the actions dashboard for all actions, the time to compute stats
causes unpleasant delay. This creates a time budget for stats to be computed in
and discards stats if the budget is exceeded.