### PR TITLE
Replace Pinery project clinical flag with pipeline

### DIFF
--- a/plugin-niassa+pinery/pom.xml
+++ b/plugin-niassa+pinery/pom.xml
@@ -42,12 +42,12 @@
     <dependency>
       <groupId>ca.on.oicr.gsi</groupId>
       <artifactId>pipedev-provenance-impl</artifactId>
-      <version>2.5.14</version>
+      <version>2.5.18</version>
     </dependency>
     <dependency>
       <groupId>ca.on.oicr.gsi</groupId>
       <artifactId>pipedev-decider-utils</artifactId>
-      <version>2.5.14</version>
+      <version>2.5.18</version>
     </dependency>
     <dependency>
       <groupId>ca.on.oicr.gsi</groupId>

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryProjectValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryProjectValue.java
@@ -18,13 +18,13 @@ public class PineryProjectValue {
   }
 
   @ShesmuVariable
-  public boolean clinical() {
-    return backing.isClinical();
+  public String name() {
+    return backing.getName();
   }
 
   @ShesmuVariable
-  public String name() {
-    return backing.getName();
+  public String pipeline() {
+    return backing.getPipeline();
   }
 
   @ShesmuVariable


### PR DESCRIPTION
The clinical flag is not used by any olives, so it is safe to remove.