### PR TITLE
Allow saving action IDs from the UI

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -192,6 +192,24 @@ export const standardExports: ExportSearchCommand[] = [
       }),
   },
   {
+    icon: "clipboard-data",
+    label: "cURL Action Identifiers",
+    description:
+      "Convert search to a cURL command to extract action identifiers.",
+    category: "Command Line",
+    categoryIcon: "terminal",
+    callback: (filters) => copyCUrlCommand("action-ids", filters),
+  },
+  {
+    icon: "clipboard-data",
+    label: "Wget Action Identifiers",
+    description:
+      "Convert search to a Wget command to extract action idetnifiers.",
+    category: "Command Line",
+    categoryIcon: "terminal",
+    callback: (filters) => copyWgetCommand("action-ids", filters),
+  },
+  {
     icon: "clipboard-x",
     label: "cURL Purge",
     description: "Convert search to a cURL command to purge matching actions.",
@@ -222,6 +240,40 @@ export const standardExports: ExportSearchCommand[] = [
     category: "Command Line",
     categoryIcon: "terminal",
     callback: (filters) => copyWgetCommand("drain", filters),
+  },
+  {
+    icon: "clipboard",
+    label: "To Clipboard as JSON",
+    description:
+      "Export action identifiers in the current view as a JSON array to the clipboard.",
+    category: "Action Identifiers",
+    categoryIcon: "camera-reels",
+    callback: (filters) =>
+      fetchJsonWithBusyDialog("action-ids", filters, saveClipboardJson),
+  },
+  {
+    icon: "clipboard-plus",
+    label: "To Clipboard as Text",
+    description:
+      "Export action identifiers in the current view as a text list to the clipboard.",
+    category: "Action Identifiers",
+    categoryIcon: "camera-reels",
+    callback: (filters) =>
+      fetchJsonWithBusyDialog("action-ids", filters, (ids) =>
+        saveClipboard(ids.join("\n"))
+      ),
+  },
+  {
+    icon: "cloud-download",
+    label: "To JSON File",
+    description:
+      "Export action identifiers in the current view as a JSON array to a file.",
+    category: "Action Identifiers",
+    categoryIcon: "camera-reels",
+    callback: (filters) =>
+      fetchJsonWithBusyDialog("action-ids", filters, (ids) =>
+        saveFile(JSON.stringify(ids), "application/json", "Action IDs.json")
+      ),
   },
 ];
 

--- a/shesmu-server-ui/src/io.ts
+++ b/shesmu-server-ui/src/io.ts
@@ -55,6 +55,7 @@ export interface MutableServerInfo<I, R> {
  * Null entires are GET requests; all others are treated as POST requests
  */
 export interface ShesmuRequestType {
+  "action-ids": ActionFilter[];
   allalerts: null;
   command: { command: string; filters: ActionFilter[] };
   constant: string;
@@ -83,6 +84,7 @@ export interface ShesmuRequestType {
  * These are the response types for all the endpoints where JSON requests can be made to the server
  */
 export interface ShesmuResponseType {
+  "action-ids": string[];
   allalerts: PrometheusAlert[];
   command: number;
   constant: ValueResponse;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -668,6 +668,10 @@ public final class ActionProcessor
     return false;
   }
 
+  public Stream<String> actionIds(Filter... filters) {
+    return startStream(filters).map(e -> e.getValue().id);
+  }
+
   /**
    * Check that an action was last added in the time range provided
    *


### PR DESCRIPTION
Add a new endpoint to get action IDs for a particular search. Since this
endpoint does not convert the actions to JSON, it is much cheaper than using
the normal action query end-point and extracting the action IDs. The goal of
this is to create a snapshot of actions for putting in tickets rather than a
query that can hide new actions.