### PR TITLE
Sign IUS in `cerberus_fp` and `pinery_ius` formats

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusFileProvenanceValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusFileProvenanceValue.java
@@ -327,7 +327,7 @@ public final class CerberusFileProvenanceValue {
     return instrument_model;
   }
 
-  @ShesmuVariable(type = "t3sis")
+  @ShesmuVariable(type = "t3sis", signable = true)
   public Tuple ius() {
     return ius;
   }

--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryIUSValue.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryIUSValue.java
@@ -328,7 +328,7 @@ public final class PineryIUSValue {
     return is_sample;
   }
 
-  @ShesmuVariable(type = "t3sis")
+  @ShesmuVariable(type = "t3sis", signable = true)
   public Tuple ius() {
     return ius;
   }


### PR DESCRIPTION
We had originally assumed that IUSs couldn't change, but a long history of
barcode issues has taught us that this isn't the case, so this will now include
the IUS in the signature.