### PR TITLE
Refactor action filter parser

### DIFF
--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.Definer;
 import ca.on.oicr.gsi.shesmu.plugin.FrontEndIcon;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import ca.on.oicr.gsi.shesmu.plugin.action.ShesmuAction;
 import ca.on.oicr.gsi.shesmu.plugin.cache.KeyValueCache;
 import ca.on.oicr.gsi.shesmu.plugin.cache.MergingRecord;
@@ -142,7 +143,8 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
       return assignee;
     }
 
-    <F> Pair<String, F> process(String name, ActionFilterBuilder<F> builder) {
+    <F> Pair<String, F> process(
+        String name, ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
       return new Pair<>(
           name.replace("{key}", key).replace("{summary}", summary).replace("{assignee}", assignee),
           filter.convert(builder));
@@ -303,7 +305,8 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
   }
 
   @Override
-  public <F> Stream<Pair<String, F>> searches(ActionFilterBuilder<F> builder) {
+  public <F> Stream<Pair<String, F>> searches(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
     try {
       return searches
           .stream()

--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JoiningRule.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JoiningRule.java
@@ -1,8 +1,10 @@
 package ca.on.oicr.gsi.shesmu.jira;
 
 import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import ca.on.oicr.gsi.shesmu.plugin.filter.ActionFilter;
 import ca.on.oicr.gsi.shesmu.plugin.filter.ActionFilterBuilder;
+import java.time.Instant;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -15,7 +17,7 @@ public enum JoiningRule {
         String baseName,
         F baseFilters,
         Stream<JiraConnection.JiraActionFilter> accessoryFilters,
-        ActionFilterBuilder<F> builder) {
+        ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
       return ActionFilter.joinAllExcept(
           baseName, baseFilters, accessoryFilters.map(f -> f.process(baseName, builder)), builder);
     }
@@ -27,7 +29,7 @@ public enum JoiningRule {
         String baseName,
         F baseFilters,
         Stream<JiraConnection.JiraActionFilter> accessoryFilters,
-        ActionFilterBuilder<F> builder) {
+        ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
       return ActionFilter.joinAllAnd(
           baseName, baseFilters, accessoryFilters.map(f -> f.process(baseName, builder)), builder);
     }
@@ -42,7 +44,7 @@ public enum JoiningRule {
         String baseName,
         F baseFilters,
         Stream<JiraConnection.JiraActionFilter> accessoryFilters,
-        ActionFilterBuilder<F> builder) {
+        ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
       return ActionFilter.joinEachAnd(
           baseName, baseFilters, accessoryFilters.map(f -> f.process(baseName, builder)), builder);
     }
@@ -53,7 +55,7 @@ public enum JoiningRule {
         String baseName,
         F baseFilters,
         Stream<JiraConnection.JiraActionFilter> accessoryFilters,
-        ActionFilterBuilder<F> builder) {
+        ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
       return accessoryFilters
           .collect(Collectors.groupingBy(JiraConnection.JiraActionFilter::assignee))
           .entrySet()
@@ -83,5 +85,5 @@ public enum JoiningRule {
       String baseName,
       F baseFilters,
       Stream<JiraConnection.JiraActionFilter> accessoryFilters,
-      ActionFilterBuilder<F> builder);
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> builder);
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFile.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFile.java
@@ -2,12 +2,14 @@ package ca.on.oicr.gsi.shesmu.plugin;
 
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.action.Action;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import ca.on.oicr.gsi.shesmu.plugin.dumper.Dumper;
 import ca.on.oicr.gsi.shesmu.plugin.filter.ActionFilterBuilder;
 import ca.on.oicr.gsi.shesmu.plugin.filter.ExportSearch;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.status.SectionRenderer;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -76,7 +78,8 @@ public abstract class PluginFile implements RequiredServices {
   public void pushAlerts(String alertJson) {}
 
   /** Create a list of searches */
-  public <F> Stream<Pair<String, F>> searches(ActionFilterBuilder<F> builder) {
+  public <F> Stream<Pair<String, F>> searches(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
     return Stream.empty();
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFileType.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/PluginFileType.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.shesmu.plugin;
 
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.action.Action;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import ca.on.oicr.gsi.shesmu.plugin.dumper.Dumper;
 import ca.on.oicr.gsi.shesmu.plugin.filter.ActionFilterBuilder;
 import ca.on.oicr.gsi.shesmu.plugin.filter.ExportSearch;
@@ -10,6 +11,7 @@ import java.io.PrintStream;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -145,7 +147,8 @@ public abstract class PluginFileType<T extends PluginFile> {
   public void pushAlerts(String alertJson) {}
 
   /** Create a list of searches */
-  public <F> Stream<Pair<String, F>> searches(ActionFilterBuilder<F> builder) {
+  public <F> Stream<Pair<String, F>> searches(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
     return Stream.empty();
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterAdded.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterAdded.java
@@ -1,12 +1,15 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import java.time.Instant;
 import java.util.Optional;
 
 public class ActionFilterAdded extends BaseRangeActionFilter {
   @Override
   protected <F> F convert(
-      Optional<Instant> start, Optional<Instant> end, ActionFilterBuilder<F> filterBuilder) {
+      Optional<Instant> start,
+      Optional<Instant> end,
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return filterBuilder.added(start, end);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterAddedAgo.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterAddedAgo.java
@@ -1,8 +1,12 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+
 public class ActionFilterAddedAgo extends BaseAgoActionFilter {
   @Override
-  protected <F> F convert(long offset, ActionFilterBuilder<F> filterBuilder) {
+  protected <F> F convert(
+      long offset, ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return filterBuilder.addedAgo(offset);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterAnd.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterAnd.java
@@ -1,10 +1,13 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
 import java.util.stream.Stream;
 
 public class ActionFilterAnd extends BaseCollectionActionFilter {
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder, Stream<F> filters) {
+  public <F> F convert(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder, Stream<F> filters) {
     return filterBuilder.and(filters);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterChecked.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterChecked.java
@@ -1,12 +1,15 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import java.time.Instant;
 import java.util.Optional;
 
 public class ActionFilterChecked extends BaseRangeActionFilter {
   @Override
   public <F> F convert(
-      Optional<Instant> start, Optional<Instant> end, ActionFilterBuilder<F> filterBuilder) {
+      Optional<Instant> start,
+      Optional<Instant> end,
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return filterBuilder.checked(start, end);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterCheckedAgo.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterCheckedAgo.java
@@ -1,8 +1,12 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+
 public class ActionFilterCheckedAgo extends BaseAgoActionFilter {
   @Override
-  public <F> F convert(long offset, ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(
+      long offset, ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return filterBuilder.checkedAgo(offset);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterExternal.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterExternal.java
@@ -1,12 +1,15 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import java.time.Instant;
 import java.util.Optional;
 
 public class ActionFilterExternal extends BaseRangeActionFilter {
   @Override
   public <F> F convert(
-      Optional<Instant> start, Optional<Instant> end, ActionFilterBuilder<F> filterBuilder) {
+      Optional<Instant> start,
+      Optional<Instant> end,
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return filterBuilder.external(start, end);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterExternalAgo.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterExternalAgo.java
@@ -1,9 +1,13 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+
 public class ActionFilterExternalAgo extends BaseAgoActionFilter {
 
   @Override
-  public <F> F convert(long offset, ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(
+      long offset, ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return filterBuilder.externalAgo(offset);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterIds.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterIds.java
@@ -1,12 +1,14 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
 import java.util.List;
 
 public class ActionFilterIds extends ActionFilter {
   private List<String> ids;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(filterBuilder.ids(ids), filterBuilder);
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterOr.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterOr.java
@@ -1,11 +1,14 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
 import java.util.stream.Stream;
 
 public class ActionFilterOr extends BaseCollectionActionFilter {
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder, Stream<F> filters) {
+  public <F> F convert(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder, Stream<F> filters) {
     return filterBuilder.or(filters);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterRegex.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterRegex.java
@@ -1,5 +1,7 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
 import java.util.regex.Pattern;
 
 public class ActionFilterRegex extends ActionFilter {
@@ -7,7 +9,7 @@ public class ActionFilterRegex extends ActionFilter {
   private String pattern;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(
         filterBuilder.textSearch(
             Pattern.compile(pattern, matchCase ? 0 : Pattern.CASE_INSENSITIVE)),

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterSourceFile.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterSourceFile.java
@@ -1,11 +1,15 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+import java.util.stream.Stream;
+
 public class ActionFilterSourceFile extends ActionFilter {
   private String[] files;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
-    return maybeNegate(filterBuilder.fromFile(files), filterBuilder);
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
+    return maybeNegate(filterBuilder.fromFile(Stream.of(files)), filterBuilder);
   }
 
   public String[] getFiles() {

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterSourceLocation.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterSourceLocation.java
@@ -1,12 +1,14 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
 import java.util.stream.Stream;
 
 public class ActionFilterSourceLocation extends ActionFilter {
   private SourceOliveLocation[] locations;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(filterBuilder.fromSourceLocation(Stream.of(locations)), filterBuilder);
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterStatus.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterStatus.java
@@ -1,13 +1,15 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+import java.util.stream.Stream;
 
 public class ActionFilterStatus extends ActionFilter {
   private ActionState[] states;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
-    return maybeNegate(filterBuilder.isState(states), filterBuilder);
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
+    return maybeNegate(filterBuilder.isState(Stream.of(states)), filterBuilder);
   }
 
   public ActionState[] getStates() {

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterStatusChanged.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterStatusChanged.java
@@ -1,12 +1,15 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import java.time.Instant;
 import java.util.Optional;
 
 public class ActionFilterStatusChanged extends BaseRangeActionFilter {
   @Override
   public <F> F convert(
-      Optional<Instant> start, Optional<Instant> end, ActionFilterBuilder<F> filterBuilder) {
+      Optional<Instant> start,
+      Optional<Instant> end,
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return filterBuilder.statusChanged(start, end);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterStatusChangedAgo.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterStatusChangedAgo.java
@@ -1,8 +1,12 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+
 public class ActionFilterStatusChangedAgo extends BaseAgoActionFilter {
   @Override
-  public <F> F convert(long offset, ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(
+      long offset, ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return filterBuilder.statusChangedAgo(offset);
   }
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterTag.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterTag.java
@@ -1,12 +1,14 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
 import java.util.stream.Stream;
 
 public class ActionFilterTag extends ActionFilter {
   private String[] tags;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(filterBuilder.tags(Stream.of(tags)), filterBuilder);
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterTagRegex.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterTagRegex.java
@@ -1,5 +1,7 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
 import java.util.regex.Pattern;
 
 public class ActionFilterTagRegex extends ActionFilter {
@@ -7,7 +9,7 @@ public class ActionFilterTagRegex extends ActionFilter {
   private String pattern;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(
         filterBuilder.tag(Pattern.compile(pattern, matchCase ? 0 : Pattern.CASE_INSENSITIVE)),
         filterBuilder);

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterText.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterText.java
@@ -1,11 +1,14 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+
 public class ActionFilterText extends ActionFilter {
   private boolean matchCase;
   private String text;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(filterBuilder.textSearch(text, matchCase), filterBuilder);
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterType.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterType.java
@@ -1,11 +1,15 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+import java.util.stream.Stream;
+
 public class ActionFilterType extends ActionFilter {
   private String[] types;
 
   @Override
-  public <F> F convert(ActionFilterBuilder<F> filterBuilder) {
-    return maybeNegate(filterBuilder.type(types), filterBuilder);
+  public <F> F convert(ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
+    return maybeNegate(filterBuilder.type(Stream.of(types)), filterBuilder);
   }
 
   public String[] getTypes() {

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/BaseAgoActionFilter.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/BaseAgoActionFilter.java
@@ -1,13 +1,18 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
+
 public abstract class BaseAgoActionFilter extends ActionFilter {
 
   private long offset;
 
-  protected abstract <F> F convert(long offset, ActionFilterBuilder<F> filterBuilder);
+  protected abstract <F> F convert(
+      long offset, ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder);
 
   @Override
-  public final <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public final <F> F convert(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(convert(offset, filterBuilder), filterBuilder);
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/BaseCollectionActionFilter.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/BaseCollectionActionFilter.java
@@ -1,19 +1,23 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import java.time.Instant;
 import java.util.stream.Stream;
 
 public abstract class BaseCollectionActionFilter extends ActionFilter {
   private ActionFilter[] filters;
 
   @Override
-  public final <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public final <F> F convert(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(
         convert(
             filterBuilder, Stream.of(filters).map(filterJson -> filterJson.convert(filterBuilder))),
         filterBuilder);
   }
 
-  protected abstract <F> F convert(ActionFilterBuilder<F> filterBuilder, Stream<F> filters);
+  protected abstract <F> F convert(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder, Stream<F> filters);
 
   public final ActionFilter[] getFilters() {
     return filters;

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/BaseRangeActionFilter.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/BaseRangeActionFilter.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.plugin.filter;
 
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -9,10 +10,13 @@ public abstract class BaseRangeActionFilter extends ActionFilter {
   private Long start;
 
   protected abstract <F> F convert(
-      Optional<Instant> start, Optional<Instant> end, ActionFilterBuilder<F> filterBuilder);
+      Optional<Instant> start,
+      Optional<Instant> end,
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder);
 
   @Override
-  public final <F> F convert(ActionFilterBuilder<F> filterBuilder) {
+  public final <F> F convert(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> filterBuilder) {
     return maybeNegate(
         convert(
             Optional.ofNullable(start).map(Instant::ofEpochMilli),

--- a/shesmu-pluginapi/src/test/java/ca/on/oicr/gsi/shesmu/plugin/TextFilterParseTest.java
+++ b/shesmu-pluginapi/src/test/java/ca/on/oicr/gsi/shesmu/plugin/TextFilterParseTest.java
@@ -14,7 +14,34 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TextFilterParseTest {
-  private abstract static class TestFilterBuilder implements ActionFilterBuilder<Boolean> {
+  private abstract static class TestFilterBuilder
+      implements ActionFilterBuilder<Boolean, ActionState, String, Instant, Long> {
+
+    @Override
+    public Boolean addedAgo(Long offset) {
+      return false;
+    }
+
+    @Override
+    public Boolean checkedAgo(Long offset) {
+      return false;
+    }
+
+    @Override
+    public Boolean externalAgo(Long offset) {
+      return false;
+    }
+
+    @Override
+    public Boolean fromJson(ActionFilter actionFilter) {
+      return false;
+    }
+
+    @Override
+    public Boolean statusChangedAgo(Long offset) {
+      return false;
+    }
+
     @Override
     public Boolean added(Optional<Instant> start, Optional<Instant> end) {
       return false;
@@ -41,7 +68,7 @@ public class TextFilterParseTest {
     }
 
     @Override
-    public Boolean fromFile(String... files) {
+    public Boolean fromFile(Stream<String> files) {
       return false;
     }
 
@@ -51,7 +78,7 @@ public class TextFilterParseTest {
     }
 
     @Override
-    public Boolean isState(ActionState... states) {
+    public Boolean isState(Stream<ActionState> states) {
       return false;
     }
 
@@ -76,7 +103,7 @@ public class TextFilterParseTest {
     }
 
     @Override
-    public Boolean type(String... types) {
+    public Boolean type(Stream<String> types) {
       return false;
     }
   }
@@ -104,6 +131,11 @@ public class TextFilterParseTest {
                           public Boolean textSearch(Pattern pattern) {
                             return pattern.matcher("test").matches();
                           }
+
+                          @Override
+                          public Boolean textSearch(String text, boolean matchCase) {
+                            return text.equals("test");
+                          }
                         }))
             .orElse(false));
   }
@@ -128,6 +160,11 @@ public class TextFilterParseTest {
                           public Boolean textSearch(Pattern pattern) {
                             return false;
                           }
+
+                          @Override
+                          public Boolean textSearch(String text, boolean matchCase) {
+                            return false;
+                          }
                         }))
             .orElse(false));
   }
@@ -150,6 +187,11 @@ public class TextFilterParseTest {
                           @Override
                           public Boolean textSearch(Pattern pattern) {
                             return pattern.matcher("test").matches();
+                          }
+
+                          @Override
+                          public Boolean textSearch(String text, boolean matchCase) {
+                            return text.equals("test");
                           }
                         }))
             .orElse(false));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
@@ -16,6 +16,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureVariableForStaticSign
 import ca.on.oicr.gsi.shesmu.plugin.*;
 import ca.on.oicr.gsi.shesmu.plugin.SourceLocation.SourceLocationLinker;
 import ca.on.oicr.gsi.shesmu.plugin.action.Action;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import ca.on.oicr.gsi.shesmu.plugin.action.CustomActionParameter;
 import ca.on.oicr.gsi.shesmu.plugin.action.ShesmuAction;
 import ca.on.oicr.gsi.shesmu.plugin.dumper.Dumper;
@@ -61,6 +62,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.TypeVariable;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -832,7 +834,8 @@ public final class PluginManager
         return Stream.concat(refillers.values().stream(), refillersFromAnnotations.stream());
       }
 
-      public <F> Stream<Pair<String, F>> searches(ActionFilterBuilder<F> builder) {
+      public <F> Stream<Pair<String, F>> searches(
+          ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
         return instance.searches(builder);
       }
 
@@ -1592,7 +1595,8 @@ public final class PluginManager
           staticRefillers.stream(), configuration.stream().flatMap(FileWrapper::refillers));
     }
 
-    public <F> Stream<Pair<String, F>> searches(ActionFilterBuilder<F> builder) {
+    public <F> Stream<Pair<String, F>> searches(
+        ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
       return Stream.concat(
           fileFormat.searches(builder), configuration.stream().flatMap(f -> f.searches(builder)));
     }
@@ -1970,7 +1974,8 @@ public final class PluginManager
     return formatTypes.stream().flatMap(FormatTypeWrapper::refillers);
   }
 
-  public <F> Stream<Pair<String, F>> searches(ActionFilterBuilder<F> builder) {
+  public <F> Stream<Pair<String, F>> searches(
+      ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
     return formatTypes.stream().flatMap(formatType -> formatType.searches(builder));
   }
 


### PR DESCRIPTION
Redesign the action filter interface so that the normal query parser and the
guided meditations parser can share the parser even though they have different
terminals.