### PR TITLE
Fix LIMS key locking again

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/AnalysisState.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/niassa/AnalysisState.java
@@ -169,7 +169,7 @@ public class AnalysisState implements Comparable<AnalysisState> {
   public void addSeenLimsKeys(Set<Pair<String, String>> seenLimsKeys) {
     limsKeys
         .stream()
-        .map(l -> new Pair<>(l.first().getProvider(), l.first().getVersion()))
+        .map(l -> new Pair<>(l.first().getProvider(), l.first().getId()))
         .forEach(seenLimsKeys::add);
   }
 


### PR DESCRIPTION
This bug means that locks are acquired on `(provider, id)`, but released on
`(provider, version)`, which is necessarily disjoint, so locks were not being
released even on success.