### PR TITLE
Fix bug preventing _Pause Script_ button from showing

### DIFF
--- a/shesmu-server-ui/src/olive.ts
+++ b/shesmu-server-ui/src/olive.ts
@@ -411,7 +411,7 @@ export function initialiseOliveDash(
       "pausefile",
       pauseFileModel,
       (reference: OliveReference, desired: boolean | null) =>
-        reference && desired !== null
+        reference
           ? {
               file: reference.script.file,
               line: null,


### PR DESCRIPTION
It needs to make a request to the server to know its own state and there was a
check that only made the request happen when it was trying to change its state.