### PR TITLE
Add custom grouper for set combinations

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CombinationsGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CombinationsGrouper.java
@@ -1,0 +1,64 @@
+package ca.on.oicr.gsi.shesmu.runtime;
+
+import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
+import ca.on.oicr.gsi.shesmu.plugin.grouper.Subgroup;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public final class CombinationsGrouper<I, O> implements Grouper<I, O> {
+
+  private final int groupSize;
+  private final Supplier<BiConsumer<O, I>> collectorConstructor;
+
+  public CombinationsGrouper(long groupSize, Supplier<BiConsumer<O, I>> collectorConstructor) {
+    this.groupSize = (int) groupSize;
+    this.collectorConstructor = collectorConstructor;
+  }
+
+  private List<int[]> generate(int total) {
+    // https://www.baeldung.com/java-combinations-algorithm
+    final List<int[]> combinations = new ArrayList<>();
+    int[] combination = new int[groupSize];
+
+    // initialize with lowest lexicographic combination
+    for (int i = 0; i < groupSize; i++) {
+      combination[i] = i;
+    }
+
+    while (combination[groupSize - 1] < total) {
+      combinations.add(combination.clone());
+
+      // generate next combination in lexicographic order
+      int t = groupSize - 1;
+      while (t != 0 && combination[t] == total - groupSize + t) {
+        t--;
+      }
+      combination[t]++;
+      for (int i = t + 1; i < groupSize; i++) {
+        combination[i] = combination[i - 1] + 1;
+      }
+    }
+
+    return combinations;
+  }
+
+  @Override
+  public Stream<Subgroup<I, O>> group(List<I> inputs) {
+    if (inputs.size() < groupSize) {
+      return Stream.empty();
+    }
+    if (inputs.size() == groupSize) {
+      return Stream.of(new Subgroup<>(collectorConstructor.get(), inputs.stream()));
+    }
+    return generate(inputs.size())
+        .stream()
+        .map(
+            combinations ->
+                new Subgroup<>(
+                    collectorConstructor.get(), IntStream.of(combinations).mapToObj(inputs::get)));
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CombinationsGrouperDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CombinationsGrouperDefinition.java
@@ -1,0 +1,26 @@
+package ca.on.oicr.gsi.shesmu.runtime;
+
+import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;
+import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperOutputs;
+import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperParameter;
+import ca.on.oicr.gsi.shesmu.plugin.types.TypeGuarantee;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices
+public final class CombinationsGrouperDefinition extends GrouperDefinition {
+  public CombinationsGrouperDefinition() {
+    super(
+        "combinations",
+        GrouperParameter.fixed(
+            "group_size",
+            TypeGuarantee.LONG,
+            "The number of elements to include in the output groups (e.g., 2 for all pairs)."),
+        GrouperOutputs.empty(),
+        CombinationsGrouper::new);
+  }
+
+  @Override
+  public String description() {
+    return "Creates all combinations of the input of a particular group size.";
+  }
+}


### PR DESCRIPTION
This custom grouper will produce all combinations of input groups of a
particular size. Requested for an olive to process all pairs for sample-swap
detection.