### PR TITLE
Make `JsonWrapper` part of the public API under a better name

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/json/AsJsonNode.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/json/AsJsonNode.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.plugin.json;
 
 import ca.on.oicr.gsi.shesmu.plugin.types.Field;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
@@ -14,9 +14,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public class JsonWrapper implements ImyhatFunction<JsonNode> {
+public class AsJsonNode implements ImyhatFunction<JsonNode> {
   public static JsonNode convert(Imyhat type, Object value) {
-    return type.apply(new JsonWrapper(), value);
+    return type.apply(new AsJsonNode(), value);
   }
 
   private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
@@ -25,7 +25,7 @@ public class JsonWrapper implements ImyhatFunction<JsonNode> {
   public JsonNode apply(String name, AccessContents accessor) {
     final ObjectNode objectNode = FACTORY.objectNode();
     objectNode.put("type", name);
-    objectNode.put("value", accessor.apply(this));
+    objectNode.set("value", accessor.apply(this));
     return objectNode;
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeConvertedVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeConvertedVariable.java
@@ -2,8 +2,8 @@ package ca.on.oicr.gsi.shesmu.compiler;
 
 import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
 
+import ca.on.oicr.gsi.shesmu.plugin.json.AsJsonNode;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
-import ca.on.oicr.gsi.shesmu.runtime.JsonWrapper;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -95,7 +95,7 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
     @Override
     protected void convert(Renderer renderer) {
       renderer.methodGen().valueOf(type.apply(TO_ASM));
-      renderer.methodGen().invokeStatic(A_JSON_WRAPPER_TYPE, JSON_CONVERTER__CONVERT);
+      renderer.methodGen().invokeStatic(A_AS_JSON_NODE_TYPE, JSON_CONVERTER__CONVERT);
     }
 
     @Override
@@ -132,8 +132,8 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
     }
   }
 
+  private static final Type A_AS_JSON_NODE_TYPE = Type.getType(AsJsonNode.class);
   private static final Type A_DOUBLE_TYPE = Type.getType(Double.class);
-  private static final Type A_JSON_WRAPPER_TYPE = Type.getType(JsonWrapper.class);
   private static final Type A_LONG_TYPE = Type.getType(Long.class);
   private static final Type A_OBJECT_MAPPER_TYPE = Type.getType(ObjectMapper.class);
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
@@ -166,13 +166,13 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
         }
 
         @Override
-        public int line() {
-          return line;
+        public Flavour flavour() {
+          return flavour;
         }
 
         @Override
-        public Flavour flavour() {
-          return flavour;
+        public int line() {
+          return line;
         }
 
         @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeJsonConvert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeJsonConvert.java
@@ -2,10 +2,10 @@ package ca.on.oicr.gsi.shesmu.compiler;
 
 import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
 
+import ca.on.oicr.gsi.shesmu.plugin.json.AsJsonNode;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.plugin.types.ImyhatTransformer;
 import ca.on.oicr.gsi.shesmu.runtime.JsonConverter;
-import ca.on.oicr.gsi.shesmu.runtime.JsonWrapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -16,10 +16,10 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
 
 public class ExpressionNodeJsonConvert extends ExpressionNode {
+  private static final Type A_AS_JSON_NODE_TYPE = Type.getType(AsJsonNode.class);
   private static final Type A_IMYHAT_TYPE = Type.getType(Imyhat.class);
   private static final Type A_JSON_CONVERTER_TYPE = Type.getType(JsonConverter.class);
   private static final Type A_JSON_NODE_TYPE = Type.getType(JsonNode.class);
-  private static final Type A_JSON_WRAPPER_TYPE = Type.getType(JsonWrapper.class);
   private static final Type A_OPTIONAL_TYPE = Type.getType(Optional.class);
   private static final Method IMYHAT__APPLY =
       new Method(
@@ -53,17 +53,12 @@ public class ExpressionNodeJsonConvert extends ExpressionNode {
   }
 
   @Override
-  public String renderEcma(EcmaScriptRenderer renderer) {
-    return expression.renderEcma(renderer);
-  }
-
-  @Override
   public void render(Renderer renderer) {
     if (type.isSame(Imyhat.JSON)) {
       renderer.loadImyhat(expression.type().descriptor());
       expression.render(renderer);
       renderer.methodGen().valueOf(expression.type().apply(TO_ASM));
-      renderer.methodGen().invokeStatic(A_JSON_WRAPPER_TYPE, JSON_CONVERTER__CONVERT);
+      renderer.methodGen().invokeStatic(A_AS_JSON_NODE_TYPE, JSON_CONVERTER__CONVERT);
     } else {
       renderer.loadImyhat(type.descriptor());
       renderer.methodGen().newInstance(A_JSON_CONVERTER_TYPE);
@@ -73,6 +68,11 @@ public class ExpressionNodeJsonConvert extends ExpressionNode {
       renderer.methodGen().invokeVirtual(A_IMYHAT_TYPE, IMYHAT__APPLY);
       renderer.methodGen().checkCast(A_OPTIONAL_TYPE);
     }
+  }
+
+  @Override
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    return expression.renderEcma(renderer);
   }
 
   @Override


### PR DESCRIPTION
The class `JsonWrapper` converts a native Shesmu value into a `JsonNode`. This
is not obvious from the name and is useful to have in the public API.