### PR TITLE
Fix text query in action search

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -1555,7 +1555,8 @@ public final class ActionProcessor
   @Override
   public Filter textSearch(String text, boolean matchCase) {
     return textSearch(
-        Pattern.compile(Pattern.quote(text), matchCase ? 0 : Pattern.CASE_INSENSITIVE));
+        Pattern.compile(
+            ".*" + Pattern.quote(text) + ".*", matchCase ? 0 : Pattern.CASE_INSENSITIVE));
   }
 
   /** Check that an action has one of the types specified */


### PR DESCRIPTION
The text fragment search should match text anywhere rather than requiring the
entire input string to match. This changes the generated regular expression to
do that.