### PR TITLE
Clear barcode errors during grouping

### DIFF
--- a/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BarcodeGrouper.java
+++ b/plugin-niassa+pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BarcodeGrouper.java
@@ -32,6 +32,7 @@ public class BarcodeGrouper<I, O> implements Grouper<I, O> {
     this.basesMaskReader = basesMaskReader;
     this.barcodeReader = barcodeReader;
     this.collectorFactory = collectorFactory;
+    badGroups.clear();
   }
 
   @Override


### PR DESCRIPTION
If a run with a barcode is removed from from the input (by being set as
on-instrument QC by the lab), the error state will persist forever, which is
not ideal. This clears the Prometheus output before each run of the grouper to
eliminate any stale errors.