### PR TITLE
Fix type checking bug in guided meditation downloads

### DIFF
--- a/guided-meditations.md
+++ b/guided-meditations.md
@@ -311,20 +311,20 @@ may not appreciate that. There are three important things to do:
 - Restrict the number of variables required (_i.e._, have a `Let` clause that limits the variables to only the ones necessary)
 - Remove duplicate rows. Normally, Shesmu handles duplicates gracefully, but implementation details here make duplicate rows more of a problem. If selecting a small number of variables that will be mostly duplicated, use a `Group By` to ensure that duplicates are collapsed.
 
-    "Peer in the file system!"
-		Form
-			Entry text owner Label "What user are you interested in?"
-    Then
-      Fetch
-        Olive
-          Let owner = owner
-          unix_file
-            Where user == shesmu::simulated::owner Let file, size
-          To files
-      Then
-        Repeat {; file,  size} In files:
-          Begin Bold "{file}" " ({size}) " End
-      Stop
+     "Peer in the file system!"
+		 Form
+			 Entry text owner Label "What user are you interested in?"
+     Then
+       Fetch
+         Olive
+           Let owner = owner
+           unix_file
+             Where user == shesmu::simulated::owner Let file, size
+           To files
+       Then
+         Repeat {; file,  size} In files:
+           Begin Bold "{file}" " ({size}) " End
+       Stop
 
 ### Define and Go-to
 It can be useful to reuse steps in different contents. At the beginning of a

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/InformationNodeDownload.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/InformationNodeDownload.java
@@ -52,10 +52,10 @@ public class InformationNodeDownload extends InformationNode {
   @Override
   public boolean typeCheck(Consumer<String> errorHandler) {
     boolean ok = true;
-    if (fileName.typeCheck(errorHandler)) {
-      if (!fileName.type().isSame(Imyhat.STRING) && !fileName.type().isSame(Imyhat.JSON)) {
+    if (contents.typeCheck(errorHandler)) {
+      if (!contents.type().isSame(Imyhat.STRING) && !contents.type().isSame(Imyhat.JSON)) {
         ok = false;
-        fileName.typeError("json or string", fileName.type(), errorHandler);
+        contents.typeError("json or string", contents.type(), errorHandler);
       }
     } else {
       ok = false;
@@ -78,10 +78,10 @@ public class InformationNodeDownload extends InformationNode {
                 })
             .orElse(true);
 
-    if (contents.typeCheck(errorHandler)) {
-      if (!contents.type().isSame(Imyhat.STRING)) {
+    if (fileName.typeCheck(errorHandler)) {
+      if (!fileName.type().isSame(Imyhat.STRING)) {
         ok = false;
-        contents.typeError(Imyhat.STRING, contents.type(), errorHandler);
+        fileName.typeError(Imyhat.STRING, fileName.type(), errorHandler);
       }
     } else {
       ok = false;


### PR DESCRIPTION
The file _contents_ should be able to be a string or JSON, but the type check
was doing this on the _filename_.