### PR TITLE
Reduce Maven logging in Travis

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -12,13 +12,13 @@ case "${JAVA_HOME}" in
 		;;
 esac
 
-mvn -DskipIT=false clean install
+mvn -q -DskipIT=false clean install
 echo ${SONAR} ${TRAVIS_PULL_REQUEST}  ${TRAVIS_PULL_REQUEST_SLUG} ${TRAVIS_REPO_SLUG}
 if ${SONAR}
 then
 	if [ "${TRAVIS_PULL_REQUEST}" = "false" ] || [ "${TRAVIS_PULL_REQUEST_SLUG}" = "${TRAVIS_REPO_SLUG}" ]
 	then
-		mvn org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar
+		mvn -q org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar
 	else
 		echo "[WARN] SonarCloud cannot run on pull requests from forks."
 	fi


### PR DESCRIPTION
The logs are now long enough for Travis to give up while Maven downloads the
Internet.