### PR TITLE
Add action command responses

### DIFF
--- a/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/RunReport.java
+++ b/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/RunReport.java
@@ -42,12 +42,12 @@ public class RunReport extends JsonParameterisedAction {
           Preference.ALLOW_BULK,
           Preference.PROMPT) {
         @Override
-        protected boolean execute(RunReport action, Optional<String> user) {
+        protected Response execute(RunReport action, Optional<String> user) {
           if (action.reportRecordId.isPresent()) {
             action.forceRelaunch = true;
-            return true;
+            return Response.RESET;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   static final CloseableHttpClient HTTP_CLIENT = HttpClients.createDefault();

--- a/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/AnnotationAction.java
+++ b/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/AnnotationAction.java
@@ -34,12 +34,12 @@ public final class AnnotationAction<A extends Attribute<?, A>> extends Action {
           Preference.ALLOW_BULK,
           Preference.ANNOY_USER) {
         @Override
-        protected boolean execute(AnnotationAction action, Optional<String> user) {
+        protected Response execute(AnnotationAction action, Optional<String> user) {
           if (!action.automatic) {
             action.automatic = true;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
 
@@ -100,8 +100,7 @@ public final class AnnotationAction<A extends Attribute<?, A>> extends Action {
       final int accession = Integer.parseInt(this.accession);
       final Metadata metadata = server.get().metadata();
       final Annotatable<A> item = type.fetch(metadata, accession);
-      if (item.getAnnotations()
-          .stream()
+      if (item.getAnnotations().stream()
           .anyMatch(a -> a.getTag().equals(key) && a.getValue().equals(value))) {
         metadata.clean_up();
         return ActionState.SUCCEEDED;

--- a/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -11,6 +11,7 @@ import ca.on.oicr.gsi.shesmu.plugin.Utils;
 import ca.on.oicr.gsi.shesmu.plugin.action.Action;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionCommand;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionCommand.Preference;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionCommand.Response;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionParameter;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionServices;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
@@ -66,12 +67,12 @@ public final class WorkflowAction extends Action {
           Preference.ALLOW_BULK,
           Preference.PROMPT) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           if (!action.overrideLock) {
             action.overrideLock = true;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   private static final ActionCommand<WorkflowAction> IGNORE_MAX_IN_FLIGHT_COMMAND =
@@ -82,12 +83,12 @@ public final class WorkflowAction extends Action {
           "Ignore Max-in-flight Limit",
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           if (!action.ignoreMaxInFlight) {
             action.ignoreMaxInFlight = true;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   private static final ActionCommand<WorkflowAction> INVALIDATE_ESSENTIALS_COMMAND =
@@ -98,12 +99,12 @@ public final class WorkflowAction extends Action {
           "Refresh Run Information",
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           if (action.runAccession != 0) {
             action.server.get().invalidateDirectoryAndIni(action.runAccession);
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   static final Comparator<LimsKey> LIMS_ID_COMPARATOR =
@@ -119,12 +120,12 @@ public final class WorkflowAction extends Action {
           "Use High Priority",
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           if (!action.priorityBoost) {
             action.priorityBoost = true;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   private static final ActionCommand<WorkflowAction> PRIORITY_NICE_COMMAND =
@@ -135,12 +136,12 @@ public final class WorkflowAction extends Action {
           "Use Normal Priority",
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           if (action.priorityBoost) {
             action.priorityBoost = false;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   private static final ActionCommand<WorkflowAction> RESET_WFR_COMMAND =
@@ -151,7 +152,7 @@ public final class WorkflowAction extends Action {
           "Reset Workflow Run Connection",
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           return action.resetWorkflowRun();
         }
       };
@@ -163,12 +164,12 @@ public final class WorkflowAction extends Action {
           "Respect LIMS Key Lock",
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           if (action.overrideLock) {
             action.overrideLock = false;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   private static final ActionCommand<WorkflowAction> RESPECT_MAX_IN_FLIGHT_COMMAND =
@@ -179,12 +180,12 @@ public final class WorkflowAction extends Action {
           "Respect Max-in-flight Limit",
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           if (action.ignoreMaxInFlight) {
             action.ignoreMaxInFlight = false;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   private static final ActionCommand<WorkflowAction> RETRY_COMMAND =
@@ -196,9 +197,9 @@ public final class WorkflowAction extends Action {
           Preference.ALLOW_BULK,
           Preference.PROMPT) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           if (action.runAccession == 0) {
-            return false;
+            return Response.IGNORED;
           } else {
             try {
               final Metadata metadata = action.server.get().metadata();
@@ -209,13 +210,13 @@ public final class WorkflowAction extends Action {
                 metadata.updateWorkflowRun(run);
                 action.lastState = ActionState.UNKNOWN;
                 metadata.clean_up();
-                return true;
+                return Response.RESET;
               }
               metadata.clean_up();
             } catch (Exception e) {
               e.printStackTrace();
             }
-            return false;
+            return Response.IGNORED;
           }
         }
       };
@@ -229,7 +230,7 @@ public final class WorkflowAction extends Action {
           Preference.ANNOY_USER,
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           return action.skipWorkflowRunMatches(action.matches);
         }
       };
@@ -242,7 +243,7 @@ public final class WorkflowAction extends Action {
           Preference.ALLOW_BULK,
           Preference.PROMPT) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           return action.skipWorkflowRunMatches(action.matches.subList(1, action.matches.size()));
         }
       };
@@ -256,12 +257,10 @@ public final class WorkflowAction extends Action {
           Preference.ANNOY_USER,
           Preference.ALLOW_BULK) {
         @Override
-        protected boolean execute(WorkflowAction action, Optional<String> user) {
+        protected Response execute(WorkflowAction action, Optional<String> user) {
           action.skipWorkflowRun(
               action.runAccession,
-              action
-                  .matches
-                  .stream()
+              action.matches.stream()
                   .filter(m -> m.state().workflowRunAccession() == action.runAccession)
                   .findAny()
                   .map(m -> m.state().workflowAccession())
@@ -676,9 +675,7 @@ public final class WorkflowAction extends Action {
           final int iusAccession = iusAccessions.get(new SimpleLimsKey(signature.getKey()));
           metadata.annotateIUS(
               iusAccession,
-              signature
-                  .getValue()
-                  .stream()
+              signature.getValue().stream()
                   .map(
                       s -> {
                         final IUSAttribute attribute = new IUSAttribute();
@@ -701,11 +698,7 @@ public final class WorkflowAction extends Action {
           final Scheduler scheduler =
               new Scheduler(
                   metadata,
-                  server
-                      .get()
-                      .settings()
-                      .entrySet()
-                      .stream()
+                  server.get().settings().entrySet().stream()
                       .collect(Collectors.toMap(Object::toString, Object::toString)));
           runAccession =
               scheduler
@@ -714,9 +707,7 @@ public final class WorkflowAction extends Action {
                       Collections.singletonList(iniFile.getAbsolutePath()),
                       true,
                       Collections.emptyList(),
-                      iusAccessions
-                          .values()
-                          .stream()
+                      iusAccessions.values().stream()
                           .map(Object::toString)
                           .collect(Collectors.toList()),
                       Collections.emptyList(),
@@ -792,15 +783,15 @@ public final class WorkflowAction extends Action {
     server.get().analysisCache().invalidate(workflowAccession);
   }
 
-  private boolean resetWorkflowRun() {
+  private Response resetWorkflowRun() {
     if (runAccession == 0) {
-      return false;
+      return Response.IGNORED;
     } else {
       runAccession = 0;
       hasLaunched = false;
       lastState = ActionState.UNKNOWN;
       workflowAccessions().forEach(server.get().analysisCache()::invalidate);
-      return true;
+      return Response.RESET;
     }
   }
 
@@ -819,8 +810,7 @@ public final class WorkflowAction extends Action {
         || limsKeysCollection.matches(query)
         || workflowAccessions()
             .anyMatch(workflow -> query.matcher(Long.toString(workflow)).matches())
-        || matches
-            .stream()
+        || matches.stream()
             .anyMatch(
                 match ->
                     query
@@ -856,8 +846,7 @@ public final class WorkflowAction extends Action {
               .cromwellUrl()
               .ifPresent(
                   root ->
-                      run.getWorkflowRunAttributes()
-                          .stream()
+                      run.getWorkflowRunAttributes().stream()
                           .filter(a -> a.getTag().equals("cromwell-workflow-id"))
                           .map(WorkflowRunAttribute::getValue)
                           .forEach(
@@ -900,7 +889,7 @@ public final class WorkflowAction extends Action {
         Collections.emptyMap());
   }
 
-  private boolean skipWorkflowRunMatches(List<WorkflowRunMatch> runs) {
+  private Response skipWorkflowRunMatches(List<WorkflowRunMatch> runs) {
     final Set<Long> dirtyAccession = new TreeSet<>();
     for (final WorkflowRunMatch run : runs) {
       if (run.state().skipped()) {
@@ -912,7 +901,7 @@ public final class WorkflowAction extends Action {
     for (final long accession : dirtyAccession) {
       server.get().analysisCache().invalidate(accession);
     }
-    return !dirtyAccession.isEmpty();
+    return dirtyAccession.isEmpty() ? Response.IGNORED : Response.RESET;
   }
 
   @ActionParameter(required = false)
@@ -1001,8 +990,7 @@ public final class WorkflowAction extends Action {
         final ArrayNode outputFiles = node.putArray("files");
 
         final Iterable<FileInfo> files =
-            matches
-                .stream()
+            matches.stream()
                 .filter(m -> m.state().workflowRunAccession() == runAccession)
                 .findAny()
                 .map(m -> m.state().files())

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/DeleteAction.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/DeleteAction.java
@@ -30,12 +30,12 @@ public class DeleteAction extends Action {
           Preference.ALLOW_BULK,
           Preference.PROMPT) {
         @Override
-        protected boolean execute(DeleteAction action, Optional<String> user) {
+        protected Response execute(DeleteAction action, Optional<String> user) {
           if (!action.automatic) {
             action.automatic = true;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
 

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SymlinkAction.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SymlinkAction.java
@@ -31,12 +31,12 @@ public class SymlinkAction extends Action {
           Preference.ALLOW_BULK) {
 
         @Override
-        protected boolean execute(SymlinkAction action, Optional user) {
+        protected Response execute(SymlinkAction action, Optional user) {
           if (!action.automatic) {
             action.automatic = true;
-            return true;
+            return Response.ACCEPTED;
           }
-          return false;
+          return Response.IGNORED;
         }
       };
   private static final Gauge filesInTheWay =

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/action/ActionCommand.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/action/ActionCommand.java
@@ -30,6 +30,21 @@ public abstract class ActionCommand<A extends Action> {
     ANNOY_USER
   }
 
+  /** The result of updating the action */
+  public enum Response {
+    /** The action executed this command, but no visible state changes occurred. */
+    ACCEPTED,
+    /** This action was not able to execute this command. */
+    IGNORED,
+    /** The action executed this command and now needs to be purged. */
+    PURGE,
+    /**
+     * The action executed this command and needs to put back in the {@link ActionState#UNKNOWN}
+     * state
+     */
+    RESET
+  }
+
   private final String buttonText;
   private final Class<A> clazz;
   private final String command;
@@ -76,7 +91,7 @@ public abstract class ActionCommand<A extends Action> {
    * @param user the user performing this action, if known
    * @return true if the command was followed; false if inappropriate or not understood
    */
-  protected abstract boolean execute(A action, Optional<String> user);
+  protected abstract Response execute(A action, Optional<String> user);
 
   /** The front end icon */
   public FrontEndIcon icon() {
@@ -96,10 +111,10 @@ public abstract class ActionCommand<A extends Action> {
    * @param user the user performing this action, if known
    * @return true if the command was followed; false if inappropriate or not understood
    */
-  public final boolean process(Action action, String command, Optional<String> user) {
+  public final Response process(Action action, String command, Optional<String> user) {
     if (command.equals(this.command) && clazz.isInstance(action)) {
       return execute(clazz.cast(action), user);
     }
-    return false;
+    return Response.IGNORED;
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/NothingAction.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/NothingAction.java
@@ -26,9 +26,23 @@ public class NothingAction extends Action {
           Preference.ALLOW_BULK,
           Preference.PROMPT) {
         @Override
-        protected boolean execute(NothingAction action, Optional<String> user) {
+        protected Response execute(NothingAction action, Optional<String> user) {
           System.err.println(action.value);
-          return true;
+          return Response.ACCEPTED;
+        }
+      };
+  private static final ActionCommand<NothingAction> SCREAM_TO_DEATH =
+      new ActionCommand<NothingAction>(
+          NothingAction.class,
+          "NOTHING-SCREAM-TO-DEATH",
+          FrontEndIcon.TRASH_FILL,
+          "Write to Server Console and Purge",
+          Preference.ALLOW_BULK,
+          Preference.PROMPT) {
+        @Override
+        protected Response execute(NothingAction action, Optional<String> user) {
+          System.err.println(action.value);
+          return Response.PURGE;
         }
       };
   @RuntimeInterop public String value = "";
@@ -39,7 +53,7 @@ public class NothingAction extends Action {
 
   @Override
   public Stream<ActionCommand<?>> commands() {
-    return Stream.of(COMPLAIN);
+    return Stream.of(COMPLAIN, SCREAM_TO_DEATH);
   }
 
   @Override


### PR DESCRIPTION
Currently, after a command completes, the action is reset to the `UNKNOWN`
state. This allows a command to either be counted as modified without resetting
state, have state reset, or be purged.