### PR TITLE
Redesign the permutation puzzle

### DIFF
--- a/shesmu-server-ui/src/util.ts
+++ b/shesmu-server-ui/src/util.ts
@@ -98,10 +98,12 @@ export function softJoin(delimiter: string, text: string[]): (string | null)[] {
 
 /**
  * Shuffle items in an array
+ *
+ * They are guaranteed not to be in the original order
  */
 export function shuffle<T>(array: T[]): void {
   for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.min(i - 1, Math.floor(Math.random() * i));
     const temp = array[i];
     array[i] = array[j];
     array[j] = temp;

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -1050,3 +1050,16 @@ input.dirty {
   padding: 0.5em;
   cursor: pointer;
 }
+
+.dragorder {
+  display: flex;
+  flex-flow: row wrap;
+}
+.dragorder > div {
+  border-left-style: solid;
+  border-right-style: solid;
+  border-left-width: 3px;
+  border-right-width: 3px;
+  border-color: #fff;
+  padding: 2em;
+}


### PR DESCRIPTION
Rather than enter a sequence, create a draggable set of blocks that can be
shuffled into the correct order.

I have plans to use this widget in other contexts.