### PR TITLE
Don't throw `ConcurrentModificationException` in cache limiter

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/ConcurrencyLimitedRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/ConcurrencyLimitedRecord.java
@@ -1,7 +1,6 @@
 package ca.on.oicr.gsi.shesmu.plugin.cache;
 
 import java.time.Instant;
-import java.util.ConcurrentModificationException;
 import java.util.concurrent.Semaphore;
 
 /**
@@ -52,7 +51,7 @@ public class ConcurrencyLimitedRecord<V> implements Record<V> {
   @Override
   public V refresh(String context) {
     if (!lock.tryAcquire()) {
-      throw new ConcurrentModificationException("Too many updates in progress.");
+      return inner.readStale();
     }
     try {
       return inner.refresh(context);


### PR DESCRIPTION
This cache record limits the number of simultaneous update by throwing an
exception. This causes Niassa workflow actions hitting the concurrency limit to
enter a spurious failed state. Rather than do fail, this reads stale data.