### PR TITLE
Fix stream capture in `Default`

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BinaryOperation.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BinaryOperation.java
@@ -279,12 +279,12 @@ public abstract class BinaryOperation {
                     renderer.root(),
                     String.format("Coalesce %d:%d", line, column),
                     LambdaBuilder.supplier(resultType),
+                    renderer.streamType(),
                     renderer
                         .allValues()
                         .filter(v -> captures.contains(v.name()))
                         .toArray(LoadableValue[]::new));
-            final Renderer orElseMethod =
-                supplier.renderer(renderer.streamType(), renderer.signerEmitter());
+            final Renderer orElseMethod = supplier.renderer(renderer.signerEmitter());
             orElseMethod.methodGen().visitCode();
             rightValue.render(orElseMethod);
             orElseMethod.methodGen().returnValue();

--- a/shesmu-server/src/test/resources/run/optional-lift-capture.shesmu
+++ b/shesmu-server/src/test/resources/run/optional-lift-capture.shesmu
@@ -1,0 +1,5 @@
+Version 1;
+Input test;
+
+Olive
+ Run ok With ok = (If True Then `` Else `False`) Default project == "the_foo_study";


### PR DESCRIPTION
For the code `x Default y`, Shesmu generates a call to `Optional.orElseGet`,
which takes a `Supplier` lambda. There is a "stream" value which is the current
row being iterated and variables that access the row read this variable. Some
lambdas take the steam as a capture (_i.e._, the stream is whatever the stream
outside) and others take the steam as a parameter (_i.e._, the stream is being
changed, such as in a grouping operation). The `Supplier` falls into the former
category but was generating a lambda of the latter type, resulting in incorrect
bytecode trying to access an argument that does not exist.