### PR TITLE
Remove concurrency restratint on Niassa

### DIFF
--- a/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
+++ b/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/NiassaServer.java
@@ -59,7 +59,7 @@ class NiassaServer extends JsonPluginFile<Configuration> {
       super(
           "niassa-analysis " + fileName.toString(),
           120,
-          TimeoutRecord.limit(45, ConcurrencyLimitedRecord.limit(4, ReplacingRecord::new)));
+          TimeoutRecord.limit(45, ReplacingRecord::new));
     }
 
     @Override


### PR DESCRIPTION
It was a good idea, but Niassa just can't keep up unless we hammer it.