### PR TITLE
Add a select-from-list to Guided Meditations

### DIFF
--- a/guided-meditations.md
+++ b/guided-meditations.md
@@ -219,7 +219,7 @@ widget.
 | `Offset`   | a number box + time unit selector | `integer` as milliseconds |
 | `Checkbox` | a check box                       | `boolean`                 |
 
-- _name_ `= Dropdown` _item_ `As` _itemlabel_ `In` _values_ `Label` _labelexpr_
+- _name_ `= Dropdown Show` _item_ `With` _itemlabel_ `From` _values_ `Label` _labelexpr_
 Creates a drop down list from the items in  _values_, which must be a list.
 Each item will be displayed as _itemlabel_, with the selected values as _item_.
 The selected value will be assigned to _name_ in subsequent steps.  _labelexpr_

--- a/guided-meditations.md
+++ b/guided-meditations.md
@@ -219,6 +219,13 @@ widget.
 | `Offset`   | a number box + time unit selector | `integer` as milliseconds |
 | `Checkbox` | a check box                       | `boolean`                 |
 
+- _name_ `= Dropdown` _item_ `As` _itemlabel_ `In` _values_ `Label` _labelexpr_
+Creates a drop down list from the items in  _values_, which must be a list.
+Each item will be displayed as _itemlabel_, with the selected values as _item_.
+The selected value will be assigned to _name_ in subsequent steps.  _labelexpr_
+is text display elements to show to the left of the input widget. If _values_
+is an empty list, the meditation will be stopped.
+
 - _name_ `= Select` _optionvalue_ `As` _optionlabel_ ... `Label` _labelexpr_
 Creates a drop down list. The _optionlabel_ is display text that will be shown.
 There is no restriction on the type of _optionvalue_, though they all must be

--- a/shesmu-server-ui/src/yogastudio.ts
+++ b/shesmu-server-ui/src/yogastudio.ts
@@ -67,7 +67,12 @@ export function renderResponse<T>(
         },
       ];
     } catch (e) {
-      return [{ name: "Implementation Error", contents: e.toString() }];
+      return [
+        {
+          name: "Implementation Error",
+          contents: [e.toString(), br(), preformatted(response?.functionBody)],
+        },
+      ];
     }
   } else {
     return [];

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNode.java
@@ -80,6 +80,34 @@ public abstract class FormNode implements Target {
           return result;
         });
     FORM_TYPE.addKeyword(
+        "Dropdown",
+        (p, o) -> {
+          final AtomicReference<DestructuredArgumentNode> itemName = new AtomicReference<>();
+          final AtomicReference<DisplayNode> itemLabel = new AtomicReference<>();
+          final AtomicReference<ExpressionNode> values = new AtomicReference<>();
+          final Parser result =
+              p.whitespace()
+                  .keyword("Show")
+                  .whitespace()
+                  .then(DestructuredArgumentNode::parse, itemName::set)
+                  .whitespace()
+                  .keyword("With")
+                  .whitespace()
+                  .then(DisplayNode::parse, itemLabel::set)
+                  .whitespace()
+                  .keyword("From")
+                  .whitespace()
+                  .then(ExpressionNode::parse, values::set)
+                  .whitespace();
+          if (result.isGood()) {
+            o.accept(
+                (label, name) ->
+                    new FormNodeDropdown(
+                        label, name, values.get(), itemName.get(), itemLabel.get()));
+          }
+          return result;
+        });
+    FORM_TYPE.addKeyword(
         "Subset",
         (p, o) -> {
           final AtomicReference<ExpressionNode> values = new AtomicReference<>();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNodeDropdown.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNodeDropdown.java
@@ -1,0 +1,98 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.ListImyhat;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public final class FormNodeDropdown extends FormNode {
+
+  private final DestructuredArgumentNode itemName;
+  private final List<DisplayNode> label;
+  private final DisplayNode itemLabel;
+  private final String name;
+  private Imyhat type = Imyhat.BAD;
+  private final ExpressionNode values;
+
+  public FormNodeDropdown(
+      List<DisplayNode> label,
+      String name,
+      ExpressionNode values,
+      DestructuredArgumentNode itemName,
+      DisplayNode itemLabel) {
+    this.label = label;
+    this.itemName = itemName;
+    this.itemLabel = itemLabel;
+    this.name = name;
+    this.values = values;
+  }
+
+  @Override
+  public Flavour flavour() {
+    return Flavour.LAMBDA;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  public void read() {
+    // Don't really care
+  }
+
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    return String.format(
+        "{label: %s, type: \"select-dynamic\", values: %s, labelMaker: %s}",
+        label.stream().map(l -> l.renderEcma(renderer)).collect(Collectors.joining(", ", "[", "]")),
+        values.renderEcma(renderer),
+        renderer.lambda(
+            1,
+            (r, a) -> {
+              itemName.renderEcma(rr -> a.apply(0)).forEach(r::define);
+              return itemLabel.renderEcma(r);
+            }));
+  }
+
+  public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
+    return label.stream().filter(l -> l.resolve(defs, errorHandler)).count() == label.size()
+        & itemLabel.resolve(defs.bind(itemName), errorHandler)
+        & values.resolve(defs, errorHandler);
+  }
+
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices,
+      DefinitionRepository nativeDefinitions,
+      Consumer<String> errorHandler) {
+    return label.stream()
+                .filter(
+                    l ->
+                        l.resolveDefinitions(
+                            expressionCompilerServices, nativeDefinitions, errorHandler))
+                .count()
+            == label.size()
+        & itemName.resolve(expressionCompilerServices, errorHandler)
+        & itemLabel.resolveDefinitions(expressionCompilerServices, nativeDefinitions, errorHandler)
+        & values.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  public Imyhat type() {
+    return type;
+  }
+
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    final boolean ok =
+        label.stream().filter(l -> l.typeCheck(errorHandler)).count() == label.size();
+    if (values.typeCheck(errorHandler)) {
+      if (values.type() instanceof ListImyhat) {
+        type = ((ListImyhat) values.type()).inner();
+        return itemName.typeCheck(type, errorHandler) && itemLabel.typeCheck(errorHandler) && ok;
+      } else {
+        values.typeError("list", values.type(), errorHandler);
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
* Fix JavaScript code for literal list -- The `newSet` function requires a comparator that was not provided. For the empty list, no comparator is available, so generate an empty list directly.
* Dump JavaScript on failure -- If a guided meditation produces an error, dump the JavaScript code after the error.
* Add a dynamic drop down selector to guided meditations -- The `Select` input type chooses from a list while this `Dropdown` input allows using a computationally-generated list of items.
