### PR TITLE
Allow setting metadata parameters globally for Vidarr

### DIFF
--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/ParameterGroup.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/ParameterGroup.java
@@ -1,49 +1,11 @@
 package ca.on.oicr.gsi.shesmu.vidarr;
 
 import ca.on.oicr.gsi.Pair;
-import ca.on.oicr.gsi.shesmu.plugin.Tuple;
-import ca.on.oicr.gsi.shesmu.plugin.action.CustomActionParameter;
 import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonObject;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
-import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.ObjectImyhat;
-import ca.on.oicr.gsi.vidarr.api.SubmitWorkflowRequest;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 final class ParameterGroup implements Comparable<ParameterGroup> {
-
-  static <T> Optional<CustomActionParameter<SubmitAction>> create(
-      String groupName,
-      BiConsumer<SubmitWorkflowRequest, ObjectNode> writer,
-      Map<String, T> parameters,
-      Function<T, Imyhat> converter) {
-    final var handlers =
-        parameters.entrySet().stream()
-            .map(entry -> new ParameterGroup(entry.getKey(), converter.apply(entry.getValue())))
-            .sorted()
-            .collect(Collectors.toList());
-
-    if (handlers.stream().anyMatch(h -> h.type.isBad())) {
-      return Optional.empty();
-    }
-    return Optional.of(
-        new CustomActionParameter<>(
-            groupName, true, new ObjectImyhat(handlers.stream().map(ParameterGroup::objectField))) {
-          @Override
-          public void store(SubmitAction action, Object value) {
-            final var tuple = (Tuple) value;
-            final var object = VidarrPlugin.MAPPER.createObjectNode();
-            writer.accept(action.request, object);
-            for (var index = 0; index < handlers.size(); index++) {
-              handlers.get(index).store(object, tuple.get(index));
-            }
-          }
-        });
-  }
 
   final String name;
   final Imyhat type;


### PR DESCRIPTION
Vidarr workflows need to know how to associate the output files from the
workflow run to the LIMS metadata. Niassa had different handlers for different
cases; these were set in the `.niassawf` files as `"type"`, usually `FILES`.
Vidarr workflows require setting each output individually. For a typical
`FILES`-equivalent workflow, that might look:

```
metadata = {
  foo = ALL {output_prefix = "/srv/vidarr/storage/"},
  bar = ALL {output_prefix = "/srv/vidarr/storage/"},
  quux = ALL {output_prefix = "/srv/vidarr/storage/"}
}
```

This is tedious at best. So, the idea is to allow setting all of these values
simultaneously if they can be set that way. This changes the above to:

```
metadata = INDIVIDUAL {
  foo = ALL {output_prefix = "/srv/vidarr/storage/"},
  bar = ALL {output_prefix = "/srv/vidarr/storage/"},
  quux = ALL {output_prefix = "/srv/vidarr/storage/"}
}
```

or it can be simplified to:

```
metadata = GLOBAL { ALL {output_prefix = "/srv/vidarr/storage/"} }
```