### PR TITLE
Change `timespan` function to take timestamps in seconds

### DIFF
--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -4253,11 +4253,11 @@ export function tile(classes: string[], ...contents: UIElement[]): UIElement {
   return element;
 }
 /**
- * Display an absolute time in a nice way.
+ * Display an absolute UNIX epoch time in a nice way.
  */
 export function timespan(time: number | undefined | null): UIElement {
   if (!time) return "N/A";
-  const { ago, absolute } = computeDuration(time);
+  const { ago, absolute } = computeDuration(time * 1000);
   return text(`${absolute} (${ago})`);
 }
 /**


### PR DESCRIPTION
The Jackson writes timestamps in seconds, not milliseconds, and can only be
configured to write in nanoseconds. This changes the `timespan` function to
handle times in seconds and it is only used by the Vidarr plugin currently, so
this will not change any other displays.