### PR TITLE
Prevent plugin exceptions from breaking the _Actions_ page

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterBuilder.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/filter/ActionFilterBuilder.java
@@ -59,7 +59,7 @@ public interface ActionFilterBuilder<F, T, S, I, O> {
           final ActionFilterExternal result = new ActionFilterExternal();
           result.setStart(start.map(Instant::getEpochSecond).orElse(null));
           result.setEnd(end.map(Instant::getEpochSecond).orElse(null));
-          return null;
+          return result;
         }
 
         @Override
@@ -254,8 +254,7 @@ public interface ActionFilterBuilder<F, T, S, I, O> {
             return new Pair<>(String.format("%s = %s", name, quote(items.get(0))), 0);
           } else {
             return new Pair<>(
-                items
-                    .stream()
+                items.stream()
                     .map(this::quote)
                     .collect(Collectors.joining(", ", name + " in (", ")")),
                 0);
@@ -279,8 +278,7 @@ public interface ActionFilterBuilder<F, T, S, I, O> {
             return new Pair<>("source = " + locationList.get(0), 0);
           }
           return new Pair<>(
-              locationList
-                  .stream()
+              locationList.stream()
                   .map(Object::toString)
                   .collect(Collectors.joining(", ", "source in (", ")")),
               0);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
@@ -395,28 +395,23 @@ public final class PluginManager
 
         // Now expose all our plugins to the olive compiler
         constantsFromAnnotations =
-            constantTemplates
-                .stream()
+            constantTemplates.stream()
                 .map(t -> t.bind(instanceName, path))
                 .collect(Collectors.toList());
         functionsFromAnnotations =
-            functionTemplates
-                .stream()
+            functionTemplates.stream()
                 .map(t -> t.bind(instanceName, path))
                 .collect(Collectors.toList());
         actionsFromAnnotations =
-            actionTemplates
-                .stream()
+            actionTemplates.stream()
                 .map(t -> t.bind(instanceName, path))
                 .collect(Collectors.toList());
         signaturesFromAnnotations =
-            signatureTemplates
-                .stream()
+            signatureTemplates.stream()
                 .map(t -> t.bind(instanceName, path))
                 .collect(Collectors.toList());
         refillersFromAnnotations =
-            refillTemplates
-                .stream()
+            refillTemplates.stream()
                 .map(t -> t.bind(instanceName, path))
                 .collect(Collectors.toList());
       }
@@ -852,7 +847,12 @@ public final class PluginManager
 
       public <F> Stream<Pair<String, F>> searches(
           ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
-        return instance.searches(builder);
+        try {
+          return instance.searches(builder);
+        } catch (Exception e) {
+          e.printStackTrace();
+          return Stream.empty();
+        }
       }
 
       public Stream<SignatureDefinition> signatures() {
@@ -1624,8 +1624,14 @@ public final class PluginManager
 
     public <F> Stream<Pair<String, F>> searches(
         ActionFilterBuilder<F, ActionState, String, Instant, Long> builder) {
-      return Stream.concat(
-          fileFormat.searches(builder), configuration.stream().flatMap(f -> f.searches(builder)));
+      Stream<Pair<String, F>> searches;
+      try {
+        searches = fileFormat.searches(builder);
+      } catch (Exception e) {
+        e.printStackTrace();
+        searches = Stream.empty();
+      }
+      return Stream.concat(searches, configuration.stream().flatMap(f -> f.searches(builder)));
     }
 
     public Stream<SignatureDefinition> signatures() {
@@ -1915,8 +1921,7 @@ public final class PluginManager
           type.staticFunctions.stream(),
           type.staticSources.keySet().stream(),
           type.staticSignatures.stream());
-      type.configuration
-          .stream()
+      type.configuration.stream()
           .forEach(
               c ->
                   dumpConfig(


### PR DESCRIPTION
The plugins can return a list of search to include on the _Actions_ page. If
one of them throws, the dashboard will fail to load. This logs the exceptions
but allows the dashboard to be built. This was in response to a JIRA bug where
the plugin would throw an exception if the login failed.