### PR TITLE
Update plugin to match Vidarr 0.1.2

### DIFF
--- a/plugin-vidarr/pom.xml
+++ b/plugin-vidarr/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>ca.on.oicr.gsi.vidarr</groupId>
       <artifactId>vidarr-pluginapi</artifactId>
-      <version>0.1.0</version>
+      <version>0.1.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
@@ -76,7 +76,8 @@ public class RunStateMonitor extends RunState {
 
   @Override
   public boolean canReattempt() {
-    return status.getOperationStatus().equals("FAILED");
+    return status.getOperationStatus().equals("FAILED")
+        || status.getOperationStatus().equals("WAITING_FOR_RESOURCES");
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/SubmitAction.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/SubmitAction.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
@@ -155,7 +154,7 @@ public final class SubmitAction extends Action {
       return false;
     }
     SubmitAction that = (SubmitAction) o;
-    return stale == that.stale && request.equals(that.request);
+    return stale == that.stale && request.equalsIgnoreAttempt(that.request);
   }
 
   @SuppressWarnings("unchecked")
@@ -183,6 +182,7 @@ public final class SubmitAction extends Action {
   @Override
   public void generateUUID(Consumer<byte[]> digest) {
     try {
+      digest.accept(new byte[] {(byte) (stale ? 1 : 0)});
       digest.accept(VidarrPlugin.MAPPER.writeValueAsBytes(request));
     } catch (JsonProcessingException e) {
       e.printStackTrace();
@@ -191,7 +191,7 @@ public final class SubmitAction extends Action {
 
   @Override
   public int hashCode() {
-    return Objects.hash(request, stale);
+    return request.hashCodeIgnoreAttempt() * 31 + Boolean.hashCode(stale);
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
@@ -232,10 +232,9 @@ public class VidarrPlugin extends JsonPluginFile<Configuration> {
                                                           .<CustomActionParameter<SubmitAction>>
                                                               empty()
                                                       : workflow.getLabels().entrySet().stream()
-                                                          .map(
+                                                          .<CustomActionParameter<SubmitAction>>map(
                                                               entry ->
-                                                                  new CustomActionParameter<
-                                                                      SubmitAction>(
+                                                                  new CustomActionParameter<>(
                                                                       sanitise(
                                                                           "label_"
                                                                               + entry.getKey()),

--- a/plugin-vidarr/src/main/resources/ca/on/oicr/gsi/shesmu/vidarr/renderer.js
+++ b/plugin-vidarr/src/main/resources/ca/on/oicr/gsi/shesmu/vidarr/renderer.js
@@ -103,6 +103,7 @@ const vidarrStateRenderer = {
       table(
         a.info.operations || [],
         ["Status", (o) => o.status],
+        ["Engine Phase", (o) => o.enginePhase],
         ["Type", (o) => o.type || "N/A"],
         [
           "Recovery State",

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -1705,7 +1705,7 @@ export function checkRandomPermutation(
   count: number,
   callback: () => void
 ): UIElement {
-  const code: number[] = new Array(Math.max(3, Math.min(26, count)));
+  const code: number[] = new Array(Math.max(3, Math.min(26, Math.log2(count))));
   for (let i = 0; i < code.length; i++) {
     code[i] = i;
   }


### PR DESCRIPTION
- Upgrade Vidarr library
- Allow reattemping unstarted workflow runs
- Show engine phase per operation
- Exclude attempt from action equality and include staleness in ID
- Make IntelliJ type inferencer happy; The type inferencer in IntelliJ has a lot of difficulty with this block even though the Java compiler doesn't. This makes them both happy.
