### PR TITLE
Cope with JSON workflow run labels

### DIFF
--- a/demo/demo.cerberus_fp-input
+++ b/demo/demo.cerberus_fp-input
@@ -60,6 +60,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "15580315",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -120,6 +121,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "15580315",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -187,6 +189,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "15580315",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -254,6 +257,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "15580315",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -328,6 +332,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -395,6 +400,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -462,6 +468,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -536,6 +543,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -610,6 +618,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -677,6 +686,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -751,6 +761,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -818,6 +829,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -884,6 +896,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       6,
@@ -950,6 +963,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       6,
@@ -1026,6 +1040,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1102,6 +1117,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1178,6 +1194,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1254,6 +1271,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1330,6 +1348,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1406,6 +1425,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1482,6 +1502,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1558,6 +1579,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1634,6 +1656,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1710,6 +1733,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1786,6 +1810,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1862,6 +1887,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -1938,6 +1964,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -2014,6 +2041,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -2086,6 +2114,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       0,
@@ -2158,6 +2187,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       0,
@@ -2228,6 +2258,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -2298,6 +2329,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -2368,6 +2400,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -2438,6 +2471,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -2508,6 +2542,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -2578,6 +2613,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -2645,6 +2681,7 @@
     "workflow_accession": "5300924",
     "workflow_run_accession": "15609099",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -2712,6 +2749,7 @@
     "workflow_accession": "5300924",
     "workflow_run_accession": "15609099",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -2779,6 +2817,7 @@
     "workflow_accession": "5300924",
     "workflow_run_accession": "15609099",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -2846,6 +2885,7 @@
     "workflow_accession": "5300924",
     "workflow_run_accession": "15609099",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -2913,6 +2953,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -2987,6 +3028,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3054,6 +3096,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3128,6 +3171,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3195,6 +3239,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3262,6 +3307,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3336,6 +3382,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3410,6 +3457,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3476,6 +3524,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       6,
@@ -3546,6 +3595,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3616,6 +3666,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3686,6 +3737,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -3759,6 +3811,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -3829,6 +3882,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -3899,6 +3953,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -3969,6 +4024,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -4039,6 +4095,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -4105,6 +4162,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       6,
@@ -4175,6 +4233,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -4245,6 +4304,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -4315,6 +4375,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       2,
@@ -4391,6 +4452,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -4467,6 +4529,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -4543,6 +4606,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -4619,6 +4683,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -4695,6 +4760,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -4771,6 +4837,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -4847,6 +4914,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -4923,6 +4991,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -4999,6 +5068,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -5075,6 +5145,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -5151,6 +5222,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -5227,6 +5299,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -5303,6 +5376,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -5379,6 +5453,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -5450,6 +5525,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -5521,6 +5597,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -5595,6 +5672,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -5666,6 +5744,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -5737,6 +5816,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -5808,6 +5888,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -5879,6 +5960,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -5950,6 +6032,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -6021,6 +6104,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -6095,6 +6179,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       3,
@@ -6167,6 +6252,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       0,
@@ -6239,6 +6325,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       0,
@@ -6309,6 +6396,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6379,6 +6467,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6449,6 +6538,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6519,6 +6609,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6589,6 +6680,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6659,6 +6751,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6729,6 +6822,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6799,6 +6893,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6869,6 +6964,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -6939,6 +7035,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -7009,6 +7106,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -7079,6 +7177,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -7149,6 +7248,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -7219,6 +7319,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -7289,6 +7390,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -7359,6 +7461,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -7435,6 +7538,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -7511,6 +7615,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -7587,6 +7692,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -7663,6 +7769,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -7739,6 +7846,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -7815,6 +7923,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -7891,6 +8000,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -7966,6 +8076,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8041,6 +8152,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8116,6 +8228,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8191,6 +8304,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8266,6 +8380,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8341,6 +8456,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8417,6 +8533,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8493,6 +8610,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8569,6 +8687,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8645,6 +8764,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8721,6 +8841,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8797,6 +8918,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8873,6 +8995,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       0,
@@ -8959,6 +9082,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       7,
@@ -9045,6 +9169,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       7,
@@ -9131,6 +9256,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       7,
@@ -9217,6 +9343,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       7,
@@ -9290,6 +9417,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       7,
@@ -9363,6 +9491,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       7,
@@ -9435,6 +9564,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       0,
@@ -9507,6 +9637,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       0,
@@ -9580,6 +9711,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       0,
@@ -9653,6 +9785,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       0,
@@ -9720,6 +9853,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "16851292",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -9787,6 +9921,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "16851292",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -9858,6 +9993,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -9929,6 +10065,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10000,6 +10137,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10071,6 +10209,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10141,6 +10280,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -10211,6 +10351,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -10281,6 +10422,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -10351,6 +10493,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -10418,6 +10561,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "16919999",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -10485,6 +10629,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "16919999",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -10556,6 +10701,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10627,6 +10773,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10698,6 +10845,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10769,6 +10917,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10844,6 +10993,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10919,6 +11069,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -10989,6 +11140,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -11059,6 +11211,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -11129,6 +11282,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -11199,6 +11353,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -11266,6 +11421,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "16984235",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -11333,6 +11489,7 @@
     "workflow_accession": "15031683",
     "workflow_run_accession": "16984235",
     "workflow_run_attributes": {},
+    "workflow_run_labels": {},
     "workflow_version": [
       2,
       9,
@@ -11404,6 +11561,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -11475,6 +11633,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -11546,6 +11705,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -11617,6 +11777,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,
@@ -11687,6 +11848,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -11757,6 +11919,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -11827,6 +11990,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -11897,6 +12061,7 @@
         "0"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       3,
       1,
@@ -11972,6 +12137,7 @@
         "hg19"
       ]
     },
+    "workflow_run_labels": {},
     "workflow_version": [
       1,
       1,

--- a/plugin-cerberus/pom.xml
+++ b/plugin-cerberus/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>ca.on.oicr.gsi.cerberus</groupId>
       <artifactId>cerberus-core</artifactId>
-      <version>0.1.2</version>
+      <version>0.1.4</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugin-cerberus/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/BaseCerberusFileProvenanceRecord.java
+++ b/plugin-cerberus/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/BaseCerberusFileProvenanceRecord.java
@@ -6,6 +6,7 @@ import ca.on.oicr.gsi.shesmu.gsicommon.CerberusFileProvenanceValue;
 import ca.on.oicr.gsi.shesmu.gsicommon.IUSUtils;
 import ca.on.oicr.gsi.shesmu.plugin.AlgebraicValue;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
+import ca.on.oicr.gsi.vidarr.api.ProvenanceWorkflowRun;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -19,18 +20,24 @@ import java.util.stream.Collectors;
 
 abstract class BaseCerberusFileProvenanceRecord<T extends LimsProvenance>
     implements CerberusFileProvenanceValue {
-  protected final ProvenanceRecord<T> provenanceRecord;
-  private final boolean stale;
-  private final Map<String, JsonNode> workflowRunLabels = new TreeMap<>();
-
-  protected BaseCerberusFileProvenanceRecord(boolean stale, ProvenanceRecord<T> provenanceRecord) {
-    this.stale = stale;
-    this.provenanceRecord = provenanceRecord;
-    final var labels = provenanceRecord.workflow().getLabels().fields();
+  static Map<String, JsonNode> labelsToMap(ProvenanceWorkflowRun<?> workflow) {
+    final var workflowRunLabels = new TreeMap<String, JsonNode>();
+    final var labels = workflow.getLabels().fields();
     while (labels.hasNext()) {
       final var label = labels.next();
       workflowRunLabels.put(label.getKey(), label.getValue());
     }
+    return workflowRunLabels;
+  }
+
+  protected final ProvenanceRecord<T> provenanceRecord;
+  private final boolean stale;
+  private final Map<String, JsonNode> workflowRunLabels;
+
+  protected BaseCerberusFileProvenanceRecord(boolean stale, ProvenanceRecord<T> provenanceRecord) {
+    this.stale = stale;
+    this.provenanceRecord = provenanceRecord;
+    workflowRunLabels = labelsToMap(provenanceRecord.workflow());
   }
 
   @Override

--- a/plugin-cerberus/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/BaseCerberusFileProvenanceRecord.java
+++ b/plugin-cerberus/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/BaseCerberusFileProvenanceRecord.java
@@ -6,11 +6,14 @@ import ca.on.oicr.gsi.shesmu.gsicommon.CerberusFileProvenanceValue;
 import ca.on.oicr.gsi.shesmu.gsicommon.IUSUtils;
 import ca.on.oicr.gsi.shesmu.plugin.AlgebraicValue;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -18,10 +21,16 @@ abstract class BaseCerberusFileProvenanceRecord<T extends LimsProvenance>
     implements CerberusFileProvenanceValue {
   protected final ProvenanceRecord<T> provenanceRecord;
   private final boolean stale;
+  private final Map<String, JsonNode> workflowRunLabels = new TreeMap<>();
 
   protected BaseCerberusFileProvenanceRecord(boolean stale, ProvenanceRecord<T> provenanceRecord) {
     this.stale = stale;
     this.provenanceRecord = provenanceRecord;
+    final var labels = provenanceRecord.workflow().getLabels().fields();
+    while (labels.hasNext()) {
+      final var label = labels.next();
+      workflowRunLabels.put(label.getKey(), label.getValue());
+    }
   }
 
   @Override
@@ -125,8 +134,12 @@ abstract class BaseCerberusFileProvenanceRecord<T extends LimsProvenance>
 
   @Override
   public final Map<String, Set<String>> workflow_run_attributes() {
-    return provenanceRecord.workflow().getLabels().entrySet().stream()
-        .collect(Collectors.toMap(Entry::getKey, e -> Set.of(e.getValue())));
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public final Map<String, JsonNode> workflow_run_labels() {
+    return workflowRunLabels;
   }
 
   @Override

--- a/plugin-cerberus/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusErrorValue.java
+++ b/plugin-cerberus/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusErrorValue.java
@@ -1,14 +1,16 @@
 package ca.on.oicr.gsi.shesmu.cerberus;
 
+import static ca.on.oicr.gsi.shesmu.cerberus.BaseCerberusFileProvenanceRecord.labelsToMap;
+
 import ca.on.oicr.gsi.cerberus.pinery.LimsProvenanceInfo;
 import ca.on.oicr.gsi.shesmu.gsicommon.IUSUtils;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.input.ShesmuVariable;
 import ca.on.oicr.gsi.vidarr.api.ExternalKey;
 import ca.on.oicr.gsi.vidarr.api.ProvenanceWorkflowRun;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -18,6 +20,7 @@ public final class CerberusErrorValue {
 
   private final Set<Tuple> availableLimsInfo;
   private final ProvenanceWorkflowRun<ExternalKey> workflow;
+  private final Map<String, JsonNode> workflowRunLabels;
 
   public CerberusErrorValue(
       ProvenanceWorkflowRun<ExternalKey> workflow, Stream<LimsProvenanceInfo> limsInfo) {
@@ -33,6 +36,7 @@ public final class CerberusErrorValue {
                         info.provider(),
                         info.lims().getVersion()))
             .collect(Collectors.toSet());
+    workflowRunLabels = labelsToMap(workflow);
   }
 
   @ShesmuVariable(type = "ao5format_revision$iid$slast_modified$sprovider$sversion$s")
@@ -83,9 +87,8 @@ public final class CerberusErrorValue {
   }
 
   @ShesmuVariable
-  public final Map<String, Set<String>> workflow_run_attributes() {
-    return workflow.getLabels().entrySet().stream()
-        .collect(Collectors.toMap(Entry::getKey, e -> Set.of(e.getValue())));
+  public final Map<String, JsonNode> workflow_run_labels() {
+    return workflowRunLabels;
   }
 
   @ShesmuVariable(type = "t3iii")

--- a/plugin-gsi-common/src/main/java/ca/on/oicr/gsi/shesmu/gsicommon/CerberusFileProvenanceValue.java
+++ b/plugin-gsi-common/src/main/java/ca/on/oicr/gsi/shesmu/gsicommon/CerberusFileProvenanceValue.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.plugin.AlgebraicValue;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.input.Gang;
 import ca.on.oicr.gsi.shesmu.plugin.input.ShesmuVariable;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
@@ -182,6 +183,9 @@ public interface CerberusFileProvenanceValue {
 
   @ShesmuVariable
   Map<String, Set<String>> workflow_run_attributes();
+
+  @ShesmuVariable
+  Map<String, JsonNode> workflow_run_labels();
 
   @ShesmuVariable(type = "t3iii")
   Tuple workflow_version();

--- a/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/pipedev/PipeDevCerberusFileProvenanceValue.java
+++ b/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/pipedev/PipeDevCerberusFileProvenanceValue.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.shesmu.gsicommon.CerberusFileProvenanceValue;
 import ca.on.oicr.gsi.shesmu.gsicommon.IUSUtils;
 import ca.on.oicr.gsi.shesmu.plugin.AlgebraicValue;
 import ca.on.oicr.gsi.shesmu.plugin.Tuple;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
@@ -506,6 +507,11 @@ public final class PipeDevCerberusFileProvenanceValue implements CerberusFilePro
   @Override
   public Map<String, Set<String>> workflow_run_attributes() {
     return workflow_run_attributes;
+  }
+
+  @Override
+  public Map<String, JsonNode> workflow_run_labels() {
+    return Collections.emptyMap();
   }
 
   @Override


### PR DESCRIPTION
Vidarr allows arbitrary JSON data to be used as labels, which is not compatible
with Niassa. To accommodate this, a second variable `workflow_run_labels` is
introduced and each workflow engine returns an empty dictionary for the other's
value.