### PR TITLE
Change guided meditation implementation and fix bugs

### DIFF
--- a/shesmu-server-ui/src/guided_meditations.ts
+++ b/shesmu-server-ui/src/guided_meditations.ts
@@ -51,6 +51,7 @@ import {
 } from "./simulation.js";
 import {
   FilenameFormatter,
+  StatefulModel,
   combineModels,
   commonPathPrefix,
   individualPropertyModel,
@@ -97,109 +98,109 @@ type Information =
   | { type: "table"; data: DisplayElement[][]; headers: string[] }
   | { type: "display"; contents: DisplayElement };
 
-type Parameters<T> = {
-  [P in keyof T]?:
-    | (T[P] extends string
-        ? {
-            label: DisplayElement;
-            type: "text";
-          }
-        : never)
-    | (T[P] extends number
-        ? {
-            label: DisplayElement;
-            type: "number" | "offset";
-          }
-        : never)
-    | (T[P] extends boolean
-        ? {
-            label: DisplayElement;
-            type: "boolean";
-          }
-        : never)
-    | (T[P] extends string[]
-        ? {
-            label: DisplayElement;
-            type: "subset";
-            values: string[];
-          }
-        : never)
-    | (T[P] extends { [name: string]: string }[]
-        ? {
-            label: DisplayElement;
-            type: "upload-table";
-            columns: string[];
-          }
-        : never)
-    | {
-        items: [DisplayElement, T[P]][];
-        label: DisplayElement;
-        type: "select";
-      }
-    | {
-        label: DisplayElement;
-        type: "upload-json";
-      }
-    | {
-        label: DisplayElement;
-        labelMaker: (input: T[P]) => DisplayElement;
-        type: "select-dynamic";
-        values: T[P][];
-      };
-};
+type FormElement<T> =
+  | (T extends string
+      ? {
+          label: DisplayElement;
+          type: "text";
+        }
+      : never)
+  | (T extends number
+      ? {
+          label: DisplayElement;
+          type: "number" | "offset";
+        }
+      : never)
+  | (T extends boolean
+      ? {
+          label: DisplayElement;
+          type: "boolean";
+        }
+      : never)
+  | (T extends string[]
+      ? {
+          label: DisplayElement;
+          type: "subset";
+          values: string[];
+        }
+      : never)
+  | (T extends { [name: string]: string }[]
+      ? {
+          label: DisplayElement;
+          type: "upload-table";
+          columns: string[];
+        }
+      : never)
+  | {
+      items: [DisplayElement, T][];
+      label: DisplayElement;
+      type: "select";
+    }
+  | {
+      label: DisplayElement;
+      type: "upload-json";
+    }
+  | {
+      label: DisplayElement;
+      labelMaker: (input: T) => DisplayElement;
+      type: "select-dynamic";
+      values: T[];
+    };
 
-type FetchOperation<T> = {
-  [P in keyof T]?:
-    | { type: "count"; filter: ActionFilter }
-    | { type: "action-ids"; filter: ActionFilter }
-    | { type: "action-tags"; filter: ActionFilter }
-    | { type: "constant"; name: string }
-    | { type: "function"; name: string; args: any[] }
-    | {
-        type: "refiller";
-        script: string;
-        compare: (a: any, b: any) => number;
-        fakeRefiller: { export_to_meditation: FakeRefillerParameters };
-        fakeConstants: { [name: string]: FakeConstant };
-      };
-};
+type FetchOperation<T> =
+  | (T extends number ? { type: "count"; filter: ActionFilter } : never)
+  | (T extends string[]
+      ?
+          | { type: "action-ids"; filter: ActionFilter }
+          | { type: "action-tags"; filter: ActionFilter }
+      : never)
+  | { type: "constant"; name: string }
+  | { type: "function"; name: string; args: any[] }
+  | {
+      type: "refiller";
+      script: string;
+      compare: (a: any, b: any) => number;
+      fakeRefiller: { export_to_meditation: FakeRefillerParameters };
+      fakeConstants: { [name: string]: FakeConstant };
+    };
 type InformationNested = Information[] | InformationNested[];
 
-type Wizard<T> =
-  | WizardFetch<T>
-  | WizardForm<T>
-  | WizardChoice<T>
-  | WizardFork<T>;
+type Wizard =
+  | WizardFetch<unknown>
+  | WizardForm<unknown>
+  | WizardChoice
+  | WizardFork<unknown>;
 
-interface WizardChoice<T> {
+interface WizardChoice {
   type: "choice";
-  choices: { [name: string]: WizardStep<T> };
+  choices: { [name: string]: WizardStep };
 }
 
 interface WizardFetch<T> {
   type: "fetch";
-  parameters: FetchOperation<T>;
-  processor: WizardStep<T>;
+  parameters: { [P in keyof T]: FetchOperation<T[P]> };
+  processor: WizardDataStep<T>;
 }
 
 interface WizardForm<T> {
   type: "form";
-  parameters: Parameters<T>;
-  processor: WizardStep<T>;
+  parameters: { [P in keyof T]: FormElement<T[P]> };
+  processor: WizardDataStep<T>;
 }
 
 interface WizardFork<T> {
   type: "fork";
-  processor: WizardStep<T>;
-  items: { title: string; extra: Partial<T> }[];
+  processor: WizardDataStep<T>;
+  items: { title: string; extra: T }[];
 }
 
-export type WizardNext<T> = {
+export type WizardNext = {
   information: InformationNested;
-  then: Wizard<T> | null;
+  then: Wizard | null;
 };
 
-export type WizardStep<T> = (input: Partial<T>) => WizardNext<T>;
+export type WizardStep = () => WizardNext;
+export type WizardDataStep<T> = (input: T) => WizardNext;
 
 const endings = [
   "Thank you for coming on this journey.",
@@ -210,18 +211,18 @@ const endings = [
 
 const meditations: GuidedMeditation[] = [];
 
-export function register<T>(name: string, wizard: WizardStep<T>) {
+export function register(name: string, wizard: () => WizardNext) {
   meditations.push({
     name: name,
     start: (filenameFormatter, exportSearches) => {
-      const { information, then } = wizard({});
+      const { information, then } = wizard();
       return [
         information
           .flat(Number.MAX_VALUE)
           .map((i) => renderInformation(i, filenameFormatter, exportSearches)),
         then == null
           ? "Well, that was fast."
-          : renderWizard({}, then, filenameFormatter, exportSearches),
+          : renderWizard(then, filenameFormatter, exportSearches),
       ];
     },
   });
@@ -272,11 +273,135 @@ export function initialiseMeditationDash(
     ]);
   }
 }
+function buildFetch<T>(
+  wizard: WizardFetch<T>,
+  model: StatefulModel<WizardNext | null>
+): UIElement {
+  const { ui: fetchUi, model: fetchModel } = pane("medium");
+  fetchModel.statusWaiting();
+  const fetchOutput = {} as T;
+  const promises: Promise<void>[] = [];
+  const refresh = () => {
+    for (const k of Object.keys(wizard.parameters)) {
+      const key = k as keyof T;
+      const parameter = wizard.parameters[key];
+      if (parameter === undefined) {
+        continue;
+      }
+      promises.push(makeFetchEntry(key, parameter, fetchOutput));
+    }
+    Promise.all(promises)
+      .then(() => {
+        fetchModel.statusChanged(
+          button(
+            [{ type: "icon", icon: "arrow-repeat" }, "Refresh"],
+            "Reload this data and start again from this point.",
+            refresh
+          )
+        );
+        model.statusChanged(wizard.processor(fetchOutput));
+      })
+      .catch((e) => fetchModel.statusFailed(`${e}`, refresh));
+  };
+  refresh();
+  return [fetchUi, br()];
+}
+function buildForm<T>(
+  wizard: WizardForm<T>,
+  model: StatefulModel<WizardNext | null>
+): UIElement {
+  const output = {} as T;
+  try {
+    const fields = Object.keys(wizard.parameters).map((k) => {
+      const key = k as keyof T;
+      return makeFormEntry(key, wizard.parameters[key], output);
+    });
 
-function inputProperty<T, K extends keyof T>(
+    return [
+      tableFromRows(
+        fields.map((f) =>
+          tableRow(null, { contents: f.label }, { contents: f.field.ui })
+        )
+      ),
+      button(
+        { type: "icon", icon: "arrow-right-circle" },
+        "Continue to next step",
+        () => {
+          for (const field of fields) {
+            field.update();
+          }
+
+          model.statusChanged(wizard.processor(output));
+        }
+      ),
+      br(),
+    ];
+  } catch (e) {
+    return e.toString();
+  }
+}
+function makeFetchEntry<T, K extends keyof T>(
   key: K,
-  definition: Parameters<T>[K],
-  output: Partial<T>
+  parameter: FetchOperation<T[K]>,
+  fetchOutput: T
+): Promise<void> {
+  switch (parameter.type) {
+    case "action-ids":
+      return fetchAsPromise("action-ids", [parameter.filter]).then((ids) => {
+        fetchOutput[key] = (ids.sort() as unknown) as T[K];
+      });
+    case "action-tags":
+      return fetchAsPromise("tags", [parameter.filter]).then((ids) => {
+        fetchOutput[key] = (ids.sort() as unknown) as T[K];
+      });
+    case "constant":
+      return fetchAsPromise("constant", parameter.name).then((constant) => {
+        if (constant.error) {
+          throw new Error(constant.error);
+        }
+        fetchOutput[key] = constant.value;
+      });
+    case "count":
+      return fetchAsPromise("count", [parameter.filter]).then((count) => {
+        fetchOutput[key] = (count as unknown) as T[K];
+      });
+    case "function":
+      return fetchAsPromise("function", {
+        name: parameter.name,
+        args: parameter.args,
+      }).then((value) => {
+        if (value.error) {
+          throw new Error(value.error);
+        }
+        fetchOutput[key] = value.value;
+      });
+    case "refiller":
+      return fetchAsPromise("simulate", {
+        allowUnused: true,
+        fakeActions: {},
+        fakeRefillers: parameter.fakeRefiller,
+        fakeConstants: parameter.fakeConstants,
+        script: parameter.script,
+        dryRun: false,
+        readStale: false,
+      }).then((result) => {
+        const items = result.refillers?.["export_to_meditation"];
+        if (items) {
+          fetchOutput[key] = (setNew(
+            items,
+            parameter.compare
+          ) as unknown) as T[K];
+        } else {
+          throw new Error(result.errors.join("\n") || "Unknown error.");
+        }
+      });
+  }
+}
+
+function makeFormEntry<T, K extends keyof T>(
+  key: K,
+  definition: FormElement<T[K]>,
+  output: T
 ) {
   let field: InputField<T[K]>;
   if (definition === undefined) {
@@ -717,54 +842,45 @@ export function renderInformation(
   }
 }
 
-export function renderWizard<T>(
-  state: Partial<T>,
-  wizard: Wizard<T>,
+export function renderWizard(
+  wizard: Wizard,
   filenameFormatter: FilenameFormatter,
   exportSearches: ExportSearchCommand[]
 ): UIElement {
-  const childDisplay = singleState(
-    (state: { state: Partial<T>; next: WizardNext<T> } | null) => {
-      if (state == null) {
-        return blank();
-      }
-      let final: UIElement = null;
-      if (state.next.then == null) {
-        final = [
-          br(),
-          { type: "icon", icon: "flower2" },
-          endings[Math.floor(Math.random() * endings.length)],
-        ];
-      } else {
-        final = renderWizard(
-          state.state,
-          state.next.then,
-          filenameFormatter,
-          exportSearches
-        );
-      }
-
-      return [
-        state.next.information
-          .flat(Number.MAX_VALUE)
-          .map((i) => renderInformation(i, filenameFormatter, exportSearches)),
-        final,
-      ];
+  const childDisplay = singleState((next: WizardNext | null) => {
+    if (next == null) {
+      return blank();
     }
-  );
+    let final: UIElement = null;
+    if (next.then == null) {
+      final = [
+        br(),
+        { type: "icon", icon: "flower2" },
+        endings[Math.floor(Math.random() * endings.length)],
+      ];
+    } else {
+      final = renderWizard(next.then, filenameFormatter, exportSearches);
+    }
+
+    return [
+      next.information
+        .flat(Number.MAX_VALUE)
+        .map((i) => renderInformation(i, filenameFormatter, exportSearches)),
+      final,
+    ];
+  });
   let inner: UIElement = "Unknown Step";
   switch (wizard.type) {
     case "choice":
       const selectors = radioSelector(
         { type: "icon", icon: "arrow-down-circle" },
         { type: "icon", icon: "arrow-down-circle-fill" },
-        mapModel(childDisplay.model, (step: WizardStep<T> | null) => {
+        mapModel(childDisplay.model, (step: WizardStep | null) => {
           if (step == null) {
             return null;
           } else {
-            const newState = { ...state };
             try {
-              return { state: newState, next: step(newState) };
+              return step();
             } catch (e) {
               dialog((_) => e.toString());
               return null;
@@ -780,141 +896,10 @@ export function renderWizard<T>(
       );
       break;
     case "form":
-      const output: Partial<T> = { ...state };
-      try {
-        const fields = Object.keys(wizard.parameters).map((key) => {
-          const k = key as keyof T;
-          return inputProperty(k, wizard.parameters[k], output);
-        });
-
-        inner = [
-          tableFromRows(
-            fields.map((f) =>
-              tableRow(null, { contents: f.label }, { contents: f.field.ui })
-            )
-          ),
-          button(
-            { type: "icon", icon: "arrow-right-circle" },
-            "Continue to next step",
-            () => {
-              for (const field of fields) {
-                field.update();
-              }
-
-              childDisplay.model.statusChanged({
-                state: output,
-                next: wizard.processor(output),
-              });
-            }
-          ),
-          br(),
-        ];
-      } catch (e) {
-        inner = e.toString();
-      }
+      inner = buildForm(wizard, childDisplay.model);
       break;
     case "fetch":
-      const { ui: fetchUi, model: fetchModel } = pane("medium");
-      inner = [fetchUi, br()];
-      fetchModel.statusWaiting();
-      const fetchOutput: Partial<T> = { ...state };
-      const promises: Promise<void>[] = [];
-      const refresh = () => {
-        for (const key of Object.keys(wizard.parameters)) {
-          const k = key as keyof T;
-          const parameter = wizard.parameters[k];
-          if (parameter === undefined) {
-            continue;
-          }
-          switch (parameter.type) {
-            case "action-ids":
-              promises.push(
-                fetchAsPromise("action-ids", [parameter.filter]).then((ids) => {
-                  fetchOutput[k] = (ids.sort() as unknown) as T[keyof T];
-                })
-              );
-              break;
-            case "action-tags":
-              promises.push(
-                fetchAsPromise("tags", [parameter.filter]).then((ids) => {
-                  fetchOutput[k] = (ids.sort() as unknown) as T[keyof T];
-                })
-              );
-              break;
-            case "constant":
-              promises.push(
-                fetchAsPromise("constant", parameter.name).then((constant) => {
-                  if (constant.error) {
-                    throw new Error(constant.error);
-                  }
-                  fetchOutput[k] = (constant.value as unknown) as T[keyof T];
-                })
-              );
-              break;
-            case "count":
-              promises.push(
-                fetchAsPromise("count", [parameter.filter]).then((count) => {
-                  fetchOutput[k] = (count as unknown) as T[keyof T];
-                })
-              );
-              break;
-            case "function":
-              promises.push(
-                fetchAsPromise("function", {
-                  name: parameter.name,
-                  args: parameter.args,
-                }).then((value) => {
-                  if (value.error) {
-                    throw new Error(value.error);
-                  }
-                  fetchOutput[k] = (value.value as unknown) as T[keyof T];
-                })
-              );
-              break;
-            case "refiller":
-              promises.push(
-                fetchAsPromise("simulate", {
-                  allowUnused: true,
-                  fakeActions: {},
-                  fakeRefillers: parameter.fakeRefiller,
-                  fakeConstants: parameter.fakeConstants,
-                  script: parameter.script,
-                  dryRun: false,
-                  readStale: false,
-                }).then((result) => {
-                  const items = result.refillers?.["export_to_meditation"];
-                  if (items) {
-                    fetchOutput[k] = (setNew(
-                      items,
-                      parameter.compare
-                    ) as unknown) as T[keyof T];
-                  } else {
-                    throw new Error(
-                      result.errors.join("\n") || "Unknown error."
-                    );
-                  }
-                })
-              );
-              break;
-          }
-        }
-        Promise.all(promises)
-          .then(() => {
-            fetchModel.statusChanged(
-              button(
-                [{ type: "icon", icon: "arrow-repeat" }, "Refresh"],
-                "Reload this data and start again from this point.",
-                refresh
-              )
-            );
-            childDisplay.model.statusChanged({
-              state: fetchOutput,
-              next: wizard.processor(fetchOutput),
-            });
-          })
-          .catch((e) => fetchModel.statusFailed(`${e}`, refresh));
-      };
-      refresh();
+      inner = buildFetch(wizard, childDisplay.model);
       break;
     case "fork":
       switch (wizard.items.length) {
@@ -926,8 +911,7 @@ export function renderWizard<T>(
           ];
           break;
         case 1:
-          const newState = { ...state, ...wizard.items[0].extra };
-          const { information, then } = wizard.processor(newState);
+          const { information, then } = wizard.processor(wizard.items[0].extra);
           inner = [
             information
               .flat(Number.MAX_VALUE)
@@ -940,15 +924,14 @@ export function renderWizard<T>(
                   { type: "icon", icon: "flower2" },
                   endings[Math.floor(Math.random() * endings.length)],
                 ]
-              : renderWizard(newState, then, filenameFormatter, exportSearches),
+              : renderWizard(then, filenameFormatter, exportSearches),
           ];
           break;
         default:
           inner = [
             tabs(
               ...wizard.items.map(({ title, extra }) => {
-                const newState = { ...state, ...extra };
-                const { information, then } = wizard.processor(newState);
+                const { information, then } = wizard.processor(extra);
                 return {
                   name: title,
                   contents: [
@@ -963,12 +946,7 @@ export function renderWizard<T>(
                           { type: "icon", icon: "flower2" } as UIElement,
                           "This branch bears no more fruit.",
                         ]
-                      : renderWizard(
-                          newState,
-                          then,
-                          filenameFormatter,
-                          exportSearches
-                        ),
+                      : renderWizard(then, filenameFormatter, exportSearches),
                   ],
                 };
               })

--- a/shesmu-server-ui/src/yogastudio.ts
+++ b/shesmu-server-ui/src/yogastudio.ts
@@ -36,7 +36,7 @@ export interface MeditationCompilationResponse {
   functionBody?: string;
 }
 
-export function renderResponse<T>(
+export function renderResponse(
   response: MeditationCompilationResponse | null,
   filenameFormatter: FilenameFormatter,
   exportSearches: ExportSearchCommand[]
@@ -44,9 +44,9 @@ export function renderResponse<T>(
   if (response?.functionBody) {
     const wizard = new Function("$runtime", response?.functionBody)(
       runtime
-    ) as WizardStep<T>;
+    ) as WizardStep;
     try {
-      const { information, then } = wizard({});
+      const { information, then } = wizard();
       return [
         {
           name: "Meditation",
@@ -58,7 +58,7 @@ export function renderResponse<T>(
               ),
             then == null
               ? "Well, that was fast."
-              : renderWizard({}, then, filenameFormatter, exportSearches),
+              : renderWizard(then, filenameFormatter, exportSearches),
           ],
         },
         {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeMatches.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeMatches.java
@@ -81,7 +81,7 @@ public final class CollectNodeMatches extends CollectNode {
             .lambda(
                 1,
                 (r, args) -> {
-                  name.create(rr -> args.apply(0)).forEach(r::define);
+                  name.create(args.apply(0)).forEach(r::define);
                   return (matchType == Match.NONE ? "!" : "") + "(" + selector.renderEcma(r) + ")";
                 }));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeOptima.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeOptima.java
@@ -36,7 +36,7 @@ public final class CollectNodeOptima extends CollectNodeOptional {
             .lambda(
                 1,
                 (r, arg) -> {
-                  name.create(rr -> arg.apply(0)).forEach(r::define);
+                  name.create(arg.apply(0)).forEach(r::define);
                   return selector.renderEcma(r);
                 }),
         builder

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodePartitionCount.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodePartitionCount.java
@@ -77,7 +77,7 @@ public class CollectNodePartitionCount extends CollectNode {
             .lambda(
                 1,
                 (r, args) -> {
-                  name.create(rr -> args.apply(0)).forEach(r::define);
+                  name.create(args.apply(0)).forEach(r::define);
                   return expression.renderEcma(r);
                 }));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeReduce.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeReduce.java
@@ -87,8 +87,8 @@ public class CollectNodeReduce extends CollectNode {
             .lambda(
                 2,
                 (r, args) -> {
-                  accumulatorName.renderEcma(rr -> args.apply(0)).forEach(r::define);
-                  name.create(rr -> args.apply(1)).forEach(r::define);
+                  accumulatorName.renderEcma(args.apply(0)).forEach(r::define);
+                  name.create(args.apply(1)).forEach(r::define);
                   return reducer.renderEcma(r);
                 }),
         initial.renderEcma(builder.renderer()));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeSum.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeSum.java
@@ -68,7 +68,7 @@ public class CollectNodeSum extends CollectNode {
             .lambda(
                 2,
                 (r, args) -> {
-                  name.create(rr -> args.apply(1)).forEach(r::define);
+                  name.create(args.apply(1)).forEach(r::define);
                   return args.apply(0) + " + " + expression.renderEcma(r);
                 }));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNode.java
@@ -41,7 +41,7 @@ public abstract class DestructuredArgumentNode implements UndefinedVariableProvi
         }
 
         @Override
-        public Stream<EcmaLoadableValue> renderEcma(Function<EcmaScriptRenderer, String> loader) {
+        public Stream<EcmaLoadableValue> renderEcma(String loader) {
           return Stream.empty();
         }
 
@@ -102,9 +102,7 @@ public abstract class DestructuredArgumentNode implements UndefinedVariableProvi
       result = result.symbol("}").whitespace();
       if (result.isGood() && !inner.get().isEmpty()) {
         final Map<Boolean, Long> formats =
-            inner
-                .get()
-                .stream()
+            inner.get().stream()
                 .collect(Collectors.partitioningBy(x -> x.first() == null, Collectors.counting()));
         if ((formats.get(true) > 0) && (formats.get(false) > 0)) {
           return result.raise("Destructuring is a mixture of object and tuple fields.");
@@ -207,7 +205,7 @@ public abstract class DestructuredArgumentNode implements UndefinedVariableProvi
 
   public abstract Stream<LoadableValue> render(Consumer<Renderer> loader);
 
-  public abstract Stream<EcmaLoadableValue> renderEcma(Function<EcmaScriptRenderer, String> loader);
+  public abstract Stream<EcmaLoadableValue> renderEcma(String loader);
 
   public abstract boolean resolve(
       ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeConvertedVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeConvertedVariable.java
@@ -8,7 +8,6 @@ import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
@@ -45,15 +44,15 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
 
   private class EcmaStringConverter extends EcmaLoadableValue {
 
-    private final Function<EcmaScriptRenderer, String> loader;
+    private final String loader;
 
-    public EcmaStringConverter(Function<EcmaScriptRenderer, String> loader) {
+    public EcmaStringConverter(String loader) {
       this.loader = loader;
     }
 
     @Override
-    public String apply(EcmaScriptRenderer renderer) {
-      return loader.apply(renderer) + ".toString()";
+    public String get() {
+      return loader + ".toString()";
     }
 
     @Override
@@ -243,13 +242,13 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
   }
 
   @Override
-  public Stream<EcmaLoadableValue> renderEcma(Function<EcmaScriptRenderer, String> loader) {
+  public Stream<EcmaLoadableValue> renderEcma(String loader) {
     if (convertedType.isSame(Imyhat.JSON)) {
       return Stream.of(
           new EcmaLoadableValue() {
             @Override
-            public String apply(EcmaScriptRenderer renderer) {
-              return loader.apply(renderer);
+            public String get() {
+              return loader;
             }
 
             @Override
@@ -269,8 +268,8 @@ public class DestructuredArgumentNodeConvertedVariable extends DestructuredArgum
         return Stream.of(
             new EcmaLoadableValue() {
               @Override
-              public String apply(EcmaScriptRenderer renderer) {
-                return String.format("JSON.toString(%s)", loader.apply(renderer));
+              public String get() {
+                return String.format("JSON.toString(%s)", loader);
               }
 
               @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeObject.java
@@ -45,8 +45,7 @@ public class DestructuredArgumentNodeObject extends DestructuredArgumentNode {
   @Override
   public WildcardCheck checkWildcard(Consumer<String> errorHandler) {
     final WildcardCheck result =
-        fields
-            .stream()
+        fields.stream()
             .map(p -> p.second().checkWildcard(errorHandler))
             .reduce(WildcardCheck.NONE, WildcardCheck::combine);
     if (result == WildcardCheck.BAD) {
@@ -80,17 +79,14 @@ public class DestructuredArgumentNodeObject extends DestructuredArgumentNode {
   }
 
   @Override
-  public Stream<EcmaLoadableValue> renderEcma(Function<EcmaScriptRenderer, String> loader) {
-    return fields
-        .stream()
-        .flatMap(f -> f.second().renderEcma(r -> loader.apply(r) + "." + f.first()));
+  public Stream<EcmaLoadableValue> renderEcma(String loader) {
+    return fields.stream().flatMap(f -> f.second().renderEcma(loader + "." + f.first()));
   }
 
   @Override
   public boolean resolve(
       ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
-    return fields
-            .stream()
+    return fields.stream()
             .filter(f -> f.second().resolve(expressionCompilerServices, errorHandler))
             .count()
         == fields.size();
@@ -111,13 +107,10 @@ public class DestructuredArgumentNodeObject extends DestructuredArgumentNode {
   @Override
   public boolean typeCheck(Imyhat type, Consumer<String> errorHandler) {
     final Map<String, Long> elementCounts =
-        fields
-            .stream()
+        fields.stream()
             .map(Pair::first)
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-    if (elementCounts
-            .entrySet()
-            .stream()
+    if (elementCounts.entrySet().stream()
             .filter(e -> e.getValue() > 1)
             .peek(
                 e ->

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeStar.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeStar.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
@@ -67,7 +66,7 @@ public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
       return name;
     }
 
-    public EcmaLoadableValue prepareEcma(Function<EcmaScriptRenderer, String> loader) {
+    public EcmaLoadableValue prepareEcma(String loader) {
       return new EcmaLoadableValue() {
         @Override
         public String name() {
@@ -75,8 +74,8 @@ public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
         }
 
         @Override
-        public String apply(EcmaScriptRenderer renderer) {
-          return loader.apply(renderer) + "." + name;
+        public String get() {
+          return loader + "." + name;
         }
       };
     }
@@ -140,7 +139,7 @@ public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
   }
 
   @Override
-  public Stream<EcmaLoadableValue> renderEcma(Function<EcmaScriptRenderer, String> loader) {
+  public Stream<EcmaLoadableValue> renderEcma(String loader) {
     return fields.values().stream().map(f -> f.prepareEcma(loader));
   }
 
@@ -164,9 +163,7 @@ public class DestructuredArgumentNodeStar extends DestructuredArgumentNode {
   public boolean typeCheck(Imyhat type, Consumer<String> errorHandler) {
     if (type instanceof Imyhat.ObjectImyhat) {
       objectType = (Imyhat.ObjectImyhat) type;
-      return fields
-              .values()
-              .stream()
+      return fields.values().stream()
               .filter(
                   target -> {
                     target.type = objectType.get(target.name);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeTuple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeTuple.java
@@ -6,7 +6,6 @@ import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.objectweb.asm.Type;
@@ -47,8 +46,7 @@ public class DestructuredArgumentNodeTuple extends DestructuredArgumentNode {
   @Override
   public WildcardCheck checkWildcard(Consumer<String> errorHandler) {
     final WildcardCheck result =
-        elements
-            .stream()
+        elements.stream()
             .map(element -> element.checkWildcard(errorHandler))
             .reduce(WildcardCheck.NONE, WildcardCheck::combine);
     if (result == WildcardCheck.BAD) {
@@ -76,17 +74,16 @@ public class DestructuredArgumentNodeTuple extends DestructuredArgumentNode {
   }
 
   @Override
-  public Stream<EcmaLoadableValue> renderEcma(Function<EcmaScriptRenderer, String> loader) {
+  public Stream<EcmaLoadableValue> renderEcma(String loader) {
     return IntStream.range(0, elements.size())
         .boxed()
-        .flatMap(i -> elements.get(i).renderEcma(r -> loader.apply(r) + "[" + i + "]"));
+        .flatMap(i -> elements.get(i).renderEcma(loader + "[" + i + "]"));
   }
 
   @Override
   public boolean resolve(
       ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
-    return elements
-            .stream()
+    return elements.stream()
             .filter(element -> element.resolve(expressionCompilerServices, errorHandler))
             .count()
         == elements.size();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeVariable.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/DestructuredArgumentNodeVariable.java
@@ -4,7 +4,6 @@ import static ca.on.oicr.gsi.shesmu.compiler.TypeUtils.TO_ASM;
 
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import org.objectweb.asm.Type;
 
@@ -96,7 +95,7 @@ public class DestructuredArgumentNodeVariable extends DestructuredArgumentNode {
   }
 
   @Override
-  public Stream<EcmaLoadableValue> renderEcma(Function<EcmaScriptRenderer, String> loader) {
+  public Stream<EcmaLoadableValue> renderEcma(String loader) {
     return Stream.of(
         new EcmaLoadableValue() {
           @Override
@@ -105,8 +104,8 @@ public class DestructuredArgumentNodeVariable extends DestructuredArgumentNode {
           }
 
           @Override
-          public String apply(EcmaScriptRenderer renderer) {
-            return loader.apply(renderer);
+          public String get() {
+            return loader;
           }
         });
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/EcmaLoadableConstructor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/EcmaLoadableConstructor.java
@@ -1,8 +1,7 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public interface EcmaLoadableConstructor {
-  Stream<EcmaLoadableValue> create(Function<EcmaScriptRenderer, String> baseLoader);
+  Stream<EcmaLoadableValue> create(String base);
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/EcmaLoadableValue.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/EcmaLoadableValue.java
@@ -1,9 +1,9 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 /** A value that can be put on the operand stack in a method. */
-public abstract class EcmaLoadableValue implements Function<EcmaScriptRenderer, String> {
+public abstract class EcmaLoadableValue implements Supplier<String> {
   /** The variable name of this value */
   public abstract String name();
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/EcmaScriptRenderer.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/EcmaScriptRenderer.java
@@ -417,7 +417,7 @@ public final class EcmaScriptRenderer {
   }
 
   public final String load(Target target) {
-    return targets.get(target.name()).apply(this);
+    return targets.get(target.name()).get();
   }
 
   public <T> void mapIf(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/EcmaStreamBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/EcmaStreamBuilder.java
@@ -51,7 +51,7 @@ public final class EcmaStreamBuilder {
             renderer.lambda(
                 1,
                 (r, arg) -> {
-                  name.create(rr -> arg.apply(0)).forEach(r::define);
+                  name.create(arg.apply(0)).forEach(r::define);
                   return render.apply(r);
                 }))
         .append(")");
@@ -80,7 +80,7 @@ public final class EcmaStreamBuilder {
             renderer.lambda(
                 1,
                 (r, arg) -> {
-                  name.create(rr -> arg.apply(0)).forEach(r::define);
+                  name.create(arg.apply(0)).forEach(r::define);
                   return render.apply(r);
                 }))
         .append(")");
@@ -108,7 +108,7 @@ public final class EcmaStreamBuilder {
             renderer.lambda(
                 1,
                 (r, arg) -> {
-                  name.create(rr -> arg.apply(0)).forEach(r::define);
+                  name.create(arg.apply(0)).forEach(r::define);
                   return render.apply(r);
                 }))
         .append("))");

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeBlock.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeBlock.java
@@ -59,7 +59,7 @@ public class ExpressionNodeBlock extends ExpressionNode {
     final EcmaScriptRenderer inner = renderer.duplicate();
     for (final Pair<DestructuredArgumentNode, ExpressionNode> definition : definitions) {
       final String value = renderer.newConst(definition.second().renderEcma(inner));
-      definition.first().renderEcma(rr -> value).forEach(inner::define);
+      definition.first().renderEcma(value).forEach(inner::define);
     }
     return result.renderEcma(inner);
   }
@@ -97,8 +97,7 @@ public class ExpressionNodeBlock extends ExpressionNode {
   @Override
   public boolean resolveDefinitions(
       ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
-    return definitions
-                .stream()
+    return definitions.stream()
                 .filter(
                     d ->
                         !d.first().resolve(expressionCompilerServices, errorHandler)

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFor.java
@@ -52,10 +52,9 @@ public class ExpressionNodeFor extends ExpressionNode {
     final EcmaStreamBuilder builder = source.render(renderer);
     return collector.render(
         builder,
-        transforms
-            .stream()
+        transforms.stream()
             .reduce(
-                name::renderEcma,
+                loader -> name.renderEcma(loader),
                 (n, transform) -> transform.render(builder, n),
                 (a, b) -> {
                   throw new UnsupportedOperationException();
@@ -67,8 +66,7 @@ public class ExpressionNodeFor extends ExpressionNode {
     final JavaStreamBuilder builder = source.render(renderer);
     collector.render(
         builder,
-        transforms
-            .stream()
+        transforms.stream()
             .reduce(
                 name::render,
                 (n, transform) -> transform.render(builder, n),
@@ -82,8 +80,7 @@ public class ExpressionNodeFor extends ExpressionNode {
     boolean ok = source.resolve(defs, errorHandler);
 
     final Optional<DestructuredArgumentNode> nextName =
-        transforms
-            .stream()
+        transforms.stream()
             .reduce(
                 Optional.of(name),
                 (n, t) -> n.flatMap(name -> t.resolve(name, defs, errorHandler)),
@@ -100,8 +97,7 @@ public class ExpressionNodeFor extends ExpressionNode {
       ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
     return source.resolveDefinitions(expressionCompilerServices, errorHandler)
         & collector.resolveDefinitions(expressionCompilerServices, errorHandler)
-        & transforms
-                .stream()
+        & transforms.stream()
                 .filter(t -> t.resolveDefinitions(expressionCompilerServices, errorHandler))
                 .count()
             == transforms.size()
@@ -120,8 +116,7 @@ public class ExpressionNodeFor extends ExpressionNode {
       return false;
     }
     final Ordering ordering =
-        transforms
-            .stream()
+        transforms.stream()
             .reduce(
                 source.ordering(),
                 (order, transform) -> transform.order(order, errorHandler),
@@ -129,8 +124,7 @@ public class ExpressionNodeFor extends ExpressionNode {
                   throw new UnsupportedOperationException();
                 });
     final Optional<Imyhat> resultType =
-        transforms
-            .stream()
+        transforms.stream()
             .reduce(
                 Optional.of(source.streamType()),
                 (t, transform) -> t.flatMap(tt -> transform.typeCheck(tt, errorHandler)),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTernaryIf.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeTernaryIf.java
@@ -45,8 +45,14 @@ public class ExpressionNodeTernaryIf extends ExpressionNode {
   @Override
   public String renderEcma(EcmaScriptRenderer renderer) {
     final String result = renderer.newLet();
-    renderer.conditional(testExpression.renderEcma(renderer), whenTrue-> whenTrue.statement(String.format("%s = %s", result, trueExpression.renderEcma(whenTrue))),
-        whenfalse-> whenfalse.statement(String.format("%s = %s", result, trueExpression.renderEcma(whenfalse))));
+    renderer.conditional(
+        testExpression.renderEcma(renderer),
+        whenTrue ->
+            whenTrue.statement(
+                String.format("%s = %s", result, trueExpression.renderEcma(whenTrue))),
+        whenFalse ->
+            whenFalse.statement(
+                String.format("%s = %s", result, falseExpression.renderEcma(whenFalse))));
     return result;
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNodeDropdown.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNodeDropdown.java
@@ -51,7 +51,7 @@ public final class FormNodeDropdown extends FormNode {
         renderer.lambda(
             1,
             (r, a) -> {
-              itemName.renderEcma(rr -> a.apply(0)).forEach(r::define);
+              itemName.renderEcma(a.apply(0)).forEach(r::define);
               return itemLabel.renderEcma(r);
             }));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/InformationNodeBaseRepeat.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/InformationNodeBaseRepeat.java
@@ -27,7 +27,7 @@ public abstract class InformationNodeBaseRepeat extends InformationNode {
   @Override
   public final String renderEcma(EcmaScriptRenderer renderer) {
     final EcmaStreamBuilder builder = source.render(renderer);
-    EcmaLoadableConstructor currentName = name::renderEcma;
+    EcmaLoadableConstructor currentName = loader -> name.renderEcma(loader);
     for (final ListNode transform : transforms) {
       currentName = transform.render(builder, currentName);
     }
@@ -43,8 +43,7 @@ public abstract class InformationNodeBaseRepeat extends InformationNode {
     boolean ok = source.resolve(defs, errorHandler);
 
     final Optional<DestructuredArgumentNode> nextName =
-        transforms
-            .stream()
+        transforms.stream()
             .reduce(
                 Optional.of(name),
                 (n, t) -> n.flatMap(name -> t.resolve(name, defs, errorHandler)),
@@ -72,8 +71,7 @@ public abstract class InformationNodeBaseRepeat extends InformationNode {
       Consumer<String> errorHandler) {
     return source.resolveDefinitions(expressionCompilerServices, errorHandler)
         & resolveTerminalDefinitions(expressionCompilerServices, nativeDefinitions, errorHandler)
-        & transforms
-                .stream()
+        & transforms.stream()
                 .filter(t -> t.resolveDefinitions(expressionCompilerServices, errorHandler))
                 .count()
             == transforms.size()
@@ -95,8 +93,7 @@ public abstract class InformationNodeBaseRepeat extends InformationNode {
       return false;
     }
     final Ordering ordering =
-        transforms
-            .stream()
+        transforms.stream()
             .reduce(
                 source.ordering(),
                 (order, transform) -> transform.order(order, errorHandler),
@@ -104,8 +101,7 @@ public abstract class InformationNodeBaseRepeat extends InformationNode {
                   throw new UnsupportedOperationException();
                 });
     final Optional<Imyhat> resultType =
-        transforms
-            .stream()
+        transforms.stream()
             .reduce(
                 Optional.of(source.streamType()),
                 (t, transform) -> t.flatMap(tt -> transform.typeCheck(tt, errorHandler)),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeMap.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeMap.java
@@ -41,7 +41,7 @@ public class ListNodeMap extends ListNodeWithExpression {
   @Override
   public EcmaLoadableConstructor render(EcmaStreamBuilder builder, EcmaLoadableConstructor name) {
     builder.map(name, expression.type(), expression::renderEcma);
-    return nextName::renderEcma;
+    return loader -> nextName.renderEcma(loader);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchAlternativeNodeRemainder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchAlternativeNodeRemainder.java
@@ -90,17 +90,18 @@ public class MatchAlternativeNodeRemainder extends MatchAlternativeNode {
 
   @Override
   public String render(EcmaScriptRenderer renderer, String original) {
-    renderer.define(new EcmaLoadableValue() {
-      @Override
-      public String name() {
-        return name;
-      }
+    renderer.define(
+        new EcmaLoadableValue() {
+          @Override
+          public String name() {
+            return name;
+          }
 
-      @Override
-      public String apply(EcmaScriptRenderer renderer) {
-        return original;
-      }
-    });
+          @Override
+          public String get() {
+            return original;
+          }
+        });
     return expression.renderEcma(renderer);
   }
 
@@ -136,9 +137,7 @@ public class MatchAlternativeNodeRemainder extends MatchAlternativeNode {
       return Imyhat.BAD;
     }
     type =
-        remainingBranches
-            .entrySet()
-            .stream()
+        remainingBranches.entrySet().stream()
             .map(
                 e ->
                     e.getValue()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchBranchNodeDiscard.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchBranchNodeDiscard.java
@@ -22,6 +22,11 @@ public class MatchBranchNodeDiscard extends MatchBranchNode {
   }
 
   @Override
+  protected Stream<EcmaLoadableValue> loadBoundNames(String base) {
+    return Stream.empty();
+  }
+
+  @Override
   protected Renderer prepare(Renderer renderer, BiConsumer<Renderer, Integer> loadElement) {
     return renderer;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchBranchNodeEmpty.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchBranchNodeEmpty.java
@@ -22,6 +22,11 @@ public class MatchBranchNodeEmpty extends MatchBranchNode {
   }
 
   @Override
+  protected Stream<EcmaLoadableValue> loadBoundNames(String base) {
+    return Stream.empty();
+  }
+
+  @Override
   protected Renderer prepare(Renderer renderer, BiConsumer<Renderer, Integer> loadElement) {
     return renderer;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchBranchNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchBranchNodeObject.java
@@ -43,12 +43,16 @@ public class MatchBranchNodeObject extends MatchBranchNode {
   }
 
   @Override
+  protected Stream<EcmaLoadableValue> loadBoundNames(String base) {
+    return fields.stream().flatMap(f -> f.second().renderEcma(base + ".contents." + f.first()));
+  }
+
+  @Override
   protected Renderer prepare(Renderer renderer, BiConsumer<Renderer, Integer> loadElement) {
     final List<String> fieldNames =
         fields.stream().map(Pair::first).sorted().collect(Collectors.toList());
     final Renderer result = renderer.duplicate();
-    fields
-        .stream()
+    fields.stream()
         .flatMap(
             f -> {
               final int i = fieldNames.indexOf(f.first());
@@ -67,8 +71,7 @@ public class MatchBranchNodeObject extends MatchBranchNode {
   @Override
   protected boolean typeCheckBindings(Imyhat argumentType, Consumer<String> errorHandler) {
     this.argumentType = argumentType;
-    return fields
-                .stream()
+    return fields.stream()
                 .filter(f -> f.second().checkWildcard(errorHandler) != WildcardCheck.BAD)
                 .count()
             == fields.size()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchBranchNodeTuple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/MatchBranchNodeTuple.java
@@ -8,6 +8,7 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.TupleImyhat;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.objectweb.asm.Type;
@@ -39,6 +40,21 @@ public class MatchBranchNodeTuple extends MatchBranchNode {
   @Override
   protected Stream<Target> boundNames() {
     return elements.stream().flatMap(DestructuredArgumentNode::targets);
+  }
+
+  @Override
+  protected Stream<EcmaLoadableValue> loadBoundNames(String base) {
+    return elements.stream()
+        .flatMap(
+            new Function<DestructuredArgumentNode, Stream<? extends EcmaLoadableValue>>() {
+              private int index;
+
+              @Override
+              public Stream<? extends EcmaLoadableValue> apply(DestructuredArgumentNode element) {
+                final int current = index++;
+                return element.renderEcma(String.format("%s.contents[%d]", base, current));
+              }
+            });
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNodeFixedWithCondition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SampleNodeFixedWithCondition.java
@@ -119,7 +119,7 @@ public class SampleNodeFixedWithCondition extends SampleNode {
         renderer.lambda(
             1,
             (r, args) -> {
-              name.create(rr -> args.apply(0)).forEach(renderer::define);
+              name.create(args.apply(0)).forEach(renderer::define);
               return conditionExpression.renderEcma(r);
             }));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchAlternativeNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchAlternativeNode.java
@@ -57,8 +57,7 @@ public abstract class WizardMatchAlternativeNode {
     return input.whitespace().dispatch(DISPATCH, output);
   }
 
-  public abstract String render(
-      EcmaScriptRenderer renderer, EcmaLoadableConstructor name, String original);
+  public abstract String render(EcmaScriptRenderer renderer, String original);
 
   public abstract boolean resolve(NameDefinitions defs, Consumer<String> errorHandler);
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchAlternativeNodeElse.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchAlternativeNodeElse.java
@@ -14,8 +14,8 @@ public class WizardMatchAlternativeNodeElse extends WizardMatchAlternativeNode {
   }
 
   @Override
-  public String render(EcmaScriptRenderer renderer, EcmaLoadableConstructor name, String original) {
-    return expression.renderEcma(renderer, name);
+  public String render(EcmaScriptRenderer renderer, String original) {
+    return expression.renderEcma(renderer);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchAlternativeNodeEmpty.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchAlternativeNodeEmpty.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 public class WizardMatchAlternativeNodeEmpty extends WizardMatchAlternativeNode {
 
   @Override
-  public String render(EcmaScriptRenderer renderer, EcmaLoadableConstructor name, String original) {
+  public String render(EcmaScriptRenderer renderer, String original) {
     renderer.statement(
         "throw new Error(\"Unsupported algebraic value in “Match” with no alternative.\")");
     return "null";

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchAlternativeNodeRemainder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchAlternativeNodeRemainder.java
@@ -47,28 +47,20 @@ public class WizardMatchAlternativeNodeRemainder extends WizardMatchAlternativeN
   }
 
   @Override
-  public String render(EcmaScriptRenderer renderer, EcmaLoadableConstructor name, String original) {
-    return String.format(
-        "$state => %s({...$state, %s: %s})",
-        step.renderEcma(
-            renderer,
-            base ->
-                Stream.concat(
-                    name.create(base),
-                    Stream.of(
-                        new EcmaLoadableValue() {
-                          @Override
-                          public String apply(EcmaScriptRenderer renderer) {
-                            return base.apply(renderer) + "." + name();
-                          }
+  public String render(EcmaScriptRenderer renderer, String original) {
+    renderer.define(
+        new EcmaLoadableValue() {
+          @Override
+          public String name() {
+            return name;
+          }
 
-                          @Override
-                          public String name() {
-                            return WizardMatchAlternativeNodeRemainder.this.name;
-                          }
-                        }))),
-        this.name,
-        original);
+          @Override
+          public String get() {
+            return original;
+          }
+        });
+    return step.renderEcma(renderer);
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchBranchNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchBranchNode.java
@@ -65,10 +65,10 @@ public abstract class WizardMatchBranchNode {
     return result;
   }
 
+  private final int column;
+  private final int line;
   private final String name;
   private final WizardNode value;
-  private final int line;
-  private final int column;
 
   protected WizardMatchBranchNode(int line, int column, String name, WizardNode value) {
     this.line = line;
@@ -81,12 +81,23 @@ public abstract class WizardMatchBranchNode {
 
   protected abstract Stream<Target> boundNames();
 
+  public final int column() {
+    return column;
+  }
+
+  public final int line() {
+    return line;
+  }
+
+  protected abstract Stream<EcmaLoadableValue> loadBoundNames(String base);
+
   public final String name() {
     return name;
   }
 
-  public String renderEcma(EcmaScriptRenderer renderer, EcmaLoadableConstructor name) {
-    return value.renderEcma(renderer, name);
+  public String renderEcma(EcmaScriptRenderer renderer, String original) {
+    loadBoundNames(original).forEach(renderer::define);
+    return value.renderEcma(renderer);
   }
 
   public final boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
@@ -103,14 +114,6 @@ public abstract class WizardMatchBranchNode {
       DefinitionRepository nativeDefinitions,
       Consumer<String> errorHandler) {
     return value.resolveDefinitions(expressionCompilerServices, nativeDefinitions, errorHandler);
-  }
-
-  public final int line() {
-    return line;
-  }
-
-  public final int column() {
-    return column;
   }
 
   public final boolean typeCheck(Imyhat argumentType, Consumer<String> errorHandler) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchBranchNodeDiscard.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchBranchNodeDiscard.java
@@ -21,6 +21,11 @@ public class WizardMatchBranchNodeDiscard extends WizardMatchBranchNode {
   }
 
   @Override
+  protected Stream<EcmaLoadableValue> loadBoundNames(String base) {
+    return Stream.empty();
+  }
+
+  @Override
   protected boolean typeCheckBindings(Imyhat argumentType, Consumer<String> errorHandler) {
     return true;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchBranchNodeEmpty.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchBranchNodeEmpty.java
@@ -21,6 +21,11 @@ public class WizardMatchBranchNodeEmpty extends WizardMatchBranchNode {
   }
 
   @Override
+  protected Stream<EcmaLoadableValue> loadBoundNames(String base) {
+    return Stream.empty();
+  }
+
+  @Override
   protected boolean typeCheckBindings(Imyhat argumentType, Consumer<String> errorHandler) {
     if (argumentType.isSame(Imyhat.NOTHING)) {
       return true;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchBranchNodeObject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardMatchBranchNodeObject.java
@@ -37,9 +37,13 @@ public class WizardMatchBranchNodeObject extends WizardMatchBranchNode {
   }
 
   @Override
+  protected Stream<EcmaLoadableValue> loadBoundNames(String base) {
+    return fields.stream().flatMap(f -> f.second().renderEcma(base + ".contents." + f.first()));
+  }
+
+  @Override
   protected boolean typeCheckBindings(Imyhat argumentType, Consumer<String> errorHandler) {
-    return fields
-                .stream()
+    return fields.stream()
                 .filter(f -> f.second().checkWildcard(errorHandler) != WildcardCheck.BAD)
                 .count()
             == fields.size()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNode.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 public abstract class WizardNode {
   private static final Parser.ParseDispatch<WizardNode> DISPATCH = new ParseDispatch<>();
   private static final Parser.ParseDispatch<WizardNode> FLOW = new ParseDispatch<>();
+  public static final String STATE = "Meditation State";
   public static final Pattern STRING_CONTENTS = Pattern.compile("^[^\"\n\\\\]*");
   private static final Parser.ParseDispatch<Function<List<InformationNode>, WizardNode>> WIZARD =
       new ParseDispatch<>();
@@ -246,7 +247,7 @@ public abstract class WizardNode {
   }
 
   /** Produce ES6/JavaScript code for this expression */
-  public abstract String renderEcma(EcmaScriptRenderer renderer, EcmaLoadableConstructor name);
+  public abstract String renderEcma(EcmaScriptRenderer renderer);
 
   /** Resolve all variable plugins in this expression and its children. */
   public abstract boolean resolve(NameDefinitions defs, Consumer<String> errorHandler);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeConditional.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeConditional.java
@@ -18,23 +18,13 @@ public class WizardNodeConditional extends WizardNode {
   }
 
   @Override
-  public String renderEcma(EcmaScriptRenderer renderer, EcmaLoadableConstructor name) {
-    return renderer.newConst(
-        renderer.lambda(
-            1,
-            (r, a) -> {
-              name.create(rr -> a.apply(0)).forEach(r::define);
-              final String result = r.newLet();
-              r.conditional(
-                  test.renderEcma(r),
-                  (rr) ->
-                      rr.statement(
-                          String.format("%s = %s", result, trueStep.renderEcma(renderer, name))),
-                  rr ->
-                      rr.statement(
-                          String.format("%s = %s", result, falseStep.renderEcma(renderer, name))));
-              return String.format("%s(%s)", result, a.apply(0));
-            }));
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    final String result = renderer.newLet();
+    renderer.conditional(
+        test.renderEcma(renderer),
+        r -> r.statement(String.format("%s = %s", result, trueStep.renderEcma(r))),
+        r -> r.statement(String.format("%s = %s", result, falseStep.renderEcma(r))));
+    return result;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeEnd.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeEnd.java
@@ -14,19 +14,12 @@ public class WizardNodeEnd extends WizardNode {
   }
 
   @Override
-  public String renderEcma(EcmaScriptRenderer renderer, EcmaLoadableConstructor name) {
-    return renderer.newConst(
-        renderer.lambda(
-            1,
-            (r, a) -> {
-              name.create(rr -> a.apply(0)).forEach(r::define);
-              return String.format(
-                  "{information: %s, then: null}",
-                  information
-                      .stream()
-                      .map(i -> i.renderEcma(r))
-                      .collect(Collectors.joining(", ", "[", "]")));
-            }));
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    return String.format(
+        "{information: %s, then: null}",
+        information.stream()
+            .map(i -> i.renderEcma(renderer))
+            .collect(Collectors.joining(", ", "[", "]")));
   }
 
   @Override
@@ -47,8 +40,7 @@ public class WizardNodeEnd extends WizardNode {
       ExpressionCompilerServices expressionCompilerServices,
       DefinitionRepository nativeDefinitions,
       Consumer<String> errorHandler) {
-    return information
-            .stream()
+    return information.stream()
             .filter(
                 i ->
                     i.resolveDefinitions(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeForm.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeForm.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class WizardNodeForm extends WizardNode {
   private final List<InformationNode> information;
@@ -30,53 +29,42 @@ public class WizardNodeForm extends WizardNode {
   }
 
   @Override
-  public String renderEcma(EcmaScriptRenderer renderer, EcmaLoadableConstructor name) {
-    final String nextFunction =
-        next.renderEcma(
-            renderer,
-            base ->
-                Stream.concat(
-                    name.create(base),
-                    entries
-                        .stream()
-                        .map(
-                            n ->
-                                new EcmaLoadableValue() {
-                                  @Override
-                                  public String name() {
-                                    return n.name();
-                                  }
-
-                                  @Override
-                                  public String apply(EcmaScriptRenderer renderer) {
-                                    return base.apply(renderer) + "." + n.name();
-                                  }
-                                })));
-    return renderer.newConst(
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    return String.format(
+        "{information: %s, then: {type: \"form\", parameters: %s, processor: %s}}",
+        information.stream()
+            .map(i -> i.renderEcma(renderer))
+            .collect(Collectors.joining(", ", "[", "]")),
+        entries.stream()
+            .map(
+                c -> {
+                  try {
+                    return RuntimeSupport.MAPPER.writeValueAsString(c.name())
+                        + ": "
+                        + c.renderEcma(renderer);
+                  } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.joining(",", "{", "}")),
         renderer.lambda(
             1,
             (r, a) -> {
-              name.create(rr -> a.apply(0)).forEach(r::define);
-              return String.format(
-                  "{information: %s, then: {type: \"form\", parameters: %s, processor: %s}}",
-                  information
-                      .stream()
-                      .map(i -> i.renderEcma(r))
-                      .collect(Collectors.joining(", ", "[", "]")),
-                  entries
-                      .stream()
-                      .map(
-                          c -> {
-                            try {
-                              return RuntimeSupport.MAPPER.writeValueAsString(c.name())
-                                  + ": "
-                                  + c.renderEcma(r);
-                            } catch (JsonProcessingException e) {
-                              throw new RuntimeException(e);
-                            }
-                          })
-                      .collect(Collectors.joining(",", "{", "}")),
-                  nextFunction);
+              for (final FormNode entry : entries) {
+                r.define(
+                    new EcmaLoadableValue() {
+                      @Override
+                      public String name() {
+                        return entry.name();
+                      }
+
+                      @Override
+                      public String get() {
+                        return a.apply(0) + "." + entry.name();
+                      }
+                    });
+              }
+              return next.renderEcma(r);
             }));
   }
 
@@ -84,8 +72,7 @@ public class WizardNodeForm extends WizardNode {
   public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
     boolean ok = true;
     for (final Map.Entry<String, Long> entry :
-        entries
-            .stream()
+        entries.stream()
             .collect(Collectors.groupingBy(FormNode::name, Collectors.counting()))
             .entrySet()) {
       if (entry.getValue() > 1) {
@@ -114,16 +101,14 @@ public class WizardNodeForm extends WizardNode {
       ExpressionCompilerServices expressionCompilerServices,
       DefinitionRepository nativeDefinitions,
       Consumer<String> errorHandler) {
-    return information
-                .stream()
+    return information.stream()
                 .filter(
                     i ->
                         i.resolveDefinitions(
                             expressionCompilerServices, nativeDefinitions, errorHandler))
                 .count()
             == information.size()
-        & entries
-                .stream()
+        & entries.stream()
                 .filter(
                     e ->
                         e.resolveDefinitions(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeGoto.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeGoto.java
@@ -21,17 +21,11 @@ public class WizardNodeGoto extends WizardNode {
   }
 
   @Override
-  public String renderEcma(EcmaScriptRenderer renderer, EcmaLoadableConstructor name) {
-    return renderer.newConst(
-        renderer.lambda(
-            1,
-            (r, a) -> {
-              name.create(rr -> a.apply(0)).forEach(r::define);
-              return arguments
-                  .stream()
-                  .map(arg -> arg.renderEcma(r))
-                  .collect(Collectors.joining(", ", definition.function() + "(", ")"));
-            }));
+  public String renderEcma(EcmaScriptRenderer renderer) {
+
+    return arguments.stream()
+        .map(arg -> arg.renderEcma(renderer))
+        .collect(Collectors.joining(", ", definition.function() + "(", ")"));
   }
 
   @Override
@@ -58,8 +52,7 @@ public class WizardNodeGoto extends WizardNode {
       ExpressionCompilerServices expressionCompilerServices,
       DefinitionRepository nativeDefinitions,
       Consumer<String> errorHandler) {
-    return arguments
-            .stream()
+    return arguments.stream()
             .filter(arg -> arg.resolveDefinitions(expressionCompilerServices, errorHandler))
             .count()
         == arguments.size();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/GuidedMeditation.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/GuidedMeditation.java
@@ -133,10 +133,10 @@ public class GuidedMeditation implements WatchedFileListener {
                   for (final WizardDefineNode definition : definitions.get()) {
                     definition.render(renderer);
                   }
+
                   renderer.statement(
                       String.format(
-                          "return %s",
-                          wizard.get().renderEcma(renderer, baseLoader -> Stream.empty())));
+                          "return %s", renderer.lambda(0, (r, a) -> wizard.get().renderEcma(r))));
                 }));
       } else {
         errorHandler.accept(errors);


### PR DESCRIPTION
The guided meditation `Flow By Match` had a bug:

```
Flow By Match
  When FOO {x} Then x # x was not available here
```

There were other inconsistent problems where variables that should be in scope
were not.

The ECMAScript code generator was originally a copy of the JVM implementation.
This lead to unnecessary complexity because the JVM implementation needs to
capture variables in lambdas while the ES6 does the capturing automatically.
The variables defined by the meditation were also placed in a state object that
the meditation console would pass between steps.

This change simplifies this by using the native capture system of ECMAScript
and removes the state object by moving that data into local variables. The
`Fetch`, `Form`, and `Fork` operations still need to be able to inject data
from the console, so they have a different signature where the console can pass
an object with named parameters that they can extract as necessary.

This removes generated ECMAScript lambdas from most `WizardNode` classes and
removes lambdas for loading variable names in much of the compiler code.

This fixes the variable capture in `Flow By Match` and implements it in
`Match`, where that was incomplete.

Also fixes a bug in `If` where the false branch was not rendered correctly.