### PR TITLE
Make tabs scrollable

### DIFF
--- a/shesmu-server-ui/types/resize-obeserver-browser/index.d.ts
+++ b/shesmu-server-ui/types/resize-obeserver-browser/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for non-npm package resize-observer-browser 0.1
+// Project: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver, https://developers.google.com/web/updates/2016/10/resizeobserver, https://wicg.github.io/ResizeObserver/
+// Definitions by: Chives <https://github.com/chivesrs>
+//                 William Furr <https://github.com/wffurr>
+//                 Alexander Shushunov <https://github.com/AlexanderShushunov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Window {
+    ResizeObserver: typeof ResizeObserver;
+}
+
+interface ResizeObserverOptions {
+    /**
+     * Sets which box model the observer will observe changes to. Possible values
+     * are `content-box` (the default), and `border-box`.
+     *
+     * @default 'content-box'
+     */
+    box?: 'content-box' | 'border-box' | 'device-pixel-content-box';
+}
+
+interface ResizeObserverSize {
+    readonly inlineSize: number;
+    readonly blockSize: number;
+}
+
+interface ResizeObserver {
+    disconnect(): void;
+    observe(target: Element, options?: ResizeObserverOptions): void;
+    unobserve(target: Element): void;
+}
+
+declare var ResizeObserver: {
+    new (callback: ResizeObserverCallback): ResizeObserver;
+    prototype: ResizeObserver;
+};
+
+interface ResizeObserverCallback {
+    (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
+}
+
+interface ResizeObserverEntry {
+    readonly target: Element;
+    readonly contentRect: DOMRectReadOnly;
+    readonly borderBoxSize: ReadonlyArray<ResizeObserverSize>;
+    readonly contentBoxSize: ReadonlyArray<ResizeObserverSize>;
+    readonly devicePixelContentBoxSize?: ReadonlyArray<ResizeObserverSize>;
+}

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -737,8 +737,18 @@ a.button.danger:visited {
   background-color: var(--widget-zebra);
 }
 
+.tabs {
+  display: flex;
+}
+.tabs > div {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: hidden;
+  min-height: max-content;
+}
+
 .tab {
-  display: inline-block;
+  flex: 0 0 auto;
   margin: 0.5em;
   padding: 1em;
   border-bottom: 0.1em solid var(--widget-highlight);


### PR DESCRIPTION
If the tab heads are too long, scroll them rather than wrap onto multiples
lines. Also, rather than maintaining two implementations, use `tabsModel` to
implement `tabs`.