### PR TITLE
Allow a multiple-fetch operation

### DIFF
--- a/guided-meditations.md
+++ b/guided-meditations.md
@@ -365,6 +365,19 @@ Running a function on the server. The constants and functions available to
 guided meditations are limited since they must run in the browser, but this
 allows executing a function, just like the _Definitions_ page.
 
+- _name_ `=` `For` _n_ `In` _source_`:` [ _transforms_ ]\* _collector_
+
+This allows doing a collection of related fetch operations.  The _source_ and
+_transforms_ are as exactly as `For` expressions. The _collector_ is one of the
+following:
+
+| Collector                | Behaviour |
+|--------------------------|-----------|
+| `List` _fetch_           | Performs the fetch for each input value and turns the results into a list. |
+| `Fetch` _fetch_          | Performs the fetch, which must return a list, for each input value and turns the results into a list. |
+| `Dict` _key_ `=` _fetch_ | Performs the fetch for each input value and turns the results into the values of a dictionary. _key_ is an expression that provides the corresponding key. |
+
+
 ### Define and Go-to
 It can be useful to reuse steps in different contents. At the beginning of a
 file, a reuable step can be defined:

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNode.java
@@ -1,0 +1,65 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
+import ca.on.oicr.gsi.shesmu.plugin.Parser;
+import ca.on.oicr.gsi.shesmu.plugin.Parser.ParseDispatch;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+public abstract class FetchCollectNode {
+  private static final ParseDispatch<FetchCollectNode> DISPATCHER = new ParseDispatch<>();
+
+  static {
+    DISPATCHER.addKeyword(
+        "List",
+        (p, o) -> p.whitespace().then(FetchNode::parse, FetchCollectNodeList::new).whitespace());
+    DISPATCHER.addKeyword(
+        "Flatten",
+        (p, o) ->
+            p.whitespace()
+                .then(
+                    FetchNode::parse,
+                    inner -> new FetchCollectNodeFlatten(p.line(), p.column(), inner))
+                .whitespace());
+    DISPATCHER.addKeyword(
+        "Dict",
+        (p, o) -> {
+          final AtomicReference<ExpressionNode> key = new AtomicReference<>();
+          final AtomicReference<FetchNode> value = new AtomicReference<>();
+          final Parser result =
+              p.whitespace()
+                  .then(ExpressionNode::parse, key::set)
+                  .whitespace()
+                  .symbol("=")
+                  .whitespace()
+                  .then(FetchNode::parse, value::set)
+                  .whitespace();
+          if (result.isGood()) {
+            o.accept(new FetchCollectNodeDictionary(key.get(), value.get()));
+          }
+          return result;
+        });
+  }
+
+  public static Parser parse(Parser parser, Consumer<FetchCollectNode> output) {
+    return parser.whitespace().dispatch(DISPATCHER, output).whitespace();
+  }
+
+  public abstract Imyhat comparatorType();
+
+  public abstract String operation();
+
+  public abstract String renderEcma(EcmaScriptRenderer renderer);
+
+  public abstract boolean resolve(NameDefinitions collectorName, Consumer<String> errorHandler);
+
+  public abstract boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices,
+      DefinitionRepository nativeDefinitions,
+      Consumer<String> errorHandler);
+
+  public abstract Imyhat type();
+
+  public abstract boolean typeCheck(Imyhat imyhat, Consumer<String> errorHandler);
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNodeDictionary.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNodeDictionary.java
@@ -1,0 +1,56 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.function.Consumer;
+
+public class FetchCollectNodeDictionary extends FetchCollectNode {
+
+  private final FetchNode value;
+  private final ExpressionNode key;
+
+  public FetchCollectNodeDictionary(ExpressionNode key, FetchNode value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  @Override
+  public Imyhat comparatorType() {
+    return key.type();
+  }
+
+  @Override
+  public String operation() {
+    return "dictionary";
+  }
+
+  @Override
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    return String.format(
+        "{key: %s, value: %s}", key.renderEcma(renderer), value.renderEcma(renderer));
+  }
+
+  @Override
+  public boolean resolve(NameDefinitions collectorName, Consumer<String> errorHandler) {
+    return key.resolve(collectorName, errorHandler) & value.resolve(collectorName, errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices,
+      DefinitionRepository nativeDefinitions,
+      Consumer<String> errorHandler) {
+    return key.resolveDefinitions(expressionCompilerServices, errorHandler)
+        & value.resolveDefinitions(expressionCompilerServices, nativeDefinitions, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return Imyhat.dictionary(key.type(), value.type());
+  }
+
+  @Override
+  public boolean typeCheck(Imyhat imyhat, Consumer<String> errorHandler) {
+    return key.typeCheck(errorHandler) & value.typeCheck(errorHandler);
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNodeFlatten.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNodeFlatten.java
@@ -1,0 +1,64 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat.ListImyhat;
+import java.util.function.Consumer;
+
+public class FetchCollectNodeFlatten extends FetchCollectNode {
+
+  private final int line;
+  private final int column;
+  private final FetchNode inner;
+
+  public FetchCollectNodeFlatten(int line, int column, FetchNode inner) {
+    this.line = line;
+    this.column = column;
+    this.inner = inner;
+  }
+
+  @Override
+  public Imyhat comparatorType() {
+    return inner.type();
+  }
+
+  @Override
+  public String operation() {
+    return "flatten";
+  }
+
+  @Override
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    return inner.renderEcma(renderer);
+  }
+
+  @Override
+  public boolean resolve(NameDefinitions collectorName, Consumer<String> errorHandler) {
+    return inner.resolve(collectorName, errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices,
+      DefinitionRepository nativeDefinitions,
+      Consumer<String> errorHandler) {
+    return inner.resolveDefinitions(expressionCompilerServices, nativeDefinitions, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return inner.type().asList();
+  }
+
+  @Override
+  public boolean typeCheck(Imyhat imyhat, Consumer<String> errorHandler) {
+    if (inner.typeCheck(errorHandler)) {
+      if (inner.type() instanceof ListImyhat) {
+        return true;
+      }
+      errorHandler.accept(
+          String.format("%d:%d: Expected list but got %s.", line, column, inner.type().name()));
+    }
+    return false;
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNodeList.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNodeList.java
@@ -1,0 +1,52 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.function.Consumer;
+
+public class FetchCollectNodeList extends FetchCollectNode {
+
+  private final FetchNode inner;
+
+  public FetchCollectNodeList(FetchNode inner) {
+    this.inner = inner;
+  }
+
+  @Override
+  public Imyhat comparatorType() {
+    return inner.type();
+  }
+
+  @Override
+  public String operation() {
+    return "list";
+  }
+
+  @Override
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    return inner.renderEcma(renderer);
+  }
+
+  @Override
+  public boolean resolve(NameDefinitions collectorName, Consumer<String> errorHandler) {
+    return inner.resolve(collectorName, errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices,
+      DefinitionRepository nativeDefinitions,
+      Consumer<String> errorHandler) {
+    return inner.resolveDefinitions(expressionCompilerServices, nativeDefinitions, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return inner.type().asList();
+  }
+
+  @Override
+  public boolean typeCheck(Imyhat imyhat, Consumer<String> errorHandler) {
+    return inner.typeCheck(errorHandler);
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeActions.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeActions.java
@@ -22,27 +22,15 @@ public class FetchNodeActions extends FetchNode {
   public FetchNodeActions(
       String fetchType,
       Imyhat type,
-      String name,
       ActionFilterNode<
               InformationParameterNode<ActionState>,
               InformationParameterNode<String>,
               InformationParameterNode<Instant>,
               InformationParameterNode<Long>>
           filter) {
-    super(name);
     this.fetchType = fetchType;
     this.type = type;
     this.filter = filter;
-  }
-
-  @Override
-  public Flavour flavour() {
-    return Flavour.LAMBDA;
-  }
-
-  @Override
-  public void read() {
-    // Do nothing.
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeConstant.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeConstant.java
@@ -13,8 +13,7 @@ public class FetchNodeConstant extends FetchNode {
   private final int column;
   private Target target = Target.BAD;
 
-  public FetchNodeConstant(int line, int column, String name, String constantName) {
-    super(name);
+  public FetchNodeConstant(int line, int column, String constantName) {
     this.line = line;
     this.column = column;
     this.constantName = constantName;
@@ -54,16 +53,6 @@ public class FetchNodeConstant extends FetchNode {
   @Override
   public boolean typeCheck(Consumer<String> errorHandler) {
     return true;
-  }
-
-  @Override
-  public Flavour flavour() {
-    return Flavour.LAMBDA;
-  }
-
-  @Override
-  public void read() {
-    // We don't care
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeFunction.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeFunction.java
@@ -17,9 +17,8 @@ public class FetchNodeFunction extends FetchNode {
   private final List<ExpressionNode> args;
   private FunctionDefinition funcDef = null;
 
-  public FetchNodeFunction(
-      String name, int line, int column, String funcName, List<ExpressionNode> args) {
-    super(name);
+  public FetchNodeFunction(int line, int column, String funcName, List<ExpressionNode> args) {
+    super();
     this.line = line;
     this.column = column;
     this.funcName = funcName;
@@ -95,16 +94,6 @@ public class FetchNodeFunction extends FetchNode {
           == args.size();
     }
     return false;
-  }
-
-  @Override
-  public Flavour flavour() {
-    return Flavour.LAMBDA;
-  }
-
-  @Override
-  public void read() {
-    // no
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeOlive.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeOlive.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.shesmu.compiler;
 
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.compiler.OliveNode.ClauseStreamOrder;
+import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.ActionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
@@ -76,28 +77,12 @@ public class FetchNodeOlive extends FetchNode {
   private Imyhat type = Imyhat.BAD;
 
   public FetchNodeOlive(
-      int line,
-      int column,
-      String name,
-      String format,
-      List<OliveClauseNode> clauses,
-      String script) {
-    super(name);
+      int line, int column, String format, List<OliveClauseNode> clauses, String script) {
     this.clauses = clauses;
     this.column = column;
     this.format = format;
     this.line = line;
     this.script = script;
-  }
-
-  @Override
-  public Flavour flavour() {
-    return Flavour.LAMBDA;
-  }
-
-  @Override
-  public void read() {
-    // Do nothing
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNode.java
@@ -231,11 +231,11 @@ public abstract class WizardNode {
     DISPATCH.addKeyword(
         "Fetch",
         (p, o) -> {
-          final var entries = new AtomicReference<List<FetchNode>>();
+          final var entries = new AtomicReference<List<Pair<String, FetchNode>>>();
           final var next = new AtomicReference<WizardNode>();
           final var result =
               p.whitespace()
-                  .list(entries::set, FetchNode::parse, ',')
+                  .list(entries::set, FetchNode::parseAsDefinition, ',')
                   .whitespace()
                   .symbol("Then")
                   .whitespace()


### PR DESCRIPTION
This creates a `For` that can be used to do multiple fetches and collect the
results into a collection. It required moving the `name` out of `FetchNode` and
having `FetchNode` no longer implement `Target`.