### PR TITLE
Add a `never_ever_launch` to Niassa workflow action

### DIFF
--- a/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
+++ b/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/WorkflowAction.java
@@ -303,6 +303,10 @@ public final class WorkflowAction extends Action {
   private InputLimsCollection limsKeysCollection;
   private long majorOliveVersion;
   private List<WorkflowRunMatch> matches = Collections.emptyList();
+
+  @ActionParameter(name = "never_ever_launch")
+  public boolean neverEverLaunch;
+
   private boolean overrideLock;
   private final long[] previousAccessions;
 
@@ -371,6 +375,7 @@ public final class WorkflowAction extends Action {
     if (o == null || getClass() != o.getClass()) return false;
     WorkflowAction that = (WorkflowAction) o;
     return majorOliveVersion == that.majorOliveVersion
+        && neverEverLaunch == that.neverEverLaunch
         && workflowAccession == that.workflowAccession
         && Objects.equals(annotations, that.annotations)
         && Objects.equals(ini, that.ini)
@@ -384,6 +389,10 @@ public final class WorkflowAction extends Action {
 
   @Override
   public void generateUUID(Consumer<byte[]> digest) {
+    if (neverEverLaunch) {
+      // Done this way to that existing action identifiers won't change
+      digest.accept(new byte[] {0});
+    }
     digest.accept(Utils.toBytes(majorOliveVersion));
     digest.accept(Utils.toBytes(workflowAccession));
     generateUUID(digest, annotations, s -> s.getBytes(StandardCharsets.UTF_8));
@@ -405,7 +414,13 @@ public final class WorkflowAction extends Action {
 
   @Override
   public int hashCode() {
-    return Objects.hash(majorOliveVersion, workflowAccession, annotations, ini, limsKeysCollection);
+    return Objects.hash(
+        neverEverLaunch,
+        majorOliveVersion,
+        workflowAccession,
+        annotations,
+        ini,
+        limsKeysCollection);
   }
 
   void limsKeyCollection(InputLimsCollection limsKeys) {
@@ -597,6 +612,10 @@ public final class WorkflowAction extends Action {
           this.errors =
               Collections.singletonList("Workflow has already been attempted. Purge to try again.");
           return ActionState.FAILED;
+        }
+        if (neverEverLaunch) {
+          this.errors = Collections.singletonList("Would launch but forbidden.");
+          return ActionState.ZOMBIE;
         }
         try {
           // Check if there are already too many copies of this workflow running; if so, wait until
@@ -942,6 +961,7 @@ public final class WorkflowAction extends Action {
   public final ObjectNode toJson(ObjectMapper mapper) {
     final ObjectNode node = mapper.createObjectNode();
     node.put("majorOliveVersion", majorOliveVersion);
+    node.put("neverEverLaunch", neverEverLaunch);
     limsKeysCollection
         .limsKeys()
         .sorted(LIMS_KEY_COMPARATOR)

--- a/plugin-niassa/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
+++ b/plugin-niassa/src/main/resources/ca/on/oicr/gsi/shesmu/niassa/renderer.js
@@ -29,6 +29,7 @@ actionRender.set("niassa", (a) => [
   title(a, `Workflow ${a.workflowName} (${a.workflowAccession})`),
   table(
     [
+      ["Can Launch?", a.neverEverLaunch ? "Never Launch" : "Will Launch"],
       ["Major Olive Version", a.majorOliveVersion.toString()],
       a.workflowRunAccession
         ? ["Workflow Run Accession", a.workflowRunAccession.toString()]


### PR DESCRIPTION
This creates a new code path so that an action can be set in a mode where it
will refuse to launch without adjusting max-in-flight.