### PR TITLE
Fix two compiler bugs in `For` expression

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JavaStreamBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JavaStreamBuilder.java
@@ -206,7 +206,7 @@ public final class JavaStreamBuilder {
     renderer
         .methodGen()
         .getStatic(A_RUNTIME_SUPPORT_TYPE, "USELESS_BINARY_OPERATOR", A_BINARY_OPERATOR_TYPE);
-    renderer.loadImyhat(currentType.descriptor());
+    renderer.loadImyhat(keyType.descriptor());
     LambdaBuilder.pushVirtual(
         renderer, "newMap", LambdaBuilder.supplier(A_MAP_TYPE), A_IMYHAT_TYPE);
     renderer.methodGen().invokeStatic(A_COLLECTORS_TYPE, METHOD_COLLECTORS__TO_MAP);

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeWithExpression.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ListNodeWithExpression.java
@@ -20,7 +20,9 @@ public abstract class ListNodeWithExpression extends ListNode {
     this.expression = expression;
   }
 
-  /** Add all free variable names to the set provided. */
+  /**
+   * Add all free variable names to the set provided.
+   */
   @Override
   public final void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
     final var remove =
@@ -73,9 +75,8 @@ public abstract class ListNodeWithExpression extends ListNode {
   public final Optional<DestructuredArgumentNode> resolve(
       DestructuredArgumentNode name, NameDefinitions defs, Consumer<String> errorHandler) {
     if (expression.resolve(defs.bind(name), errorHandler)) {
-      final var nextNames = nextName(name);
-      definedNames = nextNames.targets().map(Target::name).collect(Collectors.toSet());
-      return Optional.of(nextNames);
+      definedNames = name.targets().map(Target::name).collect(Collectors.toSet());
+      return Optional.of(nextName(name));
 
     } else {
       return Optional.empty();

--- a/shesmu-server/src/test/resources/run/list-flatten.shesmu
+++ b/shesmu-server/src/test/resources/run/list-flatten.shesmu
@@ -1,0 +1,7 @@
+Version 1;
+Input test;
+Olive
+	Run ok With ok =
+		(For {key, values} In Dict { "ok" = [True], "whatever" = [False] }:
+      Flatten (value In values Let {key, value} = {key, value})
+      Dict key = value)["ok"] Default False;


### PR DESCRIPTION
The first bug is that `Dict` collector is using the wrong type. The dictionary
generated is a `TreeMap` using a custom comparator. The comparator should match
the type of the key, but the collector was using the type of the items being
iterated over.

The second is a bug selecting free variables. In an expression like this:

     For x In xs: Let y = x + z List y

Consider `x + z`. `x` is coming from the `For` condition and `z` is coming from
outside this expression (_i.e._, it is free). Any list transformation (`Let`,
`Where`, `Flatten`) must do this name manipulation. Because some
transformations change the name (_e.g_, `Let`), each list transformation is
given a name and must produce a name for the downstream elements. Most
operations (_e.g._, `Where`) pass this name through unchanged.

The bug occurs because the names removed were *output* names rather than
*input* names. This would trigger a bug when a variable that should be free was
also an output name. The transformation would incorrectly identify it as bound
and not request it from the parent context. When trying to generate code, it
would then fail to find this variable.