### PR TITLE
Create action to unload data from Vidarr

### DIFF
--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/BaseUnloadAction.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/BaseUnloadAction.java
@@ -1,0 +1,125 @@
+package ca.on.oicr.gsi.shesmu.vidarr;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.shesmu.plugin.FrontEndIcon;
+import ca.on.oicr.gsi.shesmu.plugin.action.Action;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionCommand;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionCommand.Preference;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionServices;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
+import ca.on.oicr.gsi.vidarr.JsonBodyHandler;
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.api.UnloadRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public abstract class BaseUnloadAction extends Action {
+  private static final ActionCommand<BaseUnloadAction> HUMAN_APPROVE_COMMAND =
+      new ActionCommand<>(
+          BaseUnloadAction.class,
+          "VIDARR-HUMAN-APPROVE-UNLOAD",
+          FrontEndIcon.HAND_THUMBS_UP,
+          "Allow Unload",
+          Preference.ALLOW_BULK,
+          Preference.PROMPT,
+          Preference.ANNOY_USER) {
+        @Override
+        protected Response execute(BaseUnloadAction action, Optional<String> user) {
+          if (!action.allowedToRun) {
+            action.allowedToRun = true;
+            return Response.ACCEPTED;
+          }
+          return Response.IGNORED;
+        }
+      };
+  private boolean allowedToRun;
+  private List<String> errors = List.of();
+  private final Supplier<VidarrPlugin> owner;
+  private String vidarrOutputName;
+
+  public BaseUnloadAction(String type, Supplier<VidarrPlugin> owner) {
+    super("vidarr-unload-" + type);
+    this.owner = owner;
+  }
+
+  protected abstract void addFilterForJson(ObjectNode node);
+
+  @Override
+  public final Stream<ActionCommand<?>> commands() {
+    return allowedToRun ? Stream.empty() : Stream.of(HUMAN_APPROVE_COMMAND);
+  }
+
+  protected abstract UnloadFilter createFilter();
+
+  @Override
+  public final ActionState perform(ActionServices services) {
+    if (!allowedToRun) {
+      errors = List.of("Waiting for human approval before removing data from Víðarr.");
+      return ActionState.HALP;
+    }
+    final var result =
+        owner
+            .get()
+            .url()
+            .<Pair<ActionState, List<String>>>map(
+                vidarrUrl -> {
+                  final var input = createFilter();
+                  if (input == null) {
+                    return new Pair<>(
+                        ActionState.ZOMBIE,
+                        List.of("No input was provided. Not going to do anything."));
+                  }
+                  try {
+                    final var request = new UnloadRequest();
+                    request.setRecursive(true);
+                    request.setFilter(input);
+                    final var response =
+                        VidarrPlugin.CLIENT.send(
+                            HttpRequest.newBuilder(vidarrUrl.resolve("/api/unload"))
+                                .POST(
+                                    BodyPublishers.ofByteArray(
+                                        VidarrPlugin.MAPPER.writeValueAsBytes(request)))
+                                .build(),
+                            new JsonBodyHandler<>(VidarrPlugin.MAPPER, String.class));
+                    if (response.statusCode() < 400) {
+                      vidarrOutputName = response.body().get();
+                      return new Pair<>(ActionState.SUCCEEDED, List.of());
+                    }
+                    return new Pair<>(
+                        ActionState.FAILED,
+                        List.of("Error from Vidarr server: " + response.statusCode()));
+                  } catch (Exception e) {
+                    e.printStackTrace();
+                    return new Pair<>(ActionState.FAILED, List.of(e.getMessage()));
+                  }
+                })
+            .orElse(new Pair<>(ActionState.UNKNOWN, List.of()));
+    errors = result.second();
+    return result.first();
+  }
+
+  @Override
+  public final int priority() {
+    return 0;
+  }
+
+  @Override
+  public final long retryMinutes() {
+    return 15;
+  }
+
+  @Override
+  public final ObjectNode toJson(ObjectMapper mapper) {
+    final var node = mapper.createObjectNode();
+    node.put("vidarrOutputName", vidarrOutputName);
+    errors.forEach(node.putArray("errors")::add);
+    addFilterForJson(node);
+    return node;
+  }
+}

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/UnloadExternalIdentifiersAction.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/UnloadExternalIdentifiersAction.java
@@ -1,0 +1,98 @@
+package ca.on.oicr.gsi.shesmu.vidarr;
+
+import ca.on.oicr.gsi.shesmu.plugin.Tuple;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionParameter;
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterExternalId;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterOr;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class UnloadExternalIdentifiersAction extends BaseUnloadAction {
+  private Map<String, List<String>> externalIds = Map.of();
+
+  public UnloadExternalIdentifiersAction(Supplier<VidarrPlugin> owner) {
+    super("external-identifiers", owner);
+  }
+
+  @Override
+  protected void addFilterForJson(ObjectNode node) {
+    node.putPOJO("externalIds", externalIds);
+  }
+
+  @Override
+  protected UnloadFilter createFilter() {
+    if (externalIds.isEmpty()) {
+      return null;
+    }
+    final var filter = new UnloadFilterOr();
+    filter.setFilters(
+        externalIds.entrySet().stream()
+            .map(
+                entry -> {
+                  final var providerFilter = new UnloadFilterExternalId();
+                  providerFilter.setProvider(entry.getKey());
+                  providerFilter.setId(UnloadTextSelector.of(entry.getValue()));
+                  return providerFilter;
+                })
+            .collect(Collectors.toList()));
+    return filter;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UnloadExternalIdentifiersAction that = (UnloadExternalIdentifiersAction) o;
+    return externalIds.equals(that.externalIds);
+  }
+
+  @Override
+  public void generateUUID(Consumer<byte[]> digest) {
+    for (final var entry : externalIds.entrySet()) {
+      digest.accept(new byte[] {0});
+      digest.accept(new byte[] {0});
+      digest.accept(entry.getKey().getBytes(StandardCharsets.UTF_8));
+      for (final var id : entry.getValue()) {
+        digest.accept(id.getBytes(StandardCharsets.UTF_8));
+        digest.accept(new byte[] {0});
+      }
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(externalIds);
+  }
+
+  @Override
+  public boolean search(Pattern query) {
+    return externalIds.entrySet().stream()
+        .flatMap(entry -> Stream.concat(Stream.of(entry.getKey()), entry.getValue().stream()))
+        .anyMatch(query.asPredicate());
+  }
+
+  @ActionParameter(name = "external_identifiers", type = "ao2id$sprovider$s")
+  public void setExternalIds(Set<Tuple> externalIds) {
+    this.externalIds =
+        externalIds.stream()
+            .collect(
+                Collectors.groupingBy(
+                    tuple -> (String) tuple.get(1),
+                    Collectors.mapping(tuple -> (String) tuple.get(0), Collectors.toList())));
+  }
+}

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/UnloadWorkflowRunsAction.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/UnloadWorkflowRunsAction.java
@@ -1,0 +1,67 @@
+package ca.on.oicr.gsi.shesmu.vidarr;
+
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionParameter;
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterWorkflowRunId;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+public final class UnloadWorkflowRunsAction extends BaseUnloadAction {
+  @ActionParameter(name = "workflow_runs")
+  public Set<String> workflowRuns = Set.of();
+
+  public UnloadWorkflowRunsAction(Supplier<VidarrPlugin> owner) {
+    super("runs", owner);
+  }
+
+  @Override
+  protected void addFilterForJson(ObjectNode node) {
+    workflowRuns.forEach(node.putArray("workflowRuns")::add);
+  }
+
+  @Override
+  protected UnloadFilter createFilter() {
+    if (workflowRuns.isEmpty()) {
+      return null;
+    }
+    final var filter = new UnloadFilterWorkflowRunId();
+    filter.setId(UnloadTextSelector.of(workflowRuns));
+    return filter;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UnloadWorkflowRunsAction that = (UnloadWorkflowRunsAction) o;
+    return workflowRuns.equals(that.workflowRuns);
+  }
+
+  @Override
+  public void generateUUID(Consumer<byte[]> digest) {
+    for (final var run : workflowRuns) {
+      digest.accept(run.getBytes(StandardCharsets.UTF_8));
+      digest.accept(new byte[] {0});
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(workflowRuns);
+  }
+
+  @Override
+  public boolean search(Pattern query) {
+    return workflowRuns.stream().anyMatch(query.asPredicate());
+  }
+}

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.Definer;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
 import ca.on.oicr.gsi.shesmu.plugin.action.CustomActionParameter;
+import ca.on.oicr.gsi.shesmu.plugin.action.ShesmuAction;
 import ca.on.oicr.gsi.shesmu.plugin.json.AsJsonNode;
 import ca.on.oicr.gsi.shesmu.plugin.json.JsonPluginFile;
 import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonObject;
@@ -128,6 +129,16 @@ public class VidarrPlugin extends JsonPluginFile<Configuration> {
   public void configuration(SectionRenderer renderer) {
     final var u = url;
     u.ifPresent(uri -> renderer.link("URL", uri.toString(), uri.toString()));
+  }
+
+  @ShesmuAction(name = "unload_by_external_ids")
+  public UnloadExternalIdentifiersAction unloadByExternalIds() {
+    return new UnloadExternalIdentifiersAction(definer);
+  }
+
+  @ShesmuAction(name = "unload_by_workflow_runs")
+  public UnloadWorkflowRunsAction unloadByWorkflowRuns() {
+    return new UnloadWorkflowRunsAction(definer);
   }
 
   @Override

--- a/plugin-vidarr/src/main/resources/ca/on/oicr/gsi/shesmu/vidarr/renderer.js
+++ b/plugin-vidarr/src/main/resources/ca/on/oicr/gsi/shesmu/vidarr/renderer.js
@@ -204,3 +204,31 @@ actionRender.set("vidarr-run", (a) => [
   ),
   vidarrStateRenderer[a.runState](a),
 ]);
+
+[
+  {
+    type: "runs",
+    title: "Workflow Runs",
+    entries: (a) => a.workflowRuns,
+    columns: [["Workflow Run Identifier", (i) => i]],
+  },
+  {
+    type: "external-identifiers",
+    title: "External Identifiers",
+    entries: (a) =>
+      Object.entries(a.externalIds).flatMap(([provider, ids]) =>
+        ids.map((id) => ({
+          provider,
+          id,
+        }))
+      ),
+
+    columns: [[("Provider", (e) => e.provider)], ["Identifier", (e) => e.id]],
+  },
+].forEach(({ type, entries, title, columns }) =>
+  actionRender.set(`vidarr-unload-${type}`, (a) => [
+    title(a, "Unload Workflow Runs"),
+    a.vidarrOutputName ? "Not attempted" : `Output in ${a.vidarrOutputName}`,
+    collapsible(title, table(entries(a), ...columns)),
+  ])
+);


### PR DESCRIPTION
The goal for these plugins are to allow pipeline lead to remove workflow runs
from Vidarr. Although Vidarr supports many way to select matching workflow
runs, Shesmu is supporting only by workflow run ID or by external ID. The
workflow run IDs will be to allow removing deleted data discovered through
`cerberus_error`. The second is to allow extraction of whole sequencer runs
from `pinery_ius` and may not be used in practice.