### PR TITLE
Allow using custom lookup environment for input formats

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/input/InputFormat.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/input/InputFormat.java
@@ -1,5 +1,8 @@
 package ca.on.oicr.gsi.shesmu.plugin.input;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+
 /**
  * Define a new input format
  *
@@ -7,16 +10,32 @@ package ca.on.oicr.gsi.shesmu.plugin.input;
  * a plugin
  */
 public class InputFormat {
+  private static final Lookup PUBLIC_LOOKUP = MethodHandles.publicLookup();
+  private final Lookup lookup;
   private final String name;
   private final Class<?> clazz;
 
   /**
    * Create a new input format
    *
+   * <p>This uses public lookup. If your class is not publically visible, use the other constructor
+   * and provide a better lookup.
+   *
    * @param name the name for the input format; this must be a valid Shesmu identifier
    * @param clazz the type of each row in the input format. This class must not be generic.
    */
   public InputFormat(String name, Class<?> clazz) {
+    this(name, clazz, PUBLIC_LOOKUP);
+  }
+  /**
+   * Create a new input format
+   *
+   * @param name the name for the input format; this must be a valid Shesmu identifier
+   * @param clazz the type of each row in the input format. This class must not be generic.
+   * @param lookup the reflection lookup context to investigate the class
+   */
+  public InputFormat(String name, Class<?> clazz, Lookup lookup) {
+    this.lookup = lookup;
     if (clazz.getTypeParameters().length > 0) {
       throw new IllegalArgumentException(
           String.format(
@@ -24,6 +43,10 @@ public class InputFormat {
     }
     this.name = name;
     this.clazz = clazz;
+  }
+
+  public Lookup lookup() {
+    return lookup;
   }
 
   public final String name() {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/input/shesmu/ShesmuIntrospectionFormat.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/input/shesmu/ShesmuIntrospectionFormat.java
@@ -1,12 +1,13 @@
 package ca.on.oicr.gsi.shesmu.core.input.shesmu;
 
 import ca.on.oicr.gsi.shesmu.plugin.input.InputFormat;
+import java.lang.invoke.MethodHandles;
 import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(InputFormat.class)
-public class ShesmuIntrospectionFormat extends InputFormat {
+public final class ShesmuIntrospectionFormat extends InputFormat {
 
   public ShesmuIntrospectionFormat() {
-    super("shesmu", ShesmuIntrospectionValue.class);
+    super("shesmu", ShesmuIntrospectionValue.class, MethodHandles.lookup());
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/input/shesmu/ShesmuIntrospectionValue.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/input/shesmu/ShesmuIntrospectionValue.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ShesmuIntrospectionValue {
+public final class ShesmuIntrospectionValue {
   private final Action action;
   private final Instant changed;
   private final Instant checked;
@@ -44,8 +44,7 @@ public class ShesmuIntrospectionValue {
     this.lastStateTransition = lastStateTransition;
     this.state = state;
     this.locations =
-        locations
-            .stream()
+        locations.stream()
             .map(
                 l ->
                     new Tuple(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/AnnotatedInputFormatDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/AnnotatedInputFormatDefinition.java
@@ -398,7 +398,7 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
       new JarHashRepository<>();
   private static final Map<Pair<String, String>, CallSite> INPUT_VARIABLES_REGISTRY =
       new ConcurrentHashMap<>();
-  private static final Lookup LOOKUP = MethodHandles.publicLookup();
+  private static final Lookup LOOKUP = MethodHandles.lookup();
   private static final MethodHandle MH_IMYHAT__ACCEPT;
   private static final MethodHandle MH_PACK_STREAMING__CTOR;
   private static final MethodHandle MH_TUPLE_GET;
@@ -495,7 +495,7 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
       // cases: either we have an instance of the real type and we should call the
       // method on it, or we have a Tuple that was generated generically by one of our
       // JSON readers
-      final var getter = LOOKUP.unreflect(entry.second()).asType(methodType);
+      final var getter = format.lookup().unreflect(entry.second()).asType(methodType);
       final var handle =
           MethodHandles.guardWithTest(
               MH_TUPLE_IS_INSTANCE,

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -385,9 +386,10 @@ public class RunTest {
       inputFormats =
           new NameLoader<>(
               Stream.of(
-                  new AnnotatedInputFormatDefinition(new InputFormat("test", TestValue.class)),
                   new AnnotatedInputFormatDefinition(
-                      new InputFormat("inner_test", InnerTestValue.class))),
+                      new InputFormat("test", TestValue.class, MethodHandles.lookup())),
+                  new AnnotatedInputFormatDefinition(
+                      new InputFormat("inner_test", InnerTestValue.class, MethodHandles.lookup()))),
               InputFormatDefinition::name);
     } catch (IllegalAccessException e) {
       e.printStackTrace();


### PR DESCRIPTION
Shesmu uses reflection and annotation to allow the compiler to bind to custom
data formats. When in a module, either the data format needs to be public or
the data format needs to provide a method handle lookup context with private
visibility. This allows the data format author to decide and moves some of the
internal data formats to private access.