### PR TITLE
Relocate bootstrap methods to `RuntimeSupport`

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
@@ -11,7 +11,7 @@ import ca.on.oicr.gsi.shesmu.compiler.description.FileTable;
 import ca.on.oicr.gsi.shesmu.plugin.Utils;
 import ca.on.oicr.gsi.shesmu.runtime.ActionGenerator;
 import ca.on.oicr.gsi.shesmu.runtime.OliveServices;
-import ca.on.oicr.gsi.shesmu.server.plugins.PluginManager;
+import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -54,8 +54,8 @@ public abstract class Compiler {
   private static final Handle SERVICES_REQURED_BSM =
       new Handle(
           Opcodes.H_INVOKESTATIC,
-          Type.getInternalName(PluginManager.class),
-          "bootstrapServices",
+          Type.getInternalName(RuntimeSupport.class),
+          "pluginServicesBootstrap",
           Type.getMethodDescriptor(
               Type.getType(CallSite.class),
               Type.getType(MethodHandles.Lookup.class),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
@@ -10,6 +10,8 @@ import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonArray;
 import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonObject;
 import ca.on.oicr.gsi.shesmu.plugin.json.UnpackJson;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.server.plugins.AnnotatedInputFormatDefinition;
+import ca.on.oicr.gsi.shesmu.server.plugins.PluginManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -186,6 +188,13 @@ public final class RuntimeSupport {
     return result == null ? JsonNodeFactory.instance.nullNode() : result;
   }
 
+  public static CallSite inputBootstrap(
+      Lookup lookup, String variableName, MethodType methodType, String inputFormatName) {
+    // This is redirects to the input format manager; it's here to limit our export interface
+    return AnnotatedInputFormatDefinition.bootstrap(
+        lookup, variableName, methodType, inputFormatName);
+  }
+
   @RuntimeInterop
   public static <I, N, K, O> Stream<O> join(
       Stream<I> input,
@@ -239,6 +248,12 @@ public final class RuntimeSupport {
     }
 
     return joins.stream().map(p -> joiner.apply(inputs.get(p.first()), inners.get(p.second())));
+  }
+
+  public static CallSite pluginServicesBootstrap(
+      Lookup lookup, String methodName, MethodType methodType, String... fileNames) {
+    // This is redirects to the plugin manager; it's here to limit our export interface
+    return PluginManager.bootstrapServices(lookup, methodName, methodType, fileNames);
   }
 
   @RuntimeInterop
@@ -517,6 +532,18 @@ public final class RuntimeSupport {
             Collectors.groupingBy(item -> new Holder<>(equals, hashCode.applyAsInt(item), item)));
     input.close();
     return groups.values().stream().map(list -> list.stream().min(comparator).get());
+  }
+
+  public static CallSite pluginArbitraryBootstrap(
+      MethodHandles.Lookup lookup, String methodName, MethodType methodType) {
+    // This is redirects to the plugin manager; it's here to limit our export interface
+    return PluginManager.bootstrap(lookup, methodName, methodType);
+  }
+
+  public static CallSite pluginBootstrap(
+      MethodHandles.Lookup lookup, String methodName, MethodType methodType, String filename) {
+    // This is redirects to the plugin manager; it's here to limit our export interface
+    return PluginManager.bootstrap(lookup, methodName, methodType, filename);
   }
 
   @RuntimeInterop

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/AnnotatedInputFormatDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/AnnotatedInputFormatDefinition.java
@@ -384,8 +384,8 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
   private static final Handle BSM_INPUT_VARIABLE =
       new Handle(
           Opcodes.H_INVOKESTATIC,
-          Type.getType(AnnotatedInputFormatDefinition.class).getInternalName(),
-          "bootstrap",
+          Type.getType(RuntimeSupport.class).getInternalName(),
+          "inputBootstrap",
           Type.getMethodDescriptor(
               Type.getType(CallSite.class),
               Type.getType(Lookup.class),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/PluginManager.java
@@ -1653,8 +1653,8 @@ public final class PluginManager
   private static final Handle BSM_HANDLE =
       new Handle(
           Opcodes.H_INVOKESTATIC,
-          Type.getType(PluginManager.class).getInternalName(),
-          "bootstrap",
+          Type.getType(RuntimeSupport.class).getInternalName(),
+          "pluginBootstrap",
           Type.getMethodDescriptor(
               Type.getType(CallSite.class),
               Type.getType(Lookup.class),
@@ -1665,8 +1665,8 @@ public final class PluginManager
   private static final Handle BSM_HANDLE_ARBITRARY =
       new Handle(
           Opcodes.H_INVOKESTATIC,
-          Type.getType(PluginManager.class).getInternalName(),
-          "bootstrap",
+          Type.getType(RuntimeSupport.class).getInternalName(),
+          "pluginArbitraryBootstrap",
           BSM_DESCRIPTOR_ARBITRARY,
           false);
   private static final CallSiteRegistry<String> CONFIG_FILE_ARBITRARY_BINDINGS =
@@ -1690,18 +1690,11 @@ public final class PluginManager
   static {
     try {
       SERVICES_REQUIRED =
-          MethodHandles.publicLookup()
+          MethodHandles.lookup()
               .findStatic(
                   PluginManager.class,
                   "requiredServices",
                   MethodType.methodType(String[].class, RequiredServices[].class));
-    } catch (NoSuchMethodException | IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  static {
-    try {
       MH_SUPPLIER_GET =
           MethodHandles.publicLookup()
               .findVirtual(Supplier.class, "get", MethodType.methodType(Object.class));
@@ -1909,7 +1902,7 @@ public final class PluginManager
    * Find a dumper
    *
    * @param name the dumper to find
-   * @param columns
+   * @param columns the names of the columns
    * @return the dumper if found, or an empty optional if none is available
    */
   public Optional<Dumper> findDumper(String name, String[] columns, Imyhat... types) {


### PR DESCRIPTION
The compiler emits several `INVOKEDYNAMIC` instructions that connect to
internal server components. These classes will be inaccessible when Shesmu is
moved to the Java 9 module system. This change adds indirection methods to
`RuntimeSupport` that the compiler can use instead.