### PR TITLE
Fix incorrect falsy behaviour in UI component

### DIFF
--- a/shesmu-server-ui/src/io.ts
+++ b/shesmu-server-ui/src/io.ts
@@ -277,7 +277,11 @@ export function locallyStoredCustom<T>(
     statusFailed: (message: string) => console.log(message),
     get: () => {
       const value = localStorage.getItem(key);
-      return value == null ? empty : parse(value) || empty;
+      if (value === null) {
+        return empty;
+      }
+      const parsed = parse(value);
+      return parsed == null ? empty : parsed;
     },
     listen: (listener) => {
       currentListener = listener;


### PR DESCRIPTION
When a falsy value is in local storage and the default is truthy, the default
will override the user's selection due to the `||` operator. This checks for
explicit parse failure (`null`) and does the appropriate thing.