### PR TITLE
Allow setting a custom set of clinical projects in Pinery

### DIFF
--- a/plugin-pinery/README.md
+++ b/plugin-pinery/README.md
@@ -10,6 +10,7 @@ The Pinery plugin provides two input formats:
 To configure a Pinery source, create a JSON file ending in `.pinery` as follows:
 
     {
+      "clinicalPipelines": ["Clinical", "Accredited Pipeline"],
       "provider": "foo-v2",
       "shortProvider": "foo",
       "url": "http://pinery:8080/",
@@ -23,3 +24,8 @@ provides the Pinery data model version.
 
 For each configuration, the names of all and active projects are also available
 as constants.
+
+There are functions and constants that separate out clinical projects. If `"clinicalPipelines"` is
+set to an array, then any pipeline listed will be considered clinical. If it is `null`, then the
+legacy behaviour is enabled where the pipeline `Clinical` or any pipeline starting with `Accredited`
+will be considered clinical.

--- a/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryConfiguration.java
+++ b/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryConfiguration.java
@@ -1,13 +1,19 @@
 package ca.on.oicr.gsi.shesmu.pinery;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PineryConfiguration {
+  private Set<String> clinicalPipelines;
   private String provider;
   private String shortProvider;
   private String url;
   private int version;
+
+  public Set<String> getClinicalPipelines() {
+    return clinicalPipelines;
+  }
 
   public String getProvider() {
     return provider;
@@ -23,6 +29,10 @@ public class PineryConfiguration {
 
   public int getVersion() {
     return version;
+  }
+
+  public void setClinicalPipelines(Set<String> clinicalPipelines) {
+    this.clinicalPipelines = clinicalPipelines;
   }
 
   public void setProvider(String provider) {


### PR DESCRIPTION
The `isClinical` method is deprecated and this is the replacement.