### PR TITLE
Force HTTP/1.1 in Guanyin requests

### DIFF
--- a/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/GuanyinRemote.java
+++ b/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/GuanyinRemote.java
@@ -12,6 +12,7 @@ import ca.on.oicr.gsi.status.SectionRenderer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -37,12 +38,14 @@ public class GuanyinRemote extends JsonPluginFile<Configuration> {
           RunReport.HTTP_CLIENT.send(
               HttpRequest.newBuilder(
                       URI.create(configuration.get().getGuanyin() + "/reportdb/reports"))
+                  .version(Version.HTTP_1_1)
                   .build(),
               new JsonBodyHandler<>(RunReport.MAPPER, ReportDto[].class));
       final var recordsResponse =
           RunReport.HTTP_CLIENT.send(
               HttpRequest.newBuilder(
                       URI.create(configuration.get().getGuanyin() + "/reportdb/records"))
+                  .version(Version.HTTP_1_1)
                   .build(),
               new JsonBodyHandler<>(RunReport.MAPPER, RecordDto[].class));
       final var reports =
@@ -103,6 +106,7 @@ public class GuanyinRemote extends JsonPluginFile<Configuration> {
           RunReport.HTTP_CLIENT.send(
               HttpRequest.newBuilder(URI.create(configuration.getGuanyin() + "/reportdb/reports"))
                   .GET()
+                  .version(Version.HTTP_1_1)
                   .build(),
               new JsonBodyHandler<>(RunReport.MAPPER, ReportDto[].class));
       definer.clearActions();

--- a/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/RunReport.java
+++ b/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/RunReport.java
@@ -20,6 +20,7 @@ import io.prometheus.client.Counter;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -225,6 +226,7 @@ public class RunReport extends JsonParameterisedAction {
                     String.format(
                         "%s/reportdb/record_parameters?report=%d", owner.get().观音Url(), reportId)))
             .header("Accept", "application/json")
+            .version(Version.HTTP_1_1)
             .POST(body)
             .build();
     try (var timer = 观音RequestTime.start(owner.get().观音Url())) {
@@ -261,6 +263,7 @@ public class RunReport extends JsonParameterisedAction {
                       String.format(
                           "%s/reportdb/record_start?report=%d", owner.get().观音Url(), reportId)))
               .header("Accept", "application/json")
+              .version(Version.HTTP_1_1)
               .POST(body)
               .build();
       try (var timer = 观音RequestTime.start(owner.get().观音Url())) {
@@ -313,6 +316,7 @@ public class RunReport extends JsonParameterisedAction {
                             URI.create(
                                 String.format("%s/api/workflows/v1", owner.get().cromwellUrl())))
                         .header("Content-Type", cromwellBody.getContentType())
+                        .version(Version.HTTP_1_1)
                         .POST(cromwellBody.build())
                         .build(),
                     new JsonBodyHandler<>(MAPPER, WorkflowIdAndStatus.class))
@@ -328,6 +332,7 @@ public class RunReport extends JsonParameterisedAction {
                                 String.format(
                                     "%s/api/workflows/v1/%s/status",
                                     owner.get().cromwellUrl(), cromwellId.getId())))
+                        .version(Version.HTTP_1_1)
                         .GET()
                         .build(),
                     new JsonBodyHandler<>(MAPPER, WorkflowIdAndStatus.class))


### PR DESCRIPTION
Node.js does not provide any headers in the response which is maybe correct by
ambiguous portions of the HTTP standard. This forces HTTP/1.1 which fixes the
problem.