### PR TITLE
Allow strings to be orderable

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
@@ -1608,7 +1608,7 @@ public abstract class Imyhat {
 
         @Override
         public boolean isOrderable() {
-          return false;
+          return true;
         }
 
         @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Comparison.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Comparison.java
@@ -6,7 +6,6 @@ import static org.objectweb.asm.Type.INT_TYPE;
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.plugin.types.ImyhatTransformer;
-import java.time.Instant;
 import java.util.stream.Stream;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
@@ -202,7 +201,7 @@ public enum Comparison {
     }
   }
 
-  private static final Type A_INSTANT_TYPE = Type.getType(Instant.class);
+  private static final Type A_COMPARABLE_TYPE = Type.getType(Comparable.class);
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
 
   private static final Method METHOD_COMPARE_TO =
@@ -223,8 +222,8 @@ public enum Comparison {
     methodGen.ifCmp(Type.BOOLEAN_TYPE, id, target);
   }
 
-  public void branchDate(Label target, GeneratorAdapter methodGen) {
-    methodGen.invokeVirtual(A_INSTANT_TYPE, METHOD_COMPARE_TO);
+  public void branchComparable(Label target, GeneratorAdapter methodGen) {
+    methodGen.invokeInterface(A_COMPARABLE_TYPE, METHOD_COMPARE_TO);
     methodGen.push(0);
     methodGen.ifCmp(Type.INT_TYPE, id, target);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeComparison.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeComparison.java
@@ -58,8 +58,8 @@ public class ExpressionNodeComparison extends ExpressionNode {
       comparison.branchInt(truePath, renderer.methodGen());
     } else if (left.type().isSame(Imyhat.FLOAT)) {
       comparison.branchFloat(truePath, renderer.methodGen());
-    } else if (left.type().isSame(Imyhat.DATE)) {
-      comparison.branchDate(truePath, renderer.methodGen());
+    } else if (left.type().isOrderable()) {
+      comparison.branchComparable(truePath, renderer.methodGen());
     } else {
       comparison.branchObject(truePath, renderer.methodGen());
     }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RegroupVariablesBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RegroupVariablesBuilder.java
@@ -1056,7 +1056,7 @@ public final class RegroupVariablesBuilder implements Regrouper {
       } else if (fieldType.equals(Type.DOUBLE_TYPE)) {
         comparison.branchFloat(end, collectRenderer.methodGen());
       } else {
-        comparison.branchDate(end, collectRenderer.methodGen());
+        comparison.branchComparable(end, collectRenderer.methodGen());
       }
 
       collectRenderer.methodGen().mark(store);
@@ -1143,7 +1143,7 @@ public final class RegroupVariablesBuilder implements Regrouper {
       if (fieldType.equals(Type.LONG_TYPE)) {
         comparison.branchInt(end, collectRenderer.methodGen());
       } else {
-        comparison.branchDate(end, collectRenderer.methodGen());
+        comparison.branchComparable(end, collectRenderer.methodGen());
       }
 
       collectRenderer.methodGen().loadArg(collectedSelfArgument);

--- a/shesmu-server/src/test/resources/run/list-max-str.shesmu
+++ b/shesmu-server/src/test/resources/run/list-max-str.shesmu
@@ -1,0 +1,5 @@
+Version 1;
+Input test;
+
+Olive
+ Run ok With ok = (For x In [ "foo", "bar" ]: Max x Default "") == "foo";


### PR DESCRIPTION
This lets them be used in `Min`, `Max`, and `Sort` operations.