### PR TITLE
Add a `Tuple` collector to the `For` expression

### DIFF
--- a/language.md
+++ b/language.md
@@ -448,6 +448,17 @@ times it was _false_. The resulting value will be an object with two fields:
 Compute the sum of the resulting value from _expr_, which must be an integer or
 floating point number.
 
+- `Tuple` _expr_ `Require` _count_
+
+Take the inputs and put them into a tuple. The values must be ordered. Tuples
+have a defined number of elements, so there must be exactly the right number of
+items available. If there are _count_ then a tuple of this length will be
+produced with all of the items in the input order. If the number of items is
+either too few **or too many**, an empty optional will be returned instead.
+
+Depending on the situation, `Skip` and `Limit` can be used to trim the input
+appropriately.
+
 - `Univalued` _expr_
 
 Collect exactly one value; if none are collected, the group is rejected; if

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNode.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -50,6 +51,24 @@ public abstract class CollectNode {
           final var result = p.whitespace().then(ExpressionNode::parse0, expression::set);
           if (result.isGood()) {
             o.accept(new CollectNodeList(p.line(), p.column(), expression.get()));
+          }
+          return result;
+        });
+    DISPATCH.addKeyword(
+        "Tuple",
+        (p, o) -> {
+          final var expression = new AtomicReference<ExpressionNode>();
+          final var size = new AtomicLong();
+          final var result =
+              p.whitespace()
+                  .then(ExpressionNode::parse0, expression::set)
+                  .whitespace()
+                  .keyword("Require")
+                  .whitespace()
+                  .integer(size::set, 10)
+                  .whitespace();
+          if (result.isGood()) {
+            o.accept(new CollectNodeTuple(p.line(), p.column(), size.intValue(), expression.get()));
           }
           return result;
         });

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeFirst.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeFirst.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import ca.on.oicr.gsi.shesmu.compiler.ListNode.Ordering;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.util.function.Consumer;
 
@@ -21,6 +22,18 @@ public class CollectNodeFirst extends CollectNodeOptional {
     final var map = builder.map(line(), column(), name, returnType, loadables);
     builder.first();
     return map;
+  }
+
+  @Override
+  public boolean orderingCheck(Ordering ordering, Consumer<String> errorHandler) {
+    if (ordering == Ordering.RANDOM) {
+      errorHandler.accept(
+          String.format(
+              "%d:%d: Items to First are in random order. Results will not be reproducible. Sort first.",
+              line(), column()));
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeReduce.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeReduce.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import ca.on.oicr.gsi.shesmu.compiler.ListNode.Ordering;
 import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.nio.file.Path;
@@ -32,6 +33,18 @@ public class CollectNodeReduce extends CollectNode {
     this.reducer = reducer;
     this.initial = initial;
     accumulatorName.setFlavour(Flavour.LAMBDA);
+  }
+
+  @Override
+  public boolean orderingCheck(Ordering ordering, Consumer<String> errorHandler) {
+    if (ordering == Ordering.RANDOM) {
+      errorHandler.accept(
+          String.format(
+              "%d:%d: Items to Reduce are in random order. Results will not be reproducible. Sort first.",
+              line(), column()));
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeTuple.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/CollectNodeTuple.java
@@ -1,0 +1,105 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.ListNode.Ordering;
+import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class CollectNodeTuple extends CollectNode {
+
+  private List<String> definedNames;
+  private final ExpressionNode inner;
+  private final int size;
+
+  public CollectNodeTuple(int line, int column, int size, ExpressionNode inner) {
+    super(line, column);
+    this.size = size;
+    this.inner = inner;
+  }
+
+  @Override
+  public void collectFreeVariables(Set<String> names, Predicate<Flavour> predicate) {
+    final var remove =
+        definedNames.stream().filter(name -> !names.contains(name)).collect(Collectors.toList());
+    inner.collectFreeVariables(names, predicate);
+    names.removeAll(remove);
+  }
+
+  @Override
+  public void collectPlugins(Set<Path> pluginFileNames) {
+    inner.collectPlugins(pluginFileNames);
+  }
+
+  @Override
+  public boolean orderingCheck(Ordering ordering, Consumer<String> errorHandler) {
+    if (ordering == Ordering.RANDOM) {
+      errorHandler.accept(
+          String.format(
+              "%d:%d: Items to Tuple are in random order. Results will not be reproducible. Sort first.",
+              line(), column()));
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String render(EcmaStreamBuilder builder, EcmaLoadableConstructor name) {
+    builder.map(name, inner.type(), inner::renderEcma);
+    return String.format(
+        "(%1$s.length == %2$d) ? %1$s: null", builder.renderer().newConst(builder.finish()), size);
+  }
+
+  @Override
+  public void render(JavaStreamBuilder builder, LoadableConstructor name) {
+    final Set<String> freeVariables = new HashSet<>();
+    inner.collectFreeVariables(freeVariables, Flavour::needsCapture);
+    final var renderer =
+        builder.map(
+            line(),
+            column(),
+            name,
+            inner.type(),
+            builder
+                .renderer()
+                .allValues()
+                .filter(v -> freeVariables.contains(v.name()))
+                .toArray(LoadableValue[]::new));
+    renderer.methodGen().visitCode();
+    inner.render(renderer);
+    renderer.methodGen().returnValue();
+    renderer.methodGen().visitMaxs(0, 0);
+    renderer.methodGen().visitEnd();
+    builder.toTuple(size);
+  }
+
+  @Override
+  public boolean resolve(
+      DestructuredArgumentNode name, NameDefinitions defs, Consumer<String> errorHandler) {
+    definedNames = name.targets().map(Target::name).collect(Collectors.toList());
+    return inner.resolve(defs.bind(name), errorHandler);
+  }
+
+  @Override
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
+    return inner.resolveDefinitions(expressionCompilerServices, errorHandler);
+  }
+
+  @Override
+  public Imyhat type() {
+    return Imyhat.tuple(Collections.nCopies(size, inner.type()).toArray(Imyhat[]::new))
+        .asOptional();
+  }
+
+  @Override
+  public boolean typeCheck(Imyhat incoming, Consumer<String> errorHandler) {
+    return inner.typeCheck(errorHandler);
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeFor.java
@@ -115,19 +115,19 @@ public class ExpressionNodeFor extends ExpressionNode {
     if (!source.typeCheck(errorHandler) || !name.typeCheck(source.streamType(), errorHandler)) {
       return false;
     }
-    final var ordering =
-        transforms.stream()
-            .reduce(
-                source.ordering(),
-                (order, transform) -> transform.order(order, errorHandler),
-                (a, b) -> {
-                  throw new UnsupportedOperationException();
-                });
     final var resultType =
         transforms.stream()
             .reduce(
                 Optional.of(source.streamType()),
                 (t, transform) -> t.flatMap(tt -> transform.typeCheck(tt, errorHandler)),
+                (a, b) -> {
+                  throw new UnsupportedOperationException();
+                });
+    final var ordering =
+        transforms.stream()
+            .reduce(
+                source.ordering(),
+                (order, transform) -> transform.order(order, errorHandler),
                 (a, b) -> {
                   throw new UnsupportedOperationException();
                 });

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeFor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchNodeFor.java
@@ -94,19 +94,20 @@ public class FetchNodeFor extends FetchNode {
     if (!source.typeCheck(errorHandler) || !name.typeCheck(source.streamType(), errorHandler)) {
       return false;
     }
-    final Ordering ordering =
-        transforms.stream()
-            .reduce(
-                source.ordering(),
-                (order, transform) -> transform.order(order, errorHandler),
-                (a, b) -> {
-                  throw new UnsupportedOperationException();
-                });
-    final Optional<Imyhat> resultType =
+
+    final var resultType =
         transforms.stream()
             .reduce(
                 Optional.of(source.streamType()),
                 (t, transform) -> t.flatMap(tt -> transform.typeCheck(tt, errorHandler)),
+                (a, b) -> {
+                  throw new UnsupportedOperationException();
+                });
+    final var ordering =
+        transforms.stream()
+            .reduce(
+                source.ordering(),
+                (order, transform) -> transform.order(order, errorHandler),
                 (a, b) -> {
                   throw new UnsupportedOperationException();
                 });

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/InformationNodeBaseRepeat.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/InformationNodeBaseRepeat.java
@@ -91,19 +91,19 @@ public abstract class InformationNodeBaseRepeat extends InformationNode {
     if (!source.typeCheck(errorHandler) || !name.typeCheck(source.streamType(), errorHandler)) {
       return false;
     }
-    final var ordering =
-        transforms.stream()
-            .reduce(
-                source.ordering(),
-                (order, transform) -> transform.order(order, errorHandler),
-                (a, b) -> {
-                  throw new UnsupportedOperationException();
-                });
     final var resultType =
         transforms.stream()
             .reduce(
                 Optional.of(source.streamType()),
                 (t, transform) -> t.flatMap(tt -> transform.typeCheck(tt, errorHandler)),
+                (a, b) -> {
+                  throw new UnsupportedOperationException();
+                });
+    final var ordering =
+        transforms.stream()
+            .reduce(
+                source.ordering(),
+                (order, transform) -> transform.order(order, errorHandler),
                 (a, b) -> {
                   throw new UnsupportedOperationException();
                 });

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeContainer.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/SourceNodeContainer.java
@@ -21,6 +21,11 @@ public class SourceNodeContainer extends SourceNode {
   private enum Mode {
     LIST {
       @Override
+      public boolean isSorted() {
+        return false;
+      }
+
+      @Override
       public void render(Renderer renderer) {
         renderer.methodGen().invokeInterface(A_SET_TYPE, METHOD_SET__STREAM);
       }
@@ -31,6 +36,11 @@ public class SourceNodeContainer extends SourceNode {
       }
     },
     LIFTED_LIST {
+      @Override
+      public boolean isSorted() {
+        return false;
+      }
+
       @Override
       public void render(Renderer renderer) {
         renderer.methodGen().invokeStatic(A_COLLECTIONS_TYPE, METHOD_COLLECTIONS__EMPTY_SET);
@@ -47,6 +57,11 @@ public class SourceNodeContainer extends SourceNode {
     },
     MAP {
       @Override
+      public boolean isSorted() {
+        return false;
+      }
+
+      @Override
       public void render(Renderer renderer) {
         renderer
             .methodGen()
@@ -59,6 +74,11 @@ public class SourceNodeContainer extends SourceNode {
       }
     },
     LIFTED_MAP {
+      @Override
+      public boolean isSorted() {
+        return false;
+      }
+
       @Override
       public void render(Renderer renderer) {
         renderer.methodGen().invokeVirtual(A_OPTIONAL_TYPE, METHOD_OPTIONAL__STREAM);
@@ -81,6 +101,11 @@ public class SourceNodeContainer extends SourceNode {
     },
     OPTIONAL {
       @Override
+      public boolean isSorted() {
+        return true;
+      }
+
+      @Override
       public void render(Renderer renderer) {
         renderer.methodGen().invokeVirtual(A_OPTIONAL_TYPE, METHOD_OPTIONAL__STREAM);
       }
@@ -92,6 +117,11 @@ public class SourceNodeContainer extends SourceNode {
       }
     },
     JSON {
+      @Override
+      public boolean isSorted() {
+        return false;
+      }
+
       @Override
       public void render(Renderer renderer) {
         renderer
@@ -105,6 +135,11 @@ public class SourceNodeContainer extends SourceNode {
       }
     },
     LIFTED_JSON {
+      @Override
+      public boolean isSorted() {
+        return false;
+      }
+
       @Override
       public void render(Renderer renderer) {
         renderer.methodGen().invokeVirtual(A_OPTIONAL_TYPE, METHOD_OPTIONAL__STREAM);
@@ -125,6 +160,8 @@ public class SourceNodeContainer extends SourceNode {
             expression.renderEcma(renderer));
       }
     };
+
+    public abstract boolean isSorted();
 
     public abstract void render(Renderer renderer);
 
@@ -172,7 +209,7 @@ public class SourceNodeContainer extends SourceNode {
 
   @Override
   public Ordering ordering() {
-    return Ordering.RANDOM;
+    return mode.isSorted() ? Ordering.REQESTED : Ordering.RANDOM;
   }
 
   @Override

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeFor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/WizardNodeFor.java
@@ -117,19 +117,19 @@ public class WizardNodeFor extends WizardNode {
     if (!source.typeCheck(errorHandler) || !name.typeCheck(source.streamType(), errorHandler)) {
       return false;
     }
-    final var ordering =
-        transforms.stream()
-            .reduce(
-                source.ordering(),
-                (order, transform) -> transform.order(order, errorHandler),
-                (a, b) -> {
-                  throw new UnsupportedOperationException();
-                });
     final var resultType =
         transforms.stream()
             .reduce(
                 Optional.of(source.streamType()),
                 (t, transform) -> t.flatMap(tt -> transform.typeCheck(tt, errorHandler)),
+                (a, b) -> {
+                  throw new UnsupportedOperationException();
+                });
+    final var ordering =
+        transforms.stream()
+            .reduce(
+                source.ordering(),
+                (order, transform) -> transform.order(order, errorHandler),
                 (a, b) -> {
                   throw new UnsupportedOperationException();
                 });

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/mode-shesmu.js
@@ -102,6 +102,7 @@ ace.define(
             "Then",
             "Timeout",
             "To",
+            "Tuple",
             "TypeAlias",
             "Using",
             "When",

--- a/shesmu-server/src/test/resources/compiler/list-empty-collect.shesmu
+++ b/shesmu-server/src/test/resources/compiler/list-empty-collect.shesmu
@@ -2,5 +2,5 @@ Version 1;
 Input test;
 
 Olive
- Let foo = (For x In [ "a" ]: First [x] Default [])
+ Let foo = (For x In [ "a" ]: Sort x First [x] Default [])
  Run ok With ok =  True;

--- a/shesmu-server/src/test/resources/run/destructure-wildcard-multicontext.shesmu
+++ b/shesmu-server/src/test/resources/run/destructure-wildcard-multicontext.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For * In [ { a = True, b = 1}, { a = False, b = 2} ]: Where b == 1 Reduce (x = True) x && a);
+ Run ok With ok = (For * In [ { a = True, b = 1}, { a = False, b = 2} ]: Sort b Where b == 1 Reduce (x = True) x && a);

--- a/shesmu-server/src/test/resources/run/destructure-wildcard.shesmu
+++ b/shesmu-server/src/test/resources/run/destructure-wildcard.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For * In [ { a = True, b = 1}, { a = False, b = 2} ]: Where b == 1 First a Default False);
+ Run ok With ok = (For * In [ { a = True, b = 1}, { a = False, b = 2} ]: Where b == 1 Sort b First a Default False);

--- a/shesmu-server/src/test/resources/run/function-for.shesmu
+++ b/shesmu-server/src/test/resources/run/function-for.shesmu
@@ -1,7 +1,7 @@
 Version 1;
 Input test;
 
-Function foo([{boolean, [integer]}] input) (For x In input: Flatten (y In x[1] Let z = {x[0], y + 1}) Where z[0] Reduce(a=0) a + z[1]);
+Function foo([{boolean, [integer]}] input) (For x In input: Flatten (y In x[1] Let z = {x[0], y + 1}) Sort z[1] Where z[0] Reduce(a=0) a + z[1]);
 
 Olive
  Run ok With ok = foo([ {True, [1,2]}, {False, [3, 4]} ]) == 5;

--- a/shesmu-server/src/test/resources/run/list-default.shesmu
+++ b/shesmu-server/src/test/resources/run/list-default.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For x In [ 7 ]: Where x > 10 First x Default 3) == 3;
+ Run ok With ok = (For x In [ 7 ]: Where x > 10 Sort x First x Default 3) == 3;

--- a/shesmu-server/src/test/resources/run/list-mapflatten-capture.shesmu
+++ b/shesmu-server/src/test/resources/run/list-mapflatten-capture.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For x In [ {True, [1,2]}, {False, [3, 4]} ]: Flatten (y In x[1] Let z = {x[0], y + 1}) Where z[0] Reduce(a=0) a + z[1]) == 5;
+ Run ok With ok = (For x In [ {True, [1,2]}, {False, [3, 4]} ]: Flatten (y In x[1] Let z = {x[0], y + 1}) Sort z[1] Where z[0] Reduce(a=0) a + z[1]) == 5;

--- a/shesmu-server/src/test/resources/run/list-mapflatten.shesmu
+++ b/shesmu-server/src/test/resources/run/list-mapflatten.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For x In [ [1,2],[3, 4] ]: Flatten (y In x Let z = y + 1) Reduce(a=0) a + z) == 14;
+ Run ok With ok = (For x In [ [1,2],[3, 4] ]: Flatten (y In x Let z = y + 1) Sort z Reduce(a=0) a + z) == 14;

--- a/shesmu-server/src/test/resources/run/list-mapflatten2.shesmu
+++ b/shesmu-server/src/test/resources/run/list-mapflatten2.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For x In [ {True, [1,2]}, {False, [3, 4]} ]: Where x[0] Flatten (y In x[1] Let z = y + 1) Reduce(a=0) a + z) == 5;
+ Run ok With ok = (For x In [ {True, [1,2]}, {False, [3, 4]} ]: Where x[0] Flatten (y In x[1] Let z = y + 1) Sort z Reduce(a=0) a + z) == 5;

--- a/shesmu-server/src/test/resources/run/list-reduce.shesmu
+++ b/shesmu-server/src/test/resources/run/list-reduce.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For x In [ 1, 2 ] : Reduce(a = 0) x + a) == 3;
+ Run ok With ok = (For x In [ 1, 2 ] : Sort x Reduce(a = 0) x + a) == 3;

--- a/shesmu-server/src/test/resources/run/list-sort-destruct-convert.shesmu
+++ b/shesmu-server/src/test/resources/run/list-sort-destruct-convert.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For {x = a, y As string = b} In [ { a = True, b = 1}, { a = False, b = 2} ]: Where y == "1" First x Default False);
+ Run ok With ok = (For {x = a, y As string = b} In [ { a = True, b = 1}, { a = False, b = 2} ]: Where y == "1" Sort y First x Default False);

--- a/shesmu-server/src/test/resources/run/list-sort-destruct-convert2.shesmu
+++ b/shesmu-server/src/test/resources/run/list-sort-destruct-convert2.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For {x = a, y As string = b} In [ { a = True, b = '/good'}, { a = False, b = '/bad'} ]: Where y == "/good" First x Default False);
+ Run ok With ok = (For {x = a, y As string = b} In [ { a = True, b = '/good'}, { a = False, b = '/bad'} ]: Where y == "/good" Sort y First x Default False);

--- a/shesmu-server/src/test/resources/run/list-sort-destruct-convert3.shesmu
+++ b/shesmu-server/src/test/resources/run/list-sort-destruct-convert3.shesmu
@@ -2,4 +2,4 @@ Version 1;
 Input test;
 
 Olive
- Run ok With ok = (For { y As json = b; a } In [ { a = True, b = 1}, { a = False, b = 2} ]: Where y == (1 As json) First a Default False);
+ Run ok With ok = (For { y As json = b; a } In [ { a = True, b = 1}, { a = False, b = 2} ]: Where y == (1 As json) Sort "{y}" First a Default False);

--- a/shesmu-server/src/test/resources/run/list-tuple.shesmu
+++ b/shesmu-server/src/test/resources/run/list-tuple.shesmu
@@ -1,0 +1,4 @@
+Version 1;
+Input test;
+
+Olive Run ok With ok = (For x In [1, 2]: Sort x Tuple x Require 2) == `{1, 2}` && (For x In [1, 1]: Sort x Tuple x Require 2) == `` && (For x In [1, 2, 3]: Sort x Tuple x Require 2) == ``;

--- a/vim/syntax.vim
+++ b/vim/syntax.vim
@@ -97,6 +97,7 @@ syn keyword shesmuKeyword Univalued
 syn keyword shesmuKeyword Then
 syn keyword shesmuKeyword Timeout
 syn keyword shesmuKeyword To
+syn keyword shesmuKeyword Tuple
 syn keyword shesmuKeyword TypeAlias
 syn keyword shesmuKeyword Using
 syn keyword shesmuKeyword When


### PR DESCRIPTION
*  Make `First` and `Reduce` order-sensitive and optionals ordered

 This fixes a bug where `Reduce` and `First` can receive values in arbitrary order. This forces values to be sorted. It may break existing code, but that code is already broken.

Since optional values, when used as a source of iteration, contain only one item, they should be considered ordered. This required changing the ordering checks to occur after the type checks, since the type is required to know if its an optional or list iteration.

* Create a `Tuple` collector

This allows taking a values in a `For` expression and converting them into a tuple.