### PR TITLE
Use new chemistry to create `flowcell_geometry` variable

### DIFF
--- a/demo/demo.pinery_ius-input
+++ b/demo/demo.pinery_ius-input
@@ -9,6 +9,11 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina MiSeq",
@@ -67,6 +72,14 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -125,6 +138,14 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -183,6 +204,14 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -241,6 +270,14 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -299,6 +336,11 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina MiSeq",
@@ -357,6 +399,11 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina MiSeq",
@@ -415,6 +462,14 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -473,6 +528,14 @@
     "dv200": null,
     "external_donor_id": "",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -531,6 +594,11 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1
+      ]
+    ],
     "group_desc": "LCM Material",
     "group_id": "526",
     "instrument_model": "Illumina MiSeq",
@@ -589,6 +657,11 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina MiSeq",
@@ -647,6 +720,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "LCM Material",
     "group_id": "526",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -705,6 +786,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -763,6 +852,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "LCM Material",
     "group_id": "526",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -821,6 +918,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -879,6 +984,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "LCM Material",
     "group_id": "526",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -937,6 +1050,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -995,6 +1116,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "LCM Material",
     "group_id": "526",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -1053,6 +1182,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "",
     "group_id": "",
     "instrument_model": "Illumina NovaSeq 6000",
@@ -1111,6 +1248,11 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1
+      ]
+    ],
     "group_desc": "LCM Material",
     "group_id": "526",
     "instrument_model": "Illumina MiSeq",
@@ -1169,6 +1311,11 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1
+      ]
+    ],
     "group_desc": "LCM Material",
     "group_id": "526",
     "instrument_model": "Illumina MiSeq",
@@ -1227,6 +1374,14 @@
     "dv200": null,
     "external_donor_id": "ABC_0001",
     "external_tissue_id": null,
+    "flowcell_geometry": [
+      [
+        1,
+        2,
+        3,
+        4
+      ]
+    ],
     "group_desc": "LCM Material",
     "group_id": "526",
     "instrument_model": "Illumina NovaSeq 6000",

--- a/plugin-pinery/pom.xml
+++ b/plugin-pinery/pom.xml
@@ -12,7 +12,7 @@
   <url>https://github.com/oicr-gsi/shesmu</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pinery-version>2.18.0</pinery-version>
+    <pinery-version>2.19.0</pinery-version>
   </properties>
   <dependencies>
     <dependency>
@@ -65,6 +65,11 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ca.on.oicr.gsi</groupId>
+      <artifactId>shesmu-plugin-runscanner</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryIUSValue.java
+++ b/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PineryIUSValue.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /** IUS information from Pinery */
 public final class PineryIUSValue {
@@ -20,6 +21,7 @@ public final class PineryIUSValue {
   private final String external_donor_id;
   private final Tuple external_key;
   private final String external_tissue_id;
+  private final Set<Set<Long>> flowcellGeometry;
   private final String group_desc;
   private final String group_id;
   private final String instrumentModel;
@@ -69,6 +71,7 @@ public final class PineryIUSValue {
       String external_donor_id,
       Tuple external_key,
       String external_tissue_id,
+      Set<Set<Long>> flowcellGeometry,
       String group_desc,
       String group_id,
       String instrumentModel,
@@ -117,6 +120,7 @@ public final class PineryIUSValue {
     this.external_donor_id = external_donor_id;
     this.external_key = external_key;
     this.external_tissue_id = external_tissue_id;
+    this.flowcellGeometry = flowcellGeometry;
     this.group_desc = group_desc;
     this.group_id = group_id;
     this.instrumentModel = instrumentModel;
@@ -220,6 +224,7 @@ public final class PineryIUSValue {
         && external_donor_id.equals(that.external_donor_id)
         && external_key.equals(that.external_key)
         && external_tissue_id.equals(that.external_tissue_id)
+        && flowcellGeometry.equals(that.flowcellGeometry)
         && group_desc.equals(that.group_desc)
         && group_id.equals(that.group_id)
         && instrumentModel.equals(that.instrumentModel)
@@ -269,6 +274,11 @@ public final class PineryIUSValue {
     return external_tissue_id;
   }
 
+  @ShesmuVariable
+  public Set<Set<Long>> flowcell_geometry() {
+    return flowcellGeometry;
+  }
+
   @ShesmuVariable(signable = true)
   public String group_desc() {
     return group_desc;
@@ -298,6 +308,7 @@ public final class PineryIUSValue {
         external_donor_id,
         external_key,
         external_tissue_id,
+        flowcellGeometry,
         group_desc,
         group_id,
         instrumentModel,

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
     <module>shesmu-pluginapi</module>
     <module>shesmu-server</module>
     <module>plugin-gsi-common</module>
+    <module>plugin-runscanner</module>
     <module>plugin-cerberus</module>
     <module>plugin-github</module>
     <module>plugin-guanyin</module>
@@ -178,7 +179,6 @@
     <module>plugin-pinery</module>
     <module>plugin-prometheus</module>
     <module>plugin-ratelimit</module>
-    <module>plugin-runscanner</module>
     <module>plugin-sftp</module>
     <module>plugin-tsv</module>
     <module>plugin-vidarr</module>


### PR DESCRIPTION
We currently get this information out of Run Scanner, but this is awkward since
Pinery should have all this information. Now that is exported by Pinery, it can
be directly exported as a variable.