### PR TITLE
Add additional tags to Vidarr workflow run actions

### DIFF
--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
@@ -119,7 +119,7 @@ final class RunStateAttemptSubmit extends RunState {
 
   @Override
   public Stream<String> tags() {
-    return Stream.of("vidarr-attempt:" + attempt);
+    return Stream.of("vidarr-attempt:" + attempt, "vidarr-state:attempt");
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateConflicted.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateConflicted.java
@@ -60,7 +60,8 @@ final class RunStateConflicted extends RunState {
 
   @Override
   public Stream<String> tags() {
-    return ids.stream().map("vidarr-workflow-run:"::concat);
+    return Stream.concat(
+        Stream.of("vidarr-state:conflict"), ids.stream().map("vidarr-workflow-run:"::concat));
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateDead.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateDead.java
@@ -44,7 +44,7 @@ public class RunStateDead extends RunState {
 
   @Override
   public Stream<String> tags() {
-    return Stream.empty();
+    return Stream.of("vidar-state:dead");
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
@@ -66,7 +66,7 @@ final class RunStateMissing extends RunState {
 
   @Override
   public Stream<String> tags() {
-    return Stream.of("vidarr-workflow-run:" + id);
+    return Stream.of("vidarr-workflow-run:" + id, "vidarr-state:missing");
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
@@ -125,7 +125,9 @@ public class RunStateMonitor extends RunState {
 
   @Override
   public Stream<String> tags() {
-    return Stream.of("vidarr-workflow-run:" + status.getId());
+    return Stream.of(
+        "vidarr-workflow-run:" + status.getId(),
+        status.getCompleted() == null ? "vidarr-state:active" : "vidarr-state:finished");
   }
 
   @Override


### PR DESCRIPTION
The Vidarr submit action uses a state machine to control its interaction with
the Vidarr server. This exports the current state via a tag so that it can be
filtered on in the Shesmu UI.