### PR TITLE
Correctly update alert `endsAt` property

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -108,6 +108,7 @@ public final class ActionProcessor
 
     public void expiresIn(long ttl) {
       expiryTime = Instant.now().plusSeconds(ttl);
+      this.endsAt = DateTimeFormatter.ISO_INSTANT.format(expiryTime);
     }
 
     public String expiryTime() {
@@ -148,10 +149,6 @@ public final class ActionProcessor
 
     public void setAnnotations(Map<String, String> annotations) {
       this.annotations = annotations;
-    }
-
-    public void setEndsAt(Instant endsAt) {
-      this.endsAt = DateTimeFormatter.ISO_INSTANT.format(endsAt);
     }
 
     public void setEndsAt(String endsAt) {


### PR DESCRIPTION
When an alert is active in Prometheus Alert Manager, the `endsAt` property
needs to be in the future. The `expiresIn` method is meant to push the
timestamp into the future, but it was failing to update the timestamp used by
Prometheus and only the one used by Shesmu internally.