### PR TITLE
Remove dependency on Apache commons-lang

### DIFF
--- a/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BasesMask.java
+++ b/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BasesMask.java
@@ -3,7 +3,6 @@ package ca.on.oicr.gsi.shesmu.pinery.barcodes;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringUtils;
 
 /** @author mlaszloffy */
 public class BasesMask {
@@ -95,8 +94,6 @@ public class BasesMask {
       return prefix + length.toString();
     } else if (length != null && length == Integer.MAX_VALUE) {
       return prefix + "*";
-    } else if (length != null && length == 0) {
-      return "";
     } else {
       return "";
     }
@@ -107,12 +104,12 @@ public class BasesMask {
       return null;
     } else if ("*".equals(length)) {
       return Integer.MAX_VALUE;
-    } else if (StringUtils.isNumeric(length)) {
-      Integer i = Integer.parseInt(length);
+    } else if (length.chars().allMatch(Character::isDigit)) {
+      final var i = Integer.parseInt(length);
       if (i == 0) {
         return null;
       } else {
-        return Integer.parseInt(length);
+        return i;
       }
     } else {
       throw new IllegalArgumentException("Input value [" + length + "] is not supported");


### PR DESCRIPTION
This was being transitively included from another dependency and was failing to
build in some situations. Since it provides trivial functionality, it is
easiest to replace it.