### PR TITLE
Update org.apache.commons.lang dependency to org.apache.commons.lang3

### DIFF
--- a/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BasesMask.java
+++ b/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/barcodes/BasesMask.java
@@ -3,7 +3,7 @@ package ca.on.oicr.gsi.shesmu.pinery.barcodes;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /** @author mlaszloffy */
 public class BasesMask {


### PR DESCRIPTION
The old dependency on org.apache.commons.lang is apparently unknown to the current version of Maven. This change enables the project to build successfully in a fresh install of Ubuntu. (Apache Maven 3.6.3, Java 15.0.2, Ubuntu 20.04.)