### PR TITLE
Add a _Freeze View_ button to action

### DIFF
--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -10,7 +10,7 @@ import {
   mergingModel,
   shuffle,
 } from "./util.js";
-import { BasicQuery, createSearch } from "./actionfilters.js";
+import { Query } from "./actionfilters.js";
 import { AlertFilter } from "./alert.js";
 
 /**
@@ -1266,7 +1266,7 @@ export type SearchBarState = "ok" | "bad" | "busy" | "dirty";
  */
 export interface ShesmuLinks {
   actiondash: {
-    filters: BasicQuery | string;
+    filters: Query;
     saved: string;
   };
   alerts: {
@@ -1275,7 +1275,7 @@ export interface ShesmuLinks {
   olivedash: {
     alert: AlertFilter<RegExp>[];
     saved: SourceLocation | null;
-    filters: BasicQuery | string;
+    filters: Query;
   };
 }
 /**


### PR DESCRIPTION
This adds a new mode of "search" to the _Actions_ and _Olives_ pages. Rather
than taking a query, it uses a list of action identifiers. This allows the user
to freeze a search, locking it to the current actions.