### PR TITLE
Fix bug in meditation compiler

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FetchCollectNode.java
@@ -13,14 +13,17 @@ public abstract class FetchCollectNode {
   static {
     DISPATCHER.addKeyword(
         "List",
-        (p, o) -> p.whitespace().then(FetchNode::parse, FetchCollectNodeList::new).whitespace());
+        (p, o) ->
+            p.whitespace()
+                .then(FetchNode::parse, collector -> o.accept(new FetchCollectNodeList(collector)))
+                .whitespace());
     DISPATCHER.addKeyword(
         "Flatten",
         (p, o) ->
             p.whitespace()
                 .then(
                     FetchNode::parse,
-                    inner -> new FetchCollectNodeFlatten(p.line(), p.column(), inner))
+                    inner -> o.accept(new FetchCollectNodeFlatten(p.line(), p.column(), inner)))
                 .whitespace());
     DISPATCHER.addKeyword(
         "Dict",


### PR DESCRIPTION
When parsing `Fetch` actions, the parser for `List` and `Flatten` would
construct the correct node, but skipped invoke the output callback, resulting
in a null pointer exception in `For`.