### PR TITLE
Redesign thread pools

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/CompiledGenerator.java
@@ -25,6 +25,7 @@ import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.server.HotloadingCompiler;
 import ca.on.oicr.gsi.shesmu.server.ImportVerifier;
 import ca.on.oicr.gsi.shesmu.server.InputSource;
+import ca.on.oicr.gsi.shesmu.server.ShesmuThreadFactory;
 import ca.on.oicr.gsi.shesmu.server.plugins.AnnotatedInputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.server.plugins.CallSiteRegistry;
 import ca.on.oicr.gsi.shesmu.util.NameLoader;
@@ -898,13 +899,8 @@ public class CompiledGenerator implements DefinitionRepository {
   private Optional<AutoUpdatingDirectory<Script>> scripts = Optional.empty();
   private final ExecutorService workExecutor =
       Executors.newFixedThreadPool(
-          Math.max(1, Runtime.getRuntime().availableProcessors() - 1),
-          runnable -> {
-            final var thread = new Thread(runnable);
-            thread.setPriority(Thread.MIN_PRIORITY);
-            thread.setUncaughtExceptionHandler(Server::unhandledException);
-            return thread;
-          });
+          Runtime.getRuntime().availableProcessors() / 2 + 1,
+          new ShesmuThreadFactory("olive", Thread.MIN_PRIORITY));
 
   public CompiledGenerator(
       ScheduledExecutorService executor,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -288,7 +288,7 @@ public final class ActionProcessor
   }
 
   public static final int ACTION_PERFORM_THREADS =
-      Math.max(1, Runtime.getRuntime().availableProcessors() * 5 - 1);
+      Math.max(1, Runtime.getRuntime().availableProcessors() / 2 + 1);
   private static final BinMember<Instant> ADDED =
       new BinMember<>() {
 
@@ -588,13 +588,7 @@ public final class ActionProcessor
       Executors.newSingleThreadScheduledExecutor();
   private final ExecutorService workExecutor =
       Executors.newFixedThreadPool(
-          ACTION_PERFORM_THREADS,
-          runnable -> {
-            final var thread = new Thread(runnable);
-            thread.setPriority(Thread.MIN_PRIORITY);
-            thread.setUncaughtExceptionHandler(Server::unhandledException);
-            return thread;
-          });
+          ACTION_PERFORM_THREADS, new ShesmuThreadFactory("actions", Thread.MIN_PRIORITY));
 
   public ActionProcessor(URI baseUri, PluginManager manager, ActionServices actionServices) {
     super();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ShesmuThreadFactory.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ShesmuThreadFactory.java
@@ -1,0 +1,28 @@
+package ca.on.oicr.gsi.shesmu.server;
+
+import java.util.concurrent.ThreadFactory;
+
+public class ShesmuThreadFactory implements ThreadFactory {
+  public static void unhandledException(Thread thread, Throwable throwable) {
+    System.err.printf("Unhandled error in thread %s (%d)\n", thread.getName(), thread.getId());
+    throwable.printStackTrace();
+  }
+
+  private int id;
+  private final String prefix;
+  private final int priority;
+
+  public ShesmuThreadFactory(String prefix, int priority) {
+    this.prefix = prefix;
+    this.priority = priority;
+  }
+
+  @Override
+  public Thread newThread(Runnable runnable) {
+    final var thread = new Thread(runnable);
+    thread.setName(prefix + "-" + id++);
+    thread.setPriority(priority);
+    thread.setUncaughtExceptionHandler(ShesmuThreadFactory::unhandledException);
+    return thread;
+  }
+}


### PR DESCRIPTION
First, this collapses all the thread factories used by thread pools into a
single class. It then adjust the totals so that actions and olives each get
half-minus-one CPUs. Internal processes can run on all the CPUs since they
spend most of their time sleeping. Web requests can exceed the number of CPUs
since they spend most of their time blocking on I/O.