### PR TITLE
Increase the action queue rate

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -1577,7 +1577,7 @@ public final class ActionProcessor
                         && !entry.getValue().updateInProgress
                         && Duration.between(entry.getValue().lastChecked, now).toMinutes()
                             >= Math.max(10, entry.getKey().retryMinutes()))
-            .limit(1000L * ACTION_PERFORM_THREADS - currentRunningActions.get())
+            .limit(5000L * ACTION_PERFORM_THREADS - currentRunningActions.get())
             .collect(Collectors.toList());
     currentRunningActionsGauge.set(currentRunningActions.addAndGet(candidates.size()));
 


### PR DESCRIPTION
Change this factor which is effectively number of new actions per thread per
minute to compensate for the fact that the number of threads has been
decreased.