### PR TITLE
Add `+` and `*` operations for strings

### DIFF
--- a/language.md
+++ b/language.md
@@ -716,14 +716,22 @@ expression flags](#regexflags).
 
 Adds two values.
 
-| Left    | Right    | Result  | Description                                                     |
-|---------|----------|---------|-----------------------------------------------------------------|
-| `int`   | `int`    | `int`   | Summation                                                       |
-| `date`  | `int`    | `date`  | Add seconds to date                                             |
-| `path`  | `path`   | `path`  | Resolve paths (concatenate, unless second path starts with `/`) |
-| `path`  | `string` | `path`  | Append component to path                                        |
-| `[`x`]` | `[`x`]`  | `[`x`]` | Union of two lists (removing duplicates)                        |
-| `[`x`]` | x        | `[`x`]` | Add item to list (removing duplicates)                          |
+| Left     | Right    | Result   | Description                                                            |
+|----------|----------|----------|------------------------------------------------------------------------|
+| `integer`| `integer`| `integer`| Summation                                                              |
+| `float`  | `integer`| `float`  | Summation                                                              |
+| `integer`| `float`  | `float`  | Summation                                                              |
+| `float`  | `float`  | `float`  | Summation                                                              |
+| `date`   | `integer`| `date`   | Add seconds to date                                                    |
+| `path`   | `path`   | `path`   | Resolve paths (concatenate, unless second path starts with `/`)        |
+| `path`   | `string` | `path`   | Append component to path                                               |
+| `string` | `string` | `string` | Concatenate two strings                                                |
+| `string` | `integer`| `string` | Concatenate a string and an integer value by first converting it       |
+| `string` | `float`  | `string` | Concatenate a string and a floating-point value by first converting it |
+| `string` | `date`   | `string` | Concatenate a string and a date value by first converting it           |
+| `string` | `path`   | `string` | Concatenate a string and a path value by first converting it           |
+| `[`x`]`  | `[`x`]`  | `[`x`]`  | Union of two lists (removing duplicates)                               |
+| `[`x`]`  | x        | `[`x`]`  | Add item to list (removing duplicates)                                 |
 | `{`a1`,`...`,` an`}`              | `{`b1`,`...`,` bn`}`             | `{`a1`,`...`,` an`,`b1`,`...`,` bn`}`                         | Concatenate two tuples                       |
 | `{`fa1`=`a1`, `...`,` fan`=`an`}` | `{`fb1`=`b1`,`...`,` fbn`=`bn`}` | `{`fa1`=`a1`,`...`,` fan`=`an`,`fb1`=`b1`,`...`,` fbn`=`bn`}` | Merge two objects (with no duplicate fields) |
 
@@ -732,13 +740,16 @@ Adds two values.
 
 Subtracts two values.
 
-| Left    | Right   | Result  | Description                                                    |
-|---------|---------|---------|----------------------------------------------------------------|
-| `int`   | `int`   | `int`   | Difference                                                     |
-| `date`  | `int`   | `date`  | Subtract seconds to date                                       |
-| `date`  | `date`  | `int`   | Difference in seconds                                          |
-| `[`x`]` | `[`x`]` | `[`x`]` | Difference of two lists (first list without items from second) |
-| `[`x`]` | x       | `[`x`]` | Remove item from list (if present)                             |
+| Left     | Right    | Result    | Description                                                    |
+|----------|----------|-----------|----------------------------------------------------------------|
+| `integer`| `integer`| `integer` | Difference                                                     |
+| `float`  | `integer`| `float`   | Difference                                                     |
+| `integer`| `float`  | `float`   | Difference                                                     |
+| `float`  | `float`  | `float`   | Difference                                                     |
+| `date`   | `integer`| `date`    | Subtract seconds to date                                       |
+| `date`   | `date`   | `int`     | Difference in seconds                                          |
+| `[`x`]`  | `[`x`]`  | `[`x`]`   | Difference of two lists (first list without items from second) |
+| `[`x`]`  | x        | `[`x`]`   | Remove item from list (if present)                             |
 
 ### Conjunction
 #### Multiplication

--- a/language.md
+++ b/language.md
@@ -755,12 +755,27 @@ Subtracts two values.
 #### Multiplication
 - _expr_ `*` _expr_
 
-Multiplies two values which must be integers.
+Multiplies two values.
+
+| Left     | Right    | Result    | Description                                |
+|----------|----------|-----------|--------------------------------------------|
+| `integer`| `integer`| `integer` | Multiplication                             |
+| `float`  | `integer`| `float`   | Multiplication                             |
+| `integer`| `float`  | `float`   | Multiplication                             |
+| `float`  | `float`  | `float`   | Multiplication                             |
+| `string` | `integer`| `string`  | Repeats string a specified number of times |
 
 #### Division
 - _expr_ `/` _expr_
 
-Divides two values which must be integers.
+Divides two values.
+
+| Left     | Right    | Result    | Description |
+|----------|----------|-----------|-------------|
+| `integer`| `integer`| `integer` | Division    |
+| `float`  | `integer`| `float`   | Division    |
+| `integer`| `float`  | `float`   | Division    |
+| `float`  | `float`  | `float`   | Division    |
 
 #### Modulus
 - _expr_ `%` _expr_

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BinaryOperation.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BinaryOperation.java
@@ -116,7 +116,26 @@ public abstract class BinaryOperation {
       new Method("or", A_OPTIONAL_TYPE, new Type[] {A_SUPPLIER_TYPE});
   private static final Method METHOD_OPTIONAL__OR_ELSE_GET =
       new Method("orElseGet", A_OBJECT_TYPE, new Type[] {A_SUPPLIER_TYPE});
+  private static final Method METHOD_STRING__REPEAT =
+      new Method("repeat", A_STRING_TYPE, new Type[] {Type.INT_TYPE});
+  public static final BinaryOperation STRING_REPEAT =
+      new BinaryOperation(Imyhat.STRING) {
+        @Override
+        public void render(
+            int line, int column, Renderer renderer, Renderable leftValue, Renderable rightValue) {
+          leftValue.render(renderer);
+          rightValue.render(renderer);
+          renderer.methodGen().cast(Type.LONG_TYPE, Type.INT_TYPE);
+          renderer.methodGen().invokeVirtual(A_STRING_TYPE, METHOD_STRING__REPEAT);
+        }
 
+        @Override
+        public String render(
+            EcmaScriptRenderer renderer, ExpressionNode left, ExpressionNode right) {
+          return String.format(
+              "%s.repeat(%s)", left.renderEcma(renderer), right.renderEcma(renderer));
+        }
+      };
   public static final Method TUPLE__CONCAT =
       new Method("concat", A_TUPLE_TYPE, new Type[] {A_TUPLE_TYPE});
   public static final Method TUPLE__CTOR =

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -509,6 +509,7 @@ public abstract class ExpressionNode implements Renderable {
                 Imyhat.DATE, Imyhat.INTEGER, Imyhat.DATE, "plusSeconds", "datePlusSeconds"),
             BinaryOperation.virtualMethod(
                 Imyhat.PATH, Imyhat.PATH, Imyhat.PATH, "resolve", "pathResolve"),
+            BinaryOperation::stringConcat,
             BinaryOperation.staticMethod(
                 Imyhat.PATH,
                 Imyhat.STRING,

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNode.java
@@ -541,7 +541,11 @@ public abstract class ExpressionNode implements Renderable {
                 A_RUNTIME_SUPPORT_TYPE, "removeItem", "setRemove")));
 
     CONJUNCTION.addSymbol(
-        "*", binaryOperators("*", BinaryOperation.primitiveMathUpgrading(GeneratorAdapter.MUL)));
+        "*",
+        binaryOperators(
+            "*",
+            BinaryOperation.primitiveMathUpgrading(GeneratorAdapter.MUL),
+            BinaryOperation.exact(Imyhat.STRING, Imyhat.INTEGER, BinaryOperation.STRING_REPEAT)));
     CONJUNCTION.addSymbol(
         "/", binaryOperators("/", BinaryOperation.primitiveMathUpgrading(GeneratorAdapter.DIV)));
     CONJUNCTION.addSymbol(

--- a/shesmu-server/src/test/resources/run/string_integer.shesmu
+++ b/shesmu-server/src/test/resources/run/string_integer.shesmu
@@ -1,4 +1,4 @@
 Version 1;
 Input test;
 
-Olive Run ok With ok = "{workflow_version[0]:3}" == "001";
+Olive Run ok With ok = "{workflow_version[0]:3}" == "0" + "0" + 1;

--- a/shesmu-server/src/test/resources/run/string_repeat.shesmu
+++ b/shesmu-server/src/test/resources/run/string_repeat.shesmu
@@ -1,0 +1,4 @@
+Version 1;
+Input test;
+
+Olive Run ok With ok = "0" * 2 == "00";


### PR DESCRIPTION
- Adds a string repeat operation using `*`, similar to Python.
- Allow `+` to work for strings and a type that is convertible to string.
