### PR TITLE
Reorganize grouper and add a powerset grouper

### DIFF
--- a/plugin-runscanner/pom.xml
+++ b/plugin-runscanner/pom.xml
@@ -78,6 +78,16 @@
       <artifactId>metainf-services</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>shesmu-plugin-runscanner</finalName>

--- a/plugin-runscanner/src/main/java/ca/on/oicr/gsi/shesmu/runscanner/LaneSplittingGrouper.java
+++ b/plugin-runscanner/src/main/java/ca/on/oicr/gsi/shesmu/runscanner/LaneSplittingGrouper.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.runscanner;
 
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Subgroup;

--- a/plugin-runscanner/src/main/java/ca/on/oicr/gsi/shesmu/runscanner/LaneSplittingGrouperDefinition.java
+++ b/plugin-runscanner/src/main/java/ca/on/oicr/gsi/shesmu/runscanner/LaneSplittingGrouperDefinition.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.runscanner;
 
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperOutput;

--- a/plugin-runscanner/src/test/java/ca/on/oicr/gsi/shesmu/runscanner/LaneSplittingGrouperTest.java
+++ b/plugin-runscanner/src/test/java/ca/on/oicr/gsi/shesmu/runscanner/LaneSplittingGrouperTest.java
@@ -1,7 +1,6 @@
-package ca.on.oicr.gsi.shesmu;
+package ca.on.oicr.gsi.shesmu.runscanner;
 
 import ca.on.oicr.gsi.Pair;
-import ca.on.oicr.gsi.shesmu.runtime.LaneSplittingGrouper;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/AlwaysIncludeGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/AlwaysIncludeGrouper.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.core.groupers;
 
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Subgroup;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/AlwaysIncludeGrouperDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/AlwaysIncludeGrouperDefinition.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.core.groupers;
 
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/CombinationsGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/CombinationsGrouper.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.core.groupers;
 
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Subgroup;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/CombinationsGrouperDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/CombinationsGrouperDefinition.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.core.groupers;
 
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperOutputs;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/CrossTabGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/CrossTabGrouper.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.core.groupers;
 
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Subgroup;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/CrossTabGrouperDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/CrossTabGrouperDefinition.java
@@ -1,4 +1,4 @@
-package ca.on.oicr.gsi.shesmu.runtime;
+package ca.on.oicr.gsi.shesmu.core.groupers;
 
 import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
 import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/PowerSetGrouper.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/PowerSetGrouper.java
@@ -1,0 +1,32 @@
+package ca.on.oicr.gsi.shesmu.core.groupers;
+
+import ca.on.oicr.gsi.shesmu.plugin.grouper.Grouper;
+import ca.on.oicr.gsi.shesmu.plugin.grouper.Subgroup;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+public class PowerSetGrouper<I, O> implements Grouper<I, O> {
+
+  private final Supplier<BiConsumer<O, I>> collector;
+
+  public PowerSetGrouper(Supplier<BiConsumer<O, I>> collector) {
+    this.collector = collector;
+  }
+
+  private IntStream bitsSet(long bits, int size) {
+    return IntStream.range(0, size).filter(index -> (bits & (1L << index)) != 0);
+  }
+
+  @Override
+  public Stream<Subgroup<I, O>> group(List<I> inputs) {
+    return LongStream.range(1, (1L << inputs.size()) - 1)
+        .mapToObj(
+            bits ->
+                new Subgroup<>(
+                    collector.get(), bitsSet(bits, inputs.size()).mapToObj(inputs::get)));
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/PowerSetGrouperDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/groupers/PowerSetGrouperDefinition.java
@@ -1,0 +1,17 @@
+package ca.on.oicr.gsi.shesmu.core.groupers;
+
+import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperDefinition;
+import ca.on.oicr.gsi.shesmu.plugin.grouper.GrouperOutputs;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices
+public class PowerSetGrouperDefinition extends GrouperDefinition {
+  public PowerSetGrouperDefinition() {
+    super("powerset", GrouperOutputs.empty(), PowerSetGrouper::new);
+  }
+
+  @Override
+  public String description() {
+    return "Creates groups which are the powerset of each subgroup supplied.";
+  }
+}


### PR DESCRIPTION
* Create a powerset grouper
  This grouper was used as a demonstration of how to write a grouper.
* Move groupers to better locations
  The groupers belong in the `core` package sine they are not strictly referenced by the compiler. The lane-splitting group is tied into the Run Scanner infrastructure, so I have moved that there.
