### PR TITLE
Add a plugin to handle equivalent strings

### DIFF
--- a/plugin-tsv/README.md
+++ b/plugin-tsv/README.md
@@ -3,6 +3,7 @@ The tab-delimited file plugin provides several different features:
 
 - table-based lookup functions
 - string sets
+- equivalence tables
 - TSV dumper
 - maintenance schedules
 
@@ -29,6 +30,20 @@ This will create a function in Shesmu that can be used as
 any unassigned project to `phil`. If no catch-all row is provided, a default
 value is returned (the empty string, false, 0, the current directory, or the
 epoch) depending on the type.
+
+## Equivalence Tables
+In some cases, it is useful to decide that two strings are equivalent. This
+plugin takes a table, ending in `.equiv`, and each line is considered to be a
+set of mutually equivalent values, separated by tabs.
+
+For a file such as this:
+
+    A     B     C
+    D     E
+
+a function `is_same` will be available to the olive and `is_same("A", "B")`
+will be true, but `is_same("A", "E")` will be false. A string is always the
+same as itself, even if not listed in the table.
 
 ## String Sets
 A string set is a file, ending in `.set` that will be available to olives as a

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/EquivalenceFile.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/EquivalenceFile.java
@@ -1,0 +1,71 @@
+package ca.on.oicr.gsi.shesmu.tsv;
+
+import ca.on.oicr.gsi.shesmu.plugin.Definer;
+import ca.on.oicr.gsi.shesmu.plugin.PluginFile;
+import ca.on.oicr.gsi.shesmu.plugin.functions.ShesmuMethod;
+import ca.on.oicr.gsi.shesmu.plugin.functions.ShesmuParameter;
+import ca.on.oicr.gsi.status.SectionRenderer;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class EquivalenceFile extends PluginFile {
+
+  private static final Pattern TAB = Pattern.compile("\t");
+  private Map<String, Set<String>> current = Map.of();
+
+  @SuppressWarnings("unused")
+  private final Definer<EquivalenceFile> definer;
+
+  public EquivalenceFile(Path fileName, String instanceName, Definer<EquivalenceFile> definer) {
+    super(fileName, instanceName);
+    this.definer = definer;
+  }
+
+  @Override
+  public void configuration(SectionRenderer renderer) {
+    renderer.line("Map size", current.size());
+  }
+
+  @ShesmuMethod(
+      name = "is_same",
+      description = "Checks if the two provided names are considered equivalent.")
+  public boolean isSame(
+      @ShesmuParameter(description = "one name to check") String a,
+      @ShesmuParameter(description = "the other name to check") String b) {
+    if (a.equals(b)) {
+      return true;
+    }
+    return current.getOrDefault(a, Set.of()).contains(b);
+  }
+
+  @Override
+  public Optional<Integer> update() {
+    final var map = new TreeMap<String, Set<String>>();
+    try (final var lines = Files.lines(fileName(), StandardCharsets.UTF_8)) {
+      lines
+          .filter(l -> !l.startsWith("#") && !l.isBlank())
+          .forEach(
+              line -> {
+                final var members =
+                    TAB.splitAsStream(line).filter(m -> !m.isBlank()).collect(Collectors.toSet());
+                if (members.size() > 1) {
+                  for (final var member : members) {
+                    map.put(member, members);
+                  }
+                }
+              });
+      current = map;
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return Optional.empty();
+  }
+}

--- a/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/EquivalenceFileType.java
+++ b/plugin-tsv/src/main/java/ca/on/oicr/gsi/shesmu/tsv/EquivalenceFileType.java
@@ -1,0 +1,21 @@
+package ca.on.oicr.gsi.shesmu.tsv;
+
+import ca.on.oicr.gsi.shesmu.plugin.Definer;
+import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices
+public class EquivalenceFileType extends PluginFileType<EquivalenceFile> {
+
+  public EquivalenceFileType() {
+    super(MethodHandles.lookup(), EquivalenceFile.class, ".equiv", "equiv");
+  }
+
+  @Override
+  public EquivalenceFile create(
+      Path filePath, String instanceName, Definer<EquivalenceFile> definer) {
+    return new EquivalenceFile(filePath, instanceName, definer);
+  }
+}


### PR DESCRIPTION
This is meant for use with sample swap detection. It provides a mechanism to
create a table of identifiers are "the same", so the sample swap detector can
ignore them.