### PR TITLE
Register workflows on migration

### DIFF
--- a/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/MigrationAction.java
+++ b/plugin-niassa/src/main/java/ca/on/oicr/gsi/shesmu/niassa/MigrationAction.java
@@ -160,265 +160,269 @@ public final class MigrationAction extends Action {
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   public synchronized ActionState perform(ActionServices actionServices) {
-    final var errors = new ArrayList<String>();
-    if (limsKeysCollection.shouldZombie(errors::add)) {
-      this.errors = errors;
-      return ActionState.ZOMBIE;
-    }
-
-    // Read the analysis provenance cache to determine if this workflow has already been run
-    final Set<Integer> inputFileSWIDs = limsKeysCollection.fileSwids().collect(Collectors.toSet());
-    final List<SimpleLimsKey> limsKeys =
-        limsKeysCollection
-            .limsKeys()
-            .map(SimpleLimsKey::new)
-            .sorted(LIMS_KEY_COMPARATOR)
-            .distinct()
-            .collect(Collectors.toList());
-    final Map<SimpleLimsKey, Set<String>> signatures =
-        limsKeysCollection
-            .signatures()
-            .collect(
-                Collectors.groupingBy(
-                    p -> new SimpleLimsKey(p.first()),
-                    Collectors.mapping(Pair::second, Collectors.toSet())));
-
-    try (AutoCloseable timer = matchTime.start(Long.toString(workflowAccession))) {
-      matches =
-          workflowAccessions()
-              .distinct()
-              .boxed()
-              .flatMap(
-                  accession ->
-                      server
-                          .get()
-                          .analysisCache()
-                          .get(accession)
-                          .map(
-                              as ->
-                                  as.compare(
-                                      workflowAccessions(),
-                                      Long.toString(majorOliveVersion),
-                                      fileMatchingPolicy,
-                                      inputFileSWIDs,
-                                      limsKeys,
-                                      signatures,
-                                      annotations)))
-              .filter(
-                  pair ->
-                      pair.comparison() != AnalysisComparison.DIFFERENT
-                          && pair.actionState() == ActionState.SUCCEEDED)
-              .sorted()
-              .collect(Collectors.toList());
-    } catch (InitialCachePopulationException e) {
-      final Metadata metadata = server.get().metadata();
-      final Workflow workflow = metadata.getWorkflow((int) workflowAccession);
-      metadata.clean_up();
-      if (workflow == null) {
-        this.errors =
-            Collections.singletonList("Niassa doesn't seem to recognise this workflow SWID.");
-        cacheCollision = false;
-        return ActionState.FAILED;
-      }
-      this.errors =
-          Collections.singletonList(
-              "Another workflow is fetching the previous workflow runs from Niassa.");
-      cacheCollision = true;
-      return ActionState.WAITING;
-    } catch (Exception e) {
-      e.printStackTrace();
-      this.errors = List.of(e.getMessage());
-      return ActionState.FAILED;
-    }
-
-    if (matches.isEmpty()) {
-      // go into waiting state and try again later
-      this.errors = Collections.singletonList("No candidate workflow runs for migration.");
-      return ActionState.WAITING;
-    } else {
-      final var labels = MAPPER.createObjectNode();
-      final var arguments = MAPPER.createObjectNode();
-      final var metadata = MAPPER.createObjectNode();
-      annotations.entrySet().stream()
-          .filter(e -> userLabels.contains(e.getKey()))
-          .forEach(e -> labels.put(e.getKey(), e.getValue()));
-
-      // Populate external keys
-      Set<ExternalKey> externalKeys = new HashSet<>();
-      limsKeys.forEach(
-          limsKey -> {
-            final var newProvider = extractNewProvider(limsKey.getProvider());
-
-            ExternalKey key =
-                new ExternalKey(
-                    newProvider.first(),
-                    limsKey.getId(),
-                    Map.of("pinery-hash-" + newProvider.second(), limsKey.getVersion()));
-            externalKeys.add(key);
-          });
-
-      // Populate arguments
-      final var vidarrDBUrl = server.get().vidarrDbUrl().orElse(null);
-      final var user = server.get().vidarrDbUser().orElse(null);
-      final var password = server.get().vidarrDbPassword().orElse(null);
-
-      // Get hash id's for all input file SWIDs from matches and populate metadata
-      if (vidarrDBUrl == null) {
-        this.errors = List.of("Vidarr not configured");
-        return ActionState.HALP;
-      }
-      try (Connection conn = DriverManager.getConnection(vidarrDBUrl, user, password)) {
-        Statement statement = conn.createStatement();
-        final var inputFiles = matches.get(0).state().inputFiles();
-        final var workflowRunSWID = matches.get(0).state().workflowRunAccession();
-        final var workflowRunEssentials = server.get().directoryAndIni(workflowRunSWID);
-
-        ResultSet rs =
-            statement.executeQuery(
-                "SELECT hash_id FROM analysis WHERE (labels->>'niassa-file-accession')::integer "
-                    + "IN ("
-                    + inputFiles.stream().map(String::valueOf).collect(Collectors.joining(","))
-                    + ")");
-
-        final var arrayNode = MAPPER.createArrayNode();
-        var count = 0;
-        while (rs.next()) {
-          String hashId = rs.getString("hash_id");
-          var node = MAPPER.createObjectNode();
-          node.put("type", "INTERNAL");
-          node.putArray("contents").add("vidarr:_/file/" + hashId);
-          arrayNode.add(node);
-          count++;
-        }
-        if (count != inputFiles.size()) {
-          this.errors = List.of("Input files have not been converted");
-          return ActionState.WAITING;
-        }
-
-        arguments.put("workflowRunSWID", workflowRunSWID);
-        arguments.putPOJO("inputFiles", arrayNode);
-        final var ini = arguments.putObject("ini");
-        for (final var entry : workflowRunEssentials.ini().entrySet()) {
-          ini.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
-        }
-      } catch (SQLException e) {
-        e.printStackTrace();
-        this.errors = List.of(e.getMessage());
-        return ActionState.FAILED; // Should this fail?
-      }
-
-      // For each output file, create following object entry:
-      // { "fileSWID": 12346, "output": {"type": "MANUAL", "contents": [
-      // "/scratch2/group/gsi/development/vidarr", [{ "provider": "pinery-miso", "id":
-      // "123_1_LDI100" }]]}}
-      final var outputFileMigration = metadata.putArray("migration");
-      final var outputFiles = matches.get(0).state().files();
-      outputFiles.forEach(
-          file -> {
-            final var fileNode = outputFileMigration.addObject();
-            final var outputNode = fileNode.putObject("fileMetadata");
-            outputNode.put("type", "MANUAL");
-            final var contents = outputNode.putArray("contents");
-            contents
-                .addObject()
-                .put("outputDirectory", server.get().outputDirectory().orElseThrow());
-            var limsKeyNode = contents.addArray();
-            file.iterator()
-                .forEachRemaining(
-                    limsKey -> {
-                      var content = MAPPER.createObjectNode();
-                      content.put("provider", extractNewProvider(limsKey.first()).first());
-                      content.put("id", limsKey.second());
-                      limsKeyNode.add(content);
-                    });
-            fileNode.put("fileSWID", file.getAccession());
-          });
-
-      request.setArguments(arguments);
-      request.setConsumableResources(new TreeMap<>());
-      request.setExternalKeys(externalKeys);
-      request.setLabels(labels);
-      request.setMetadata(metadata);
-      request.setTarget("MIGRATION");
-      request.setWorkflow(workflowName);
-      request.setWorkflowVersion(
-          matches.get(0).state().workflowVersion()
-              + "."
-              + matches.get(0).state().workflowAccession());
-
-      if (stale) {
+    if (request.getWorkflowVersion() != null) {
+      final var errors = new ArrayList<String>();
+      if (limsKeysCollection.shouldZombie(errors::add)) {
+        this.errors = errors;
         return ActionState.ZOMBIE;
       }
 
-      // Automatically register workflow version
-      final var workflowVersion = MAPPER.createObjectNode();
-      workflowVersion.put("language", "NIASSA");
-      workflowVersion.put("workflow", Long.toString(matches.get(0).state().workflowAccession()));
-      final var workflowVersionParameters = workflowVersion.putObject("parameters");
-      workflowVersionParameters.put("workflowRunSWID", "integer");
-      final var wvpInputFiles = workflowVersionParameters.putObject("inputFiles");
-      wvpInputFiles.put("is", "list");
-      wvpInputFiles.put("inner", "file");
-      final var wvpIni = workflowVersionParameters.putObject("ini");
-      wvpIni.put("is", "dictionary");
-      wvpIni.put("key", "string");
-      wvpIni.put("value", "string");
-      final var wvom = workflowVersion.putObject("outputs").putObject("migration");
-      wvom.put("is", "list");
-      wvom.putObject("keys").put("fileSWID", "INTEGER");
-      wvom.putObject("outputs").put("fileMetadata", "file-with-labels");
+      // Read the analysis provenance cache to determine if this workflow has already been run
+      final Set<Integer> inputFileSWIDs =
+          limsKeysCollection.fileSwids().collect(Collectors.toSet());
+      final List<SimpleLimsKey> limsKeys =
+          limsKeysCollection
+              .limsKeys()
+              .map(SimpleLimsKey::new)
+              .sorted(LIMS_KEY_COMPARATOR)
+              .distinct()
+              .collect(Collectors.toList());
+      final Map<SimpleLimsKey, Set<String>> signatures =
+          limsKeysCollection
+              .signatures()
+              .collect(
+                  Collectors.groupingBy(
+                      p -> new SimpleLimsKey(p.first()),
+                      Collectors.mapping(Pair::second, Collectors.toSet())));
 
-      try {
-        final var url = server.get().vidarrUrl();
-        if (url.isPresent()
-            && HTTP_CLIENT
-                    .send(
-                        HttpRequest.newBuilder(
-                                url.get()
-                                    .resolve(
-                                        String.format(
-                                            "/api/workflow/%s/%s",
-                                            request.getWorkflow(), request.getWorkflowVersion())))
-                            .version(Version.HTTP_1_1)
-                            .POST(
-                                BodyPublishers.ofString(MAPPER.writeValueAsString(workflowVersion)))
-                            .build(),
-                        BodyHandlers.discarding())
-                    .statusCode()
-                != 200) {
-          this.errors = List.of("Failed to create workflow");
+      try (AutoCloseable timer = matchTime.start(Long.toString(workflowAccession))) {
+        matches =
+            workflowAccessions()
+                .distinct()
+                .boxed()
+                .flatMap(
+                    accession ->
+                        server
+                            .get()
+                            .analysisCache()
+                            .get(accession)
+                            .map(
+                                as ->
+                                    as.compare(
+                                        workflowAccessions(),
+                                        Long.toString(majorOliveVersion),
+                                        fileMatchingPolicy,
+                                        inputFileSWIDs,
+                                        limsKeys,
+                                        signatures,
+                                        annotations)))
+                .filter(
+                    pair ->
+                        pair.comparison() != AnalysisComparison.DIFFERENT
+                            && pair.actionState() == ActionState.SUCCEEDED)
+                .sorted()
+                .collect(Collectors.toList());
+      } catch (InitialCachePopulationException e) {
+        final Metadata metadata = server.get().metadata();
+        final Workflow workflow = metadata.getWorkflow((int) workflowAccession);
+        metadata.clean_up();
+        if (workflow == null) {
+          this.errors =
+              Collections.singletonList("Niassa doesn't seem to recognise this workflow SWID.");
+          cacheCollision = false;
           return ActionState.FAILED;
         }
-      } catch (IOException | InterruptedException e) {
+        this.errors =
+            Collections.singletonList(
+                "Another workflow is fetching the previous workflow runs from Niassa.");
+        cacheCollision = true;
+        return ActionState.WAITING;
+      } catch (Exception e) {
         e.printStackTrace();
         this.errors = List.of(e.getMessage());
         return ActionState.FAILED;
       }
 
-      final RunState.PerformResult result =
-          server
-              .get()
-              .vidarrUrl()
-              .map(
-                  url -> {
-                    try {
-                      return state.perform(url, request);
-                    } catch (IOException | InterruptedException e) {
-                      e.printStackTrace();
-                      return new RunState.PerformResult(
-                          List.of(e.getMessage()), ActionState.UNKNOWN, state);
-                    }
-                  })
-              .orElseGet(
-                  () ->
-                      new RunState.PerformResult(
-                          List.of("Internal error: No Vidarr URL available"),
-                          ActionState.UNKNOWN,
-                          state));
-      this.errors = result.errors();
-      state = result.nextState();
-      return result.actionState();
+      if (matches.isEmpty()) {
+        // go into waiting state and try again later
+        this.errors = Collections.singletonList("No candidate workflow runs for migration.");
+        return ActionState.WAITING;
+      } else {
+        final var labels = MAPPER.createObjectNode();
+        final var arguments = MAPPER.createObjectNode();
+        final var metadata = MAPPER.createObjectNode();
+        annotations.entrySet().stream()
+            .filter(e -> userLabels.contains(e.getKey()))
+            .forEach(e -> labels.put(e.getKey(), e.getValue()));
+
+        // Populate external keys
+        Set<ExternalKey> externalKeys = new HashSet<>();
+        limsKeys.forEach(
+            limsKey -> {
+              final var newProvider = extractNewProvider(limsKey.getProvider());
+
+              ExternalKey key =
+                  new ExternalKey(
+                      newProvider.first(),
+                      limsKey.getId(),
+                      Map.of("pinery-hash-" + newProvider.second(), limsKey.getVersion()));
+              externalKeys.add(key);
+            });
+
+        // Populate arguments
+        final var vidarrDBUrl = server.get().vidarrDbUrl().orElse(null);
+        final var user = server.get().vidarrDbUser().orElse(null);
+        final var password = server.get().vidarrDbPassword().orElse(null);
+
+        // Get hash id's for all input file SWIDs from matches and populate metadata
+        if (vidarrDBUrl == null) {
+          this.errors = List.of("Vidarr not configured");
+          return ActionState.HALP;
+        }
+        try (Connection conn = DriverManager.getConnection(vidarrDBUrl, user, password)) {
+          Statement statement = conn.createStatement();
+          final var inputFiles = matches.get(0).state().inputFiles();
+          final var workflowRunSWID = matches.get(0).state().workflowRunAccession();
+          final var workflowRunEssentials = server.get().directoryAndIni(workflowRunSWID);
+
+          ResultSet rs =
+              statement.executeQuery(
+                  "SELECT hash_id FROM analysis WHERE (labels->>'niassa-file-accession')::integer "
+                      + "IN ("
+                      + inputFiles.stream().map(String::valueOf).collect(Collectors.joining(","))
+                      + ")");
+
+          final var arrayNode = MAPPER.createArrayNode();
+          var count = 0;
+          while (rs.next()) {
+            String hashId = rs.getString("hash_id");
+            var node = MAPPER.createObjectNode();
+            node.put("type", "INTERNAL");
+            node.putArray("contents").add("vidarr:_/file/" + hashId);
+            arrayNode.add(node);
+            count++;
+          }
+          if (count != inputFiles.size()) {
+            this.errors = List.of("Input files have not been converted");
+            return ActionState.WAITING;
+          }
+
+          arguments.put("workflowRunSWID", workflowRunSWID);
+          arguments.putPOJO("inputFiles", arrayNode);
+          final var ini = arguments.putObject("ini");
+          for (final var entry : workflowRunEssentials.ini().entrySet()) {
+            ini.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+          }
+        } catch (SQLException e) {
+          e.printStackTrace();
+          this.errors = List.of(e.getMessage());
+          return ActionState.FAILED; // Should this fail?
+        }
+
+        // For each output file, create following object entry:
+        // { "fileSWID": 12346, "output": {"type": "MANUAL", "contents": [
+        // "/scratch2/group/gsi/development/vidarr", [{ "provider": "pinery-miso", "id":
+        // "123_1_LDI100" }]]}}
+        final var outputFileMigration = metadata.putArray("migration");
+        final var outputFiles = matches.get(0).state().files();
+        outputFiles.forEach(
+            file -> {
+              final var fileNode = outputFileMigration.addObject();
+              final var outputNode = fileNode.putObject("fileMetadata");
+              outputNode.put("type", "MANUAL");
+              final var contents = outputNode.putArray("contents");
+              contents
+                  .addObject()
+                  .put("outputDirectory", server.get().outputDirectory().orElseThrow());
+              var limsKeyNode = contents.addArray();
+              file.iterator()
+                  .forEachRemaining(
+                      limsKey -> {
+                        var content = MAPPER.createObjectNode();
+                        content.put("provider", extractNewProvider(limsKey.first()).first());
+                        content.put("id", limsKey.second());
+                        limsKeyNode.add(content);
+                      });
+              fileNode.put("fileSWID", file.getAccession());
+            });
+
+        request.setArguments(arguments);
+        request.setConsumableResources(new TreeMap<>());
+        request.setExternalKeys(externalKeys);
+        request.setLabels(labels);
+        request.setMetadata(metadata);
+        request.setTarget("MIGRATION");
+        request.setWorkflow(workflowName);
+        request.setWorkflowVersion(
+            matches.get(0).state().workflowVersion()
+                + "."
+                + matches.get(0).state().workflowAccession());
+
+        if (stale) {
+          return ActionState.ZOMBIE;
+        }
+
+        // Automatically register workflow version
+        final var workflowVersion = MAPPER.createObjectNode();
+        workflowVersion.put("language", "NIASSA");
+        workflowVersion.put("workflow", Long.toString(matches.get(0).state().workflowAccession()));
+        final var workflowVersionParameters = workflowVersion.putObject("parameters");
+        workflowVersionParameters.put("workflowRunSWID", "integer");
+        final var wvpInputFiles = workflowVersionParameters.putObject("inputFiles");
+        wvpInputFiles.put("is", "list");
+        wvpInputFiles.put("inner", "file");
+        final var wvpIni = workflowVersionParameters.putObject("ini");
+        wvpIni.put("is", "dictionary");
+        wvpIni.put("key", "string");
+        wvpIni.put("value", "string");
+        final var wvom = workflowVersion.putObject("outputs").putObject("migration");
+        wvom.put("is", "list");
+        wvom.putObject("keys").put("fileSWID", "INTEGER");
+        wvom.putObject("outputs").put("fileMetadata", "file-with-labels");
+
+        try {
+          final var url = server.get().vidarrUrl();
+          if (url.isPresent()
+              && HTTP_CLIENT
+                      .send(
+                          HttpRequest.newBuilder(
+                                  url.get()
+                                      .resolve(
+                                          String.format(
+                                              "/api/workflow/%s/%s",
+                                              request.getWorkflow(), request.getWorkflowVersion())))
+                              .version(Version.HTTP_1_1)
+                              .POST(
+                                  BodyPublishers.ofString(
+                                      MAPPER.writeValueAsString(workflowVersion)))
+                              .build(),
+                          BodyHandlers.discarding())
+                      .statusCode()
+                  != 200) {
+            this.errors = List.of("Failed to create workflow");
+            return ActionState.FAILED;
+          }
+        } catch (IOException | InterruptedException e) {
+          e.printStackTrace();
+          this.errors = List.of(e.getMessage());
+          return ActionState.FAILED;
+        }
+      }
     }
+
+    final RunState.PerformResult result =
+        server
+            .get()
+            .vidarrUrl()
+            .map(
+                url -> {
+                  try {
+                    return state.perform(url, request);
+                  } catch (IOException | InterruptedException e) {
+                    e.printStackTrace();
+                    return new RunState.PerformResult(
+                        List.of(e.getMessage()), ActionState.UNKNOWN, state);
+                  }
+                })
+            .orElseGet(
+                () ->
+                    new RunState.PerformResult(
+                        List.of("Internal error: No Vidarr URL available"),
+                        ActionState.UNKNOWN,
+                        state));
+    this.errors = result.errors();
+    state = result.nextState();
+    return result.actionState();
   }
 
   @Override


### PR DESCRIPTION
* Allow polling Vidarr during migration action
  Only do the hard work once and then allow the migration action to keep polling Vidarr.
* Automatically register workflows during migration
  Rather than pre-registering the workflows, register them once as part of migration.
