### PR TITLE
Change Vidarr action names

### DIFF
--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
@@ -271,7 +271,7 @@ public class VidarrPlugin extends JsonPluginFile<Configuration> {
                                               + Parser.NAMESPACE_SEPARATOR
                                               + sanitise(
                                                   workflow.getName()
-                                                      + "_ "
+                                                      + "_v"
                                                       + workflow.getVersion()),
                                           String.format(
                                               "Workflow %s version %s from Vidarr instance %s on target %s.",


### PR DESCRIPTION
Vidarr workflows should have action names that are _workfow_ `_v` version, but
there was a typo.