### PR TITLE
Improve type error messages for algebraic data types

### DIFF
--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/types/Imyhat.java
@@ -283,6 +283,10 @@ public abstract class Imyhat {
       return AlgebraicValue.class;
     }
 
+    public Stream<String> members() {
+      return unions.keySet().stream();
+    }
+
     @Override
     public String name() {
       return unions.entrySet().stream()
@@ -297,6 +301,10 @@ public abstract class Imyhat {
                 return e.getKey() + " " + e.getValue().name();
               })
           .collect(Collectors.joining(" | "));
+    }
+
+    public Imyhat typeFor(String name) {
+      return unions.getOrDefault(name, Imyhat.BAD);
     }
 
     @Override


### PR DESCRIPTION
This allows peering inside algebraic data types to provide more insight into
what is wrong when there is a type mismatch.