### PR TITLE
Fix Vidarr error message for "missing" state

### DIFF
--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
@@ -68,6 +68,8 @@ public final class RunStateAttemptSubmit extends RunState {
           if (result instanceof SubmitWorkflowResponseSuccess) {
             return RunStateMonitor.create(
                 vidarrUrl, ((SubmitWorkflowResponseSuccess) result).getId());
+          } else if (result instanceof SubmitWorkflowResponseDryRun) {
+            return new PerformResult(List.of(), ActionState.ZOMBIE, new RunStateDead());
           } else {
             return new PerformResult(
                 List.of("Server said success but returned a failure response."),
@@ -91,8 +93,6 @@ public final class RunStateAttemptSubmit extends RunState {
             final var conflict = ((SubmitWorkflowResponseConflict) result);
             final var nextState = new RunStateConflicted(conflict.getIds());
             return new PerformResult(nextState.errors(), ActionState.HALP, nextState);
-          } else if (result instanceof SubmitWorkflowResponseDryRun) {
-            return new PerformResult(List.of(), ActionState.ZOMBIE, new RunStateDead());
           } else {
             return new PerformResult(
                 List.of("Server said failure but returned an unexpected response."),

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
@@ -86,7 +86,7 @@ public final class RunStateAttemptSubmit extends RunState {
           } else if (result instanceof SubmitWorkflowResponseMissingKeyVersions) {
             final var keyResult = ((SubmitWorkflowResponseMissingKeyVersions) result);
             final var nextState = new RunStateMissing(keyResult.getId(), keyResult.getKeys());
-            return new PerformResult(nextState.errors(), ActionState.FAILED, this);
+            return new PerformResult(nextState.errors(), ActionState.HALP, this);
           } else if (result instanceof SubmitWorkflowResponseConflict) {
             final var conflict = ((SubmitWorkflowResponseConflict) result);
             final var nextState = new RunStateConflicted(conflict.getIds());

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
@@ -21,12 +21,14 @@ final class RunStateMissing extends RunState {
     this.id = id;
     this.keys = keys;
     errors =
-        keys.stream()
-            .map(
-                k ->
-                    String.format(
-                        "LIMS key %s/%s does not have a version for %s. This is a design error in the olive.",
-                        k.getProvider(), k.getId(), id))
+        Stream.concat(
+                Stream.of("This workflow probably needs to be reprocessed."),
+                keys.stream()
+                    .map(
+                        k ->
+                            String.format(
+                                "LIMS key %s/%s does not have a version that overlaps with LIMS key in Vidarr workflow %s.",
+                                k.getProvider(), k.getId(), id)))
             .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
The message displayed was incorrect for the error returned by Vidarr. This
updates the error text to match the information communicated by Vidarr.