### PR TITLE
Fix automatic MIME types in guided meditations

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/InformationNodeDownload.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/InformationNodeDownload.java
@@ -26,7 +26,7 @@ public class InformationNodeDownload extends InformationNode {
         fileName.renderEcma(renderer),
         mimeType
             .map(m -> m.renderEcma(renderer))
-            .orElse(isJson ? "application/json" : "text/plain"),
+            .orElse(isJson ? "\"application/json\"" : "\"text/plain\""),
         contents.renderEcma(renderer));
   }
 


### PR DESCRIPTION
The guided meditation compiler will insert a default MIME type when none is
supplied. This fixes a bug where the default types were inserted as unquoted
strings, which JavaScript interpreted as division between two variable that do
not exist.