### PR TITLE
Fix alert query marshalling

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -1327,7 +1327,9 @@ public final class Server implements ServerConfig, ActionServices {
           t.sendResponseHeaders(200, 0);
           final var filters =
               handleJsonQueryParameter(
-                  AlertFilter[].class, getParameters(t).get("filters"), new AlertFilter[0]);
+                  ArrayNode.class,
+                  getParameters(t).get("filters"),
+                  RuntimeSupport.MAPPER.createArrayNode());
           try (var os = t.getResponseBody()) {
             new BasePage(this, false) {
               @Override


### PR DESCRIPTION
The query passed through the alert page is not in the `AlertFilter` format, and
so must not be demarshalled as such.