### PR TITLE
Prioritize QUEUED and INFLIGHT actions as they need to move quickly

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -1642,6 +1642,24 @@ public final class ActionProcessor
                                     .getSeconds()
                                 / 600)
                     .thenComparingInt(e -> e.getKey().priority()))
+            .sorted(
+                new Comparator<>() {
+                  @Override
+                  public int compare(Entry<Action, Information> o1, Entry<Action, Information> o2) {
+                    ActionState o1State = o1.getValue().lastState,
+                        o2State = o2.getValue().lastState;
+                    // Consider INFLIGHT and QUEUED to be Equal but greater than the rest
+                    if (o1State == o2State
+                        || (o1State == ActionState.INFLIGHT && o2State == ActionState.QUEUED)
+                        || (o1State == ActionState.QUEUED && o2State == ActionState.INFLIGHT))
+                      return 0;
+                    // At this point we know either o1State or o2State is one of the other ones
+                    if (o1State == ActionState.INFLIGHT || o1State == ActionState.QUEUED) return 1;
+                    if (o2State == ActionState.INFLIGHT || o2State == ActionState.QUEUED) return -1;
+                    // At this point both are of some other state
+                    return 0;
+                  }
+                })
             .limit(1000L * ACTION_PERFORM_THREADS - currentRunningActions.get())
             .collect(Collectors.toList());
     currentRunningActionsGauge.set(currentRunningActions.addAndGet(candidates.size()));


### PR DESCRIPTION
Once they've been sorted by time-since-last-check, further bucket by lastState - QUEUED and INFLIGHT get greater priority in order to reflect cromwell status better and set off downstream workflows faster. Previously the scheduler had a chance of only looking at UNKNOWN actions and never checking the real work getting done.

Java promises sorted() otherwise preserves internal order but idk if i trust it. I'm not sure if this undoes the previous sort instead of preserving it inside the two tiers i'm trying to build. 

This change is untested! I don't have a local environment with actual actions going through