### PR TITLE
Fix successful vidarr workflow runs becoming UNKNOWN

### DIFF
--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
@@ -22,7 +22,12 @@ public class RunStateMonitor extends RunState {
     // engine itself to fail.
     // This state leaves broken actions stuck in QUEUED. Check early for engine failure to ensure
     // correct ActionState.
-    if (response.getEnginePhase().equals("FAILED")) {
+    // If the workflow run is completed, then enginephase will be null, as enginephase belongs to
+    // the
+    // active_workflow_run record associated with the workflow_run, and the active_workflow_run
+    // record is removed
+    // when a workflow run is successful.
+    if (null != response.getEnginePhase() && response.getEnginePhase().equals("FAILED")) {
       return ActionState.FAILED;
     }
     if (response.getCompleted() != null) {


### PR DESCRIPTION
A NullPointerException was thrown in actionStatusForWorkflowRun when checking a workflow run's enginePhase. It is valid for enginePhase to be null - this happens when the active_workflow_run record is removed from the database, which happens when a workflow run is successful. Old code assumed this field would always contain a String.