### PR TITLE
Include detailed counts when running commands

### DIFF
--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -569,16 +569,21 @@ function createCallbackForActionCommand(
           },
         ],
       },
-      (count) => {
-        if (count == 0) {
+      (counts) => {
+        if (counts.ignored > 0) {
           dialog(() => [
             "This action is indifferent to your pleas. Maybe the action's internal state has changed? Try refreshing.",
             img("indifferent.gif"),
           ]);
-        } else if (count > 1) {
+        } else if (counts.executed > 1) {
           dialog(() => [
-            `The command executed on ${count} actions!!! This is awkward. The unique action IDs aren't unique!`,
+            `The command executed on ${counts.executed} actions!!! This is awkward. The unique action IDs aren't unique!`,
             img("ohno.gif"),
+          ]);
+        } else if (counts.executed == 0) {
+          dialog(() => [
+            "The action vanished before the command was executed.",
+            img("holtburn.gif"),
           ]);
         }
         reload();
@@ -621,13 +626,17 @@ function createCallbackForBulkCommand(
         command: command.command,
         filters: filters,
       },
-      (count) => {
+      (counts) => {
         butter(
           5000,
           { type: "icon", icon: command.icon },
           "The command ",
           { type: "i", contents: command.buttonText },
-          `executed on ${count} actions.`
+          counts.executed > 0 ? ` executed on ${counts.executed} actions` : "",
+          counts.purged > 0 ? ` (${counts.purged} of which were purged)` : "",
+          counts.executed > 0 && counts.ignored > 0 ? " and" : "",
+          counts.ignored > 0 ? ` was ignored by ${counts.ignored} actions` : "",
+          "."
         );
         reload();
       }

--- a/shesmu-server-ui/src/io.ts
+++ b/shesmu-server-ui/src/io.ts
@@ -96,7 +96,7 @@ export interface ShesmuRequestType {
 export interface ShesmuResponseType {
   "action-ids": string[];
   allalerts: PrometheusAlert[];
-  command: number;
+  command: { ignored: number; executed: number; purged: number };
   "compile-meditation": MeditationCompilationResponse;
   constant: ValueResponse;
   count: number;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/CommandStatistics.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/CommandStatistics.java
@@ -1,0 +1,25 @@
+package ca.on.oicr.gsi.shesmu.server;
+
+public final class CommandStatistics {
+  private final long executed;
+  private final long ignored;
+  private final long purged;
+
+  public CommandStatistics(long executed, long ignored, long purged) {
+    this.executed = executed;
+    this.ignored = ignored;
+    this.purged = purged;
+  }
+
+  public long getExecuted() {
+    return executed;
+  }
+
+  public long getIgnored() {
+    return ignored;
+  }
+
+  public long getPurged() {
+    return purged;
+  }
+}


### PR DESCRIPTION
When a command is executed, the server counts the number of actions that
responded to the command. This can be misleading since actions can
ignore the command. Additionally, some commands can lead to the action
purging, so the count of actions after refreshing will not make much
sense.

This changes the interface to report the number of actions matching the
search that did and did not respond to the command and the subset of
matching actions that want to be purged.