### PR TITLE
Fix compilation errors with newer versions of TypeScript

### DIFF
--- a/shesmu-server-ui/tsconfig.json
+++ b/shesmu-server-ui/tsconfig.json
@@ -21,6 +21,7 @@
     "target": "es2020",
     "typeRoots": [
       "./types"
-    ]
+    ],
+    "useUnknownInCatchVariables": false
   }
 }


### PR DESCRIPTION
The GitHub release Maven Package workflow run now fails because it downloads the latest version of TypeScript. Since TypeScript 4.4, errors are automatically cast as unknown, so you can't do anything with them without type checking so a few cases in shesmu-server-ui were failing in the catch error step. `"strict": true`, sets `useUnknownInCatchVariables` to true since TS 4.4, and then `"useUnknownInCatchVariables": false`, overrides that and sets it back to false.