### PR TITLE
Fix confusing errors when `?` fails for other reasons

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionCompilerServices.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionCompilerServices.java
@@ -4,9 +4,13 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.FunctionDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 public interface ExpressionCompilerServices {
-  default Optional<TargetWithContext> captureOptional(ExpressionNode expression) {
+  default Optional<TargetWithContext> captureOptional(
+      ExpressionNode expression, int line, int column, Consumer<String> errorHandler) {
+    errorHandler.accept(
+        String.format("%d:%d: Optional operation “?” must be inside of ``.", line, column));
     return Optional.empty();
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalUnbox.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/ExpressionNodeOptionalUnbox.java
@@ -56,13 +56,12 @@ public class ExpressionNodeOptionalUnbox extends ExpressionNode {
   @Override
   public boolean resolveDefinitions(
       ExpressionCompilerServices expressionCompilerServices, Consumer<String> errorHandler) {
-    final var candidate = expressionCompilerServices.captureOptional(expression);
+    final var candidate =
+        expressionCompilerServices.captureOptional(expression, line(), column(), errorHandler);
     if (candidate.isPresent()) {
       target = candidate.get();
       return true;
     } else {
-      errorHandler.accept(
-          String.format("%d:%d: Optional operation “?” must be inside of ``.", line(), column()));
       return false;
     }
   }


### PR DESCRIPTION
General failures of expressions in `?` expressions can lead to it complaining
about the optional type or context, even though that was not the source of the
error. This move the error handling to avoid suprious errors.