### PR TITLE
Revert "Track dumper creation so that they can be stopped and finalized"

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Revert "Track dumper creation so that they can be stopped and finalized." (See: GP-3243)
+
 # [1.18.4] - 2022-03-18T18:47+00:00
 
 * Fix confusing errors when ? fails for other reasons1~

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
@@ -299,11 +299,6 @@ public abstract class RootBuilder {
 
   public final void createDumper(
       String dumper, Renderer renderer, List<Pair<String, Imyhat>> columns) {
-    final var fieldName = "dump$" + dumper;
-    classVisitor
-        .visitField(Opcodes.ACC_PRIVATE, fieldName, A_DUMPER_TYPE.getDescriptor(), null, null)
-        .visitEnd();
-    runMethod.loadThis();
     renderer.emitNamed("Olive Services");
     renderer.methodGen().push(dumper);
     renderer.methodGen().push(columns.size());
@@ -325,10 +320,6 @@ public abstract class RootBuilder {
       renderer.methodGen().arrayStore(A_IMYHAT_TYPE);
     }
     renderer.methodGen().invokeInterface(A_OLIVE_SERVICES_TYPE, METHOD_OLIVE_SERVICES__FIND_DUMPER);
-    runMethod.putField(selfType, fieldName, A_DUMPER_TYPE);
-    runMethod.loadThis();
-    runMethod.getField(selfType, fieldName, A_DUMPER_TYPE);
-    dumpers.add(fieldName);
   }
 
   public void defineConstant(String name, Type type, Consumer<GeneratorAdapter> loader) {


### PR DESCRIPTION
This reverts commit a3ccb1dbc0b99dc1cddcfdc1d725377655bb1a89.

This work will be completed in https://github.com/oicr-gsi/shesmu/tree/GP-3243