### PR TITLE
Fix bug where dumpers are not cleaned up

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LambdaBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LambdaBuilder.java
@@ -47,6 +47,7 @@ public final class LambdaBuilder {
   private static final Type A_FUNCTION_TYPE = Type.getType(Function.class);
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
   private static final Type A_PREDICATE_TYPE = Type.getType(Predicate.class);
+  private static final Type A_RUNNABLE_TYPE = Type.getType(Runnable.class);
   private static final Type A_SUPPLIER_TYPE = Type.getType(Supplier.class);
   private static final Type A_TO_DOUBLE_FUNCTION_TYPE = Type.getType(ToDoubleFunction.class);
   private static final Type A_TO_INT_FUNCTION_TYPE = Type.getType(ToIntFunction.class);
@@ -59,6 +60,33 @@ public final class LambdaBuilder {
           "metafactory",
           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
           false);
+  public static final LambdaType RUNNABLE =
+      new LambdaType() {
+        @Override
+        public Type interfaceType() {
+          return A_RUNNABLE_TYPE;
+        }
+
+        @Override
+        public String methodName() {
+          return "run";
+        }
+
+        @Override
+        public Stream<Type> parameterTypes(AccessMode accessMode) {
+          return Stream.empty();
+        }
+
+        @Override
+        public int parameters() {
+          return 0;
+        }
+
+        @Override
+        public Type returnType(AccessMode accessMode) {
+          return VOID_TYPE;
+        }
+      };
 
   private static void assertNonPrimitive(Type type) {
     if (type.getSort() != Type.OBJECT && type.getSort() != Type.ARRAY) {
@@ -1121,6 +1149,15 @@ public final class LambdaBuilder {
             Type.getMethodType(
                 lambda.returnType(AccessMode.BOXED),
                 lambda.parameterTypes(AccessMode.BOXED).toArray(Type[]::new)));
+  }
+
+  /**
+   * Create a new renderer (method generator) for the body of the lambda that does not have stream
+   * access.
+   */
+  public Renderer renderer() {
+    return new RendererNoStream(
+        owner, methodGen(), RootBuilder.proxyCaptured(0, capturedVariables), null);
   }
 
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeMonitor.java
@@ -67,6 +67,11 @@ public class OliveClauseNodeMonitor extends OliveClauseNode implements RejectNod
   }
 
   @Override
+  public void renderOnClose(Renderer closeRenderer) {
+    // Do nothing
+  }
+
+  @Override
   public int column() {
     return column;
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeReject.java
@@ -17,6 +17,7 @@ import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
@@ -101,33 +102,31 @@ public class OliveClauseNodeReject extends OliveClauseNode {
     final Set<String> freeVariables = new HashSet<>();
     expression.collectFreeVariables(freeVariables, Flavour::needsCapture);
     handlers.forEach(handler -> handler.collectFreeVariables(freeVariables));
-    final var renderer =
-        oliveBuilder.filter(
-            line,
-            column,
-            Stream.of(
-                    Stream.of(
-                        new LoadableValue() {
+    final var captures =
+        Stream.of(
+                Stream.of(
+                    new LoadableValue() {
 
-                          @Override
-                          public void accept(Renderer renderer) {
-                            oliveBuilder.loadOliveServices(renderer.methodGen());
-                          }
+                      @Override
+                      public void accept(Renderer renderer) {
+                        oliveBuilder.loadOliveServices(renderer.methodGen());
+                      }
 
-                          @Override
-                          public String name() {
-                            return "Olive Services";
-                          }
+                      @Override
+                      public String name() {
+                        return "Olive Services";
+                      }
 
-                          @Override
-                          public Type type() {
-                            return A_OLIVE_SERVICES_TYPE;
-                          }
-                        }),
-                    handlers.stream().flatMap(handler -> handler.requiredCaptures(builder)),
-                    oliveBuilder.loadableValues().filter(v -> freeVariables.contains(v.name())))
-                .flatMap(Function.identity())
-                .toArray(LoadableValue[]::new));
+                      @Override
+                      public Type type() {
+                        return A_OLIVE_SERVICES_TYPE;
+                      }
+                    }),
+                handlers.stream().flatMap(handler -> handler.requiredCaptures(builder)),
+                oliveBuilder.loadableValues().filter(v -> freeVariables.contains(v.name())))
+            .flatMap(Function.identity())
+            .toArray(LoadableValue[]::new);
+    final var renderer = oliveBuilder.filter(line, column, captures);
 
     renderer.methodGen().visitCode();
     expression.render(renderer);
@@ -141,6 +140,13 @@ public class OliveClauseNodeReject extends OliveClauseNode {
     renderer.methodGen().returnValue();
     renderer.methodGen().visitMaxs(0, 0);
     renderer.methodGen().visitEnd();
+
+    final var closeRenderer = oliveBuilder.onClose("Reject", line, column, captures);
+    closeRenderer.methodGen().visitCode();
+    handlers.forEach(handler -> handler.renderOnClose(closeRenderer));
+    closeRenderer.methodGen().visitInsn(Opcodes.RETURN);
+    closeRenderer.methodGen().visitMaxs(0, 0);
+    closeRenderer.methodGen().visitEnd();
 
     oliveBuilder.measureFlow(line, column);
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveNodeAlert.java
@@ -144,6 +144,11 @@ public class OliveNodeAlert extends OliveNodeWithClauses implements RejectNode {
   }
 
   @Override
+  public void renderOnClose(Renderer closeRenderer) {
+    // Do nothing
+  }
+
+  @Override
   public void collectPluginsExtra(Set<Path> pluginFileNames) {
     labels.forEach(arg -> arg.collectPlugins(pluginFileNames));
     annotations.forEach(arg -> arg.collectPlugins(pluginFileNames));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RejectNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RejectNode.java
@@ -10,6 +10,8 @@ public interface RejectNode {
 
   void collectPlugins(Set<Path> pluginFileNames);
 
+  void renderOnClose(Renderer closeRenderer);
+
   void render(RootBuilder builder, Renderer renderer);
 
   Stream<LoadableValue> requiredCaptures(RootBuilder builder);

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/RunTest.java
@@ -89,10 +89,12 @@ public class RunTest {
       if (columns.length != types.length) {
         bad++;
       }
+      // We assume this test is bad unless it cleans up the dumper, as is required by that API.
+      bad++;
       return new Dumper() {
         @Override
         public void stop() {
-          // Do nothing.
+          bad--;
         }
 
         @Override

--- a/shesmu-server/src/test/resources/run/define-complex-dump.shesmu
+++ b/shesmu-server/src/test/resources/run/define-complex-dump.shesmu
@@ -1,0 +1,14 @@
+Version 1;
+Input test;
+
+# We export this, but the unit testing framework doesn't have a way to consume
+# it; however, it does exercise all the bytecode generation pathways involved
+# in exporting.
+Export Define foo({string, integer} s, [string] projects)
+ Dump All To foo
+ Where project In projects || project == s[0] && ActionName == `"ok"`;
+
+Olive
+ foo({"a", 3}, ["the_foo_study"])
+ Dump All To bar
+ Run ok With ok = True;

--- a/shesmu-server/src/test/resources/run/define-reject.shesmu
+++ b/shesmu-server/src/test/resources/run/define-reject.shesmu
@@ -1,0 +1,19 @@
+Version 1;
+Input test;
+
+# We export this, but the unit testing framework doesn't have a way to consume
+# it; however, it does exercise all the bytecode generation pathways involved
+# in exporting.
+Export Define foo([string] projects)
+ Reject !(project In projects)
+   OnReject
+     Dump All To foo
+ Resume;
+
+Olive
+ foo(["the_foo_study"])
+ Require p = `project`
+   OnReject
+     Dump All To foo
+ Resume
+ Run ok With ok = p == "the_foo_study";


### PR DESCRIPTION
There was incorrect code in `BaseOliveBuilder` for cleaning up dumpers that
tried to use fields. Because dumpers can be connected to `Define` olives, the
dumper can be invoked from shared context and should not change instance
fields. To solve this problem, this creates `Stream.onClose` handlders that
clean up any created dumpers. To accomplish this:

1. Remove all the dumper logic from `RootBuilder`.
2. Create a lambda builder for `Runnable`.
3. Add an `onClose` code generator in `BaseOliveBuilder`.
4. Expand `RejectNode` to have code generation for both the work and the
   cleanup (`onClose`) methods.
5. Extend `OliveClauseNodeBaseDump` to call `Dumper.stop` in the `onClose`
   handler.
6. Modify the testing framework to ensure that dumper cleanup is performed.