### PR TITLE
added Maven config to fix plugin-niassa build

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings ./.mvn/project-settings.xml

--- a/.mvn/project-settings.xml
+++ b/.mvn/project-settings.xml
@@ -1,0 +1,36 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>maven-restlet-insecure</id>
+      <mirrorOf>maven-restlet</mirrorOf>
+      <url>http://maven.restlet.org</url>
+    </mirror>
+    <mirror>
+      <id>seqware-insecure</id>
+      <mirrorOf>seqware.sourceforge.net</mirrorOf>
+      <url>http://artifacts.oicr.on.ca/artifactory/seqware-release</url>
+    </mirror>
+      <mirror>
+        <id>seqware-snapshots-insecure</id>
+        <mirrorOf>snapshot.seqware.sourceforge.net</mirrorOf>
+        <url>http://artifacts.oicr.on.ca/artifactory/seqware-snapshot</url>
+    </mirror>
+      <mirror>
+        <id>org.codehaus.plexus-insecure</id>
+        <mirrorOf>org.codehaus.plexus</mirrorOf>
+        <url>http://repo1.maven.org/maven2/org/codehaus/plexus</url>
+    </mirror>
+    <mirror>
+      <id>jcenter-insecure</id>
+      <mirrorOf>jcenter</mirrorOf>
+      <url>http://jcenter.bintray.com</url>
+    </mirror>
+    <mirror>
+      <id>netbeans-mirror</id>
+      <mirrorOf>netbeans</mirrorOf>
+      <url>https://netbeans.apidesign.org/maven2</url>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
With this added config, anyone should be able to build without having any dependencies previously cached, and without polluting their global config to allow the HTTP repos

JIRA Ticket: n/a

- [ ] Updates Changelog (n/a)
- [ ] Updates developer documentation (n/a)
