### PR TITLE
[GP-3379] Add gauges to track last start and end of cache refresh

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Adds metrics for cache refresh start and end times
+
 # [1.19.3] - 2022-06-22T19:04+00:00
 
 * Display `cerberus_fp` `workflow_version` even when workflow version contains four parts (3 for the version and one for the Niassa workflow accession)

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/BaseRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/BaseRecord.java
@@ -62,11 +62,15 @@ public abstract class BaseRecord<V, S> implements Record<V> {
     }
     if (doRefresh) {
       try (var timer = refreshLatency.start(fetcher.owner().name())) {
+        refreshStartTime.labels(fetcher.owner().name()).setToCurrentTime();
         S result = update(state, fetchTime);
         if (result != null) {
           synchronized (this) {
             state = result;
             fetchTime = Instant.now();
+            refreshEndTime
+                .labels(fetcher.owner().name())
+                .setToCurrentTime(); // TODO why can't i use fetchTime
             initialState = false;
           }
           shouldThrow = false;

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/BaseRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/BaseRecord.java
@@ -70,7 +70,7 @@ public abstract class BaseRecord<V, S> implements Record<V> {
             fetchTime = Instant.now();
             refreshEndTime
                 .labels(fetcher.owner().name())
-                .setToCurrentTime(); // TODO why can't i use fetchTime
+                .setToCurrentTime(); // Can't use the Instant we just created unfortunately
             initialState = false;
           }
           shouldThrow = false;

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/Record.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/Record.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.shesmu.plugin.cache;
 
 import ca.on.oicr.gsi.prometheus.LatencyHistogram;
 import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 import java.time.Instant;
 
 /**
@@ -10,6 +11,18 @@ import java.time.Instant;
  * @param <V> the type that can be retrieved from a cache
  */
 public interface Record<V> {
+  Gauge refreshStartTime =
+      Gauge.build(
+              "shesmu_cache_refresh_start_timestamp",
+              "The UNIX time when a cache refresh was last started.")
+          .labelNames("name")
+          .register();
+  Gauge refreshEndTime =
+      Gauge.build(
+              "shesmu_cache_refresh_end_timestamp",
+              "The UNIX time when a cache refresh was finished.")
+          .labelNames("name")
+          .register();
   LatencyHistogram refreshLatency =
       new LatencyHistogram(
           "shesmu_cache_refresh_latency",


### PR DESCRIPTION
JIRA Ticket: GP-3379

These metrics have been served on shesmu-dev for about a day, they are available in prometheus and grafana, please let me know if these are useful

- [X] Updates Changelog
- [N/A] Updates developer documentation
