### PR TITLE
Include typescript compilation in maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>tsc-build</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>tsc</executable>
+              <arguments>
+                <argument>-p</argument>
+                <argument>shesmu-server-ui</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
JIRA Ticket: GP-3477

This executes, but says:
`shesmu-server-ui/src/actionfilters.ts(792,37): error TS2571: Object is of type 'unknown'.
shesmu-server-ui/src/guided_meditations.ts(403,12): error TS2571: Object is of type 'unknown'.
shesmu-server-ui/src/guided_meditations.ts(648,61): error TS2571: Object is of type 'unknown'.
shesmu-server-ui/src/guided_meditations.ts(1012,29): error TS2571: Object is of type 'unknown'.
shesmu-server-ui/src/yogastudio.ts(80,22): error TS2571: Object is of type 'unknown'.
shesmu-server-ui/types/resize-obeserver-browser/index.d.ts(47,14): error TS2687: All declarations of 'devicePixelContentBoxSize' must have identical modifiers.
shesmu-server-ui/types/resize-obeserver-browser/index.d.ts(47,14): error TS2717: Subsequent property declarations must have the same type.  Property 'devicePixelContentBoxSize' must be of type 'readonly ResizeObserverSize[]', but here has type 'readonly ResizeObserverSize[] | undefined'.
../../../../usr/local/lib/node_modules/typescript/lib/lib.dom.d.ts(11244,14): error TS2687: All declarations of 'devicePixelContentBoxSize' must have identical modifiers.
`
I don't know why. I didn't change the front end code at all.
Could someone more familiar with typescript explain?

- [ ] Updates Changelog
- [ ] Updates developer documentation
