### PR TITLE
Fix using signatures after `Flatten` and `Require`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Update Nabu plugin to use version 3 API
+* Fix bad bytecode using signatures after `Flatten` or `Require`
 
 # [1.21.0] - 2022-11-08T13:26+00:00
 

--- a/shesmu-server/src/test/resources/run/sign-flatten.shesmu
+++ b/shesmu-server/src/test/resources/run/sign-flatten.shesmu
@@ -1,0 +1,8 @@
+Version 1;
+Input test;
+
+Olive
+    Flatten p In [project]
+  Let
+    test = {signature = std::signature::sha1; p}
+  Run ok With ok = test.p == "the_foo_study";


### PR DESCRIPTION
Changes incorrect field types for dynamic signatures that causes a missing field when the correct `GETFIELD` bytecode is executed.

JIRA Ticket: 

- [X] Updates Changelog
- [X] Updates developer documentation
