### PR TITLE
Add `Paste` input type to Guided Meditations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 * Add a gauge to monitor the number of items sent to a refiller
 * Runscanner -> 1.15.0
+* Add a _paste_ input source to guided meditations to extract matching strings
 
 # [1.22.0] - 2023-01-04T19:19+00:00
 

--- a/guided-meditations.md
+++ b/guided-meditations.md
@@ -244,6 +244,12 @@ The selected value will be assigned to _name_ in subsequent steps.  _labelexpr_
 is text display elements to show to the left of the input widget. If _values_
 is an empty list, the meditation will be stopped.
 
+- _name_ `= Paste /`_regex_`/ With Label` _labelexpr_
+Creates a large text area where a user can paste text and any parts of matching
+_regex_ will be extracted as a list of strings. This is meant to allow pasting
+lists of identifiers from chat, email, tickets, other applications and
+extracting easily recognized identifiers.
+
 - _name_ `= Select` _optionvalue_ `As` _optionlabel_ ... `With Label` _labelexpr_
 Creates a drop down list. The _optionlabel_ is display text that will be shown.
 There is no restriction on the type of _optionvalue_, though they all must be
@@ -435,6 +441,13 @@ Start
       Then
         Download "Hello, {name}! Does this meet your expectations"
           To "example.txt" MimeType "text/plain"
+        Stop
+    When "I have so many things"
+      Form
+        things = Paste /[A-Z]\d{3,}/ With Label "Can you list all the things?"
+      Then
+        RepeatFor thing In things: Table
+            Column "A Thing" "Try not to let {thing} bother you."
         Stop
     When "I yearn for knowledge"
       Simulate

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -4627,6 +4627,16 @@ function treeSplitPaths(
     });
   return indented(children.concat(leaves));
 }
+/**
+ * Unordered list of items
+ */
+export function unorderedList(...contents: DisplayElement[]): UIElement {
+  const element = createUiFromTag(
+    "ul",
+    contents.map((item) => createUiFromTag("li", item))
+  );
+  return element;
+}
 // Preload images
 new Image().src = "press.svg";
 new Image().src = "dead.svg";

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNode.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNode.java
@@ -1,5 +1,8 @@
 package ca.on.oicr.gsi.shesmu.compiler;
 
+import static ca.on.oicr.gsi.shesmu.compiler.ExpressionNode.REGEX;
+import static ca.on.oicr.gsi.shesmu.compiler.ExpressionNode.regexParser;
+
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
 import ca.on.oicr.gsi.shesmu.plugin.Parser;
@@ -76,6 +79,19 @@ public abstract class FormNode implements Target {
                   .whitespace();
           if (result.isGood()) {
             o.accept((label, name) -> new FormNodeSelect(label, name, options.get()));
+          }
+          return result;
+        });
+    FORM_TYPE.addKeyword(
+        "Paste",
+        (p, o) -> {
+          final var regex = new AtomicReference<Pair<String, Integer>>();
+          final var result =
+              p.whitespace().regex(REGEX, regexParser(regex), "Regular expression.").whitespace();
+          if (result.isGood()) {
+            o.accept(
+                (label, name) ->
+                    new FormNodePaste(label, name, regex.get().first(), regex.get().second()));
           }
           return result;
         });

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNodePaste.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FormNodePaste.java
@@ -1,0 +1,71 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import ca.on.oicr.gsi.shesmu.compiler.definitions.DefinitionRepository;
+import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public final class FormNodePaste extends FormNode {
+  private final String name;
+  private final int flags;
+  private final String regex;
+
+  public FormNodePaste(List<DisplayNode> label, String name, String regex, int flags) {
+    this.label = label;
+    this.name = name;
+    this.regex = regex;
+    this.flags = flags;
+  }
+
+  private final List<DisplayNode> label;
+
+  @Override
+  public Flavour flavour() {
+    return Flavour.LAMBDA;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  public void read() {
+    // Don't really care
+  }
+
+  public String renderEcma(EcmaScriptRenderer renderer) {
+    // String.prototype.matchAll requires a global flag, so we always set it
+    // https://tc39.es/ecma262/#sec-string.prototype.matchall
+    return String.format(
+        "{label: %s, type: \"paste\", regex: /%s/g%s}",
+        label.stream().map(l -> l.renderEcma(renderer)).collect(Collectors.joining(", ", "[", "]")),
+        regex,
+        EcmaScriptRenderer.regexFlagsToString(flags));
+  }
+
+  public boolean resolve(NameDefinitions defs, Consumer<String> errorHandler) {
+    return label.stream().filter(l -> l.resolve(defs, errorHandler)).count() == label.size();
+  }
+
+  public boolean resolveDefinitions(
+      ExpressionCompilerServices expressionCompilerServices,
+      DefinitionRepository nativeDefinitions,
+      Consumer<String> errorHandler) {
+    return label.stream()
+            .filter(
+                l ->
+                    l.resolveDefinitions(
+                        expressionCompilerServices, nativeDefinitions, errorHandler))
+            .count()
+        == label.size();
+  }
+
+  public Imyhat type() {
+    return Imyhat.STRING.asList();
+  }
+
+  public boolean typeCheck(Consumer<String> errorHandler) {
+    return label.stream().filter(l -> l.typeCheck(errorHandler)).count() == label.size();
+  }
+}


### PR DESCRIPTION
Create a new input type for guided meditations that ingests a block of text and extracts matching substrings using a regular expression. This is intended to extract identifiers from chat/email.

JIRA Ticket: 

- [x] Updates Changelog
- [X] Updates developer documentation
