### PR TITLE
Remove vidarr-workflow-run ID tag from action cards

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,8 @@
 * Add a gauge to monitor the number of items sent to a refiller
 * Runscanner -> 1.15.1
 * Add a _paste_ input source to guided meditations to extract matching strings
-	* Add functions for returning list of names of `Accredited` and `Accredited with Clinical Report` projects from Pinery plugin
+* Add functions for returning list of names of `Accredited` and `Accredited with Clinical Report` projects from Pinery plugin
+* Remove `vidarr-workflow-run:<id>` tag from action cards
 
 # [1.22.0] - 2023-01-04T19:19+00:00
 

--- a/ops-guide.md
+++ b/ops-guide.md
@@ -321,8 +321,6 @@ The Vidarr actions also generates some useful tags:
 - `vidarr-target:`_name_: The _target_ on the Vidarr instance.
 - `vidarr-workflow:`_name_[`/`_version_`]: The workflow that this action will
   run, both with and without the version.
-- `vidarr-workflow-run:`_id_: The Vidarr identifier for the matched workflow
-  run.
 - `vidarr-state:`[`active`|`attempt`|`conflict`|`dead`|`finished`|`missing`]:
 	The action uses a state machine while its communicating with Vidarr. This is
   the current state of that machine.

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateConflicted.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateConflicted.java
@@ -60,8 +60,7 @@ final class RunStateConflicted extends RunState {
 
   @Override
   public Stream<String> tags() {
-    return Stream.concat(
-        Stream.of("vidarr-state:conflict"), ids.stream().map("vidarr-workflow-run:"::concat));
+    return Stream.of("vidarr-state:conflict");
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
@@ -68,7 +68,7 @@ final class RunStateMissing extends RunState {
 
   @Override
   public Stream<String> tags() {
-    return Stream.of("vidarr-workflow-run:" + id, "vidarr-state:missing");
+    return Stream.of("vidarr-state:missing");
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
@@ -144,7 +144,6 @@ final class RunStateMonitor extends RunState {
   @Override
   public Stream<String> tags() {
     return Stream.of(
-        "vidarr-workflow-run:" + status.getId(),
         status.getCompleted() == null ? "vidarr-state:active" : "vidarr-state:finished");
   }
 


### PR DESCRIPTION
The high cardinality of this tag was causing pipeline leads' browsers to freeze up and they are not using this tag

JIRA Ticket: GP-3757

- [x] Updates Changelog
- [x] Updates developer documentation
