### PR TITLE
Redesign input cache population

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * Fix OpenAPI schema
 * Fix Basic filter view saying 'Matches' for negated regex matching
 * Fix GitHub Pages build by replacing grafana-datasource logo.svg with the original file
+* Redesign input format cache
 
 # [1.23.0] - 2023-02-15T19:54+00:00
 


### PR DESCRIPTION
Change the way that the required input formats are extracted and placed in cache for the olives. The goal of this is to prevent an olive from running when its input was not cached.

- [X] Updates Changelog
- [X] Updates developer documentation
