### PR TITLE
Add Prometheus counter for simulation staleness

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 * Fix Basic filter view saying 'Matches' for negated regex matching
 * Fix GitHub Pages build by replacing grafana-datasource logo.svg with the original file
 * Redesign input format cache
+* Export simulation cache staleness count requests
 
 # [1.23.0] - 2023-02-15T19:54+00:00
 


### PR DESCRIPTION
Counts the number of simulation requests that request live (refreshed) or stale (not refreshed).

JIRA Ticket: 

- [X] Updates Changelog
- [X] Updates developer documentation
