### PR TITLE
Create new SFTP `stat` function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Replace SFTP file information functions with single `stat` function
+
 # [1.24.0] - 2023-04-18T18:08+00:00
 
 * Fix OpenAPI schema


### PR DESCRIPTION
This replaces the SFTP `exists`, `modified_time`, and `size` functions with a single `stat` function that gracefully handles files which don't exist or can't be accessed due to permission errors.

Additionally, when the file is available, it will provide more information (access time, permissions, mode, and type), and, in the case of symbolic links, provide resolve the target path..

- [X] Updates Changelog
- [X] Updates developer documentation
