### PR TITLE
Improve simuation UI when allowing unused variables

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix GitHub release workflow
+* Make simulation more clear when undeclared variables are allowed
 
 # [1.25.0] - 2023-05-16T17:32+00:00
 

--- a/shesmu-server-ui/src/simulation.ts
+++ b/shesmu-server-ui/src/simulation.ts
@@ -1001,7 +1001,10 @@ export function initialiseSimulationDashboard(
       }
       return {
         tabs: renderResponse(response),
-        activate: response?.errors.length === 0,
+        activate:
+          response != null &&
+          response.bytecode != null &&
+          !response.exceptionThrown,
       };
     }
   );


### PR DESCRIPTION
Causes the output tabs to be activated when a simulation has unused variables and it is permitted. Since the unused variable declarations always produce errors, the current check did not change focus to the output tabs even when output was generated.

JIRA Ticket: N/A

- [X] Updates Changelog
- [ ] Updates developer documentation
