### PR TITLE
Add case_archive input format

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * Fix GitHub release workflow
 * Make simulation more clear when undeclared variables are allowed
 * Update README files with new requirements, clarifications about plugin-gsi-common
+* Add Nabu `case_archive` input format
 
 # [1.25.0] - 2023-05-16T17:32+00:00
 

--- a/plugin-nabu/README.md
+++ b/plugin-nabu/README.md
@@ -1,11 +1,22 @@
 # Nabu
 [Nabu](https://github.com/oicr-gsi/nabu) is a web application which tracks the QC
-status of files.
-The Nabu plugin for Shesmu can set Nabu up as a Shesmu input source.
+status of files, as well as the archive status/progress for cases.
+The Nabu plugin for Shesmu provides Nabu data for file QCs (`nabu` input source)
+and case archive status (`case_archive` input source).
 
-The Nabu API matches Shemsu's remote JSON source, so `myserver.nabu-remote` can be set up as follows:
+The input sources can be set up as follows:
 
+* `nabu` input format: create a `shesmuserver.nabu-remote` file with the following contents:
+   ```
     {
-      "url": "http://myserver:3000/fileqcs-only",
+      "url": "http://nabu.server/fileqcs-only",
       "ttl":30
     }
+   ```
+* `case_archive` input format: create a `shesmuserver.case_archive-remote` file with the following contents:
+   ```
+    {
+      "url": "http://nabu.server/cases",
+      "ttl":30
+    }
+   ```

--- a/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveFormatDefinition.java
+++ b/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveFormatDefinition.java
@@ -1,0 +1,12 @@
+package ca.on.oicr.gsi.shesmu.nabu;
+
+import ca.on.oicr.gsi.shesmu.plugin.input.InputFormat;
+import org.kohsuke.MetaInfServices;
+
+@MetaInfServices
+public class NabuCaseArchiveFormatDefinition extends InputFormat {
+
+  public NabuCaseArchiveFormatDefinition() {
+    super("case_archive", NabuCaseArchiveValue.class);
+  }
+}

--- a/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveValue.java
+++ b/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveValue.java
@@ -1,0 +1,101 @@
+package ca.on.oicr.gsi.shesmu.nabu;
+
+import ca.on.oicr.gsi.shesmu.plugin.input.ShesmuVariable;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+
+public class NabuCaseArchiveValue {
+  private final Optional<Instant> caseFilesUnloaded;
+  private final String caseIdentifier;
+  private final Optional<String> commvaultBackupJobId;
+  private final Instant created;
+  private final Optional<Instant> filesCopiedToOffsiteArchiveStagingDir;
+  private final Optional<Instant> filesLoadedIntoVidarrArchival;
+  private final Set<String> limsIds;
+  private final Instant modified;
+  private final long requisitionId;
+  private final Set<String> workflowRunIdsForOffsiteArchive;
+  private final Optional<Set<String>> workflowRunIdsForVidarrArchival;
+
+  public NabuCaseArchiveValue(
+      Optional<Instant> caseFilesUnloaded,
+      String caseIdentifier,
+      Optional<String> commvaultBackupJobId,
+      Instant created,
+      Optional<Instant> filesCopiedToOffsiteArchiveStagingDir,
+      Optional<Instant> filesLoadedIntoVidarrArchival,
+      Set<String> limsIds,
+      Instant modified,
+      long requisitionId,
+      Set<String> workflowRunIdsForOffsiteArchive,
+      Optional<Set<String>> workflowRunIdsForVidarrArchival) {
+    super();
+    this.caseFilesUnloaded = caseFilesUnloaded;
+    this.caseIdentifier = caseIdentifier;
+    this.commvaultBackupJobId = commvaultBackupJobId;
+    this.created = created;
+    this.filesCopiedToOffsiteArchiveStagingDir = filesCopiedToOffsiteArchiveStagingDir;
+    this.filesLoadedIntoVidarrArchival = filesLoadedIntoVidarrArchival;
+    this.limsIds = limsIds;
+    this.modified = modified;
+    this.requisitionId = requisitionId;
+    this.workflowRunIdsForOffsiteArchive = workflowRunIdsForOffsiteArchive;
+    this.workflowRunIdsForVidarrArchival = workflowRunIdsForVidarrArchival;
+  }
+
+  @ShesmuVariable
+  public Optional<Instant> caseFilesUnloaded() {
+    return caseFilesUnloaded;
+  }
+
+  @ShesmuVariable
+  public String caseIdentifier() {
+    return caseIdentifier;
+  }
+
+  @ShesmuVariable
+  public Optional<String> commvaultBackupJobId() {
+    return commvaultBackupJobId;
+  }
+
+  @ShesmuVariable
+  public Instant created() {
+    return created;
+  }
+
+  @ShesmuVariable
+  public Optional<Instant> filesCopiedToOffsiteArchiveStagingDir() {
+    return filesCopiedToOffsiteArchiveStagingDir;
+  }
+
+  @ShesmuVariable
+  public Optional<Instant> filesLoadedIntoVidarrArchival() {
+    return filesLoadedIntoVidarrArchival;
+  }
+
+  @ShesmuVariable
+  public Set<String> limsIds() {
+    return limsIds;
+  }
+
+  @ShesmuVariable
+  public Instant modified() {
+    return modified;
+  }
+
+  @ShesmuVariable
+  public long requisitionId() {
+    return requisitionId;
+  }
+
+  @ShesmuVariable
+  public Set<String> workflowRunIdsForOffsiteArchive() {
+    return workflowRunIdsForOffsiteArchive;
+  }
+
+  @ShesmuVariable
+  public Optional<Set<String>> workflowRunIdsForVidarrArchival() {
+    return workflowRunIdsForVidarrArchival;
+  }
+}


### PR DESCRIPTION
JIRA Ticket: GP-3994

- [x] Updates Changelog
- [x] Updates developer documentation

I'm not super attached to the `Nabu` prefix for `NabuCaseArchiveFormatDefinition`, and could certainly remove that if you think that would be clearer.

Can test this out against nabu-dev by creating a `infrastructure/shesmu/local/local.case_archive-remote` file with:
```
  { "url": "https://nabu-dev.gsi.oicr.on.ca/cases", "ttl": 30 } 
```