### PR TITLE
Fix multiple `Join`s causing bad bytecode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix compilation error with multiple `Join` clauses
+
 # [1.26.1] - 2023-09-07T16:53+00:00
 * Fix 'not a function' errors when Vidarr labels are types other than String
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeBaseJoin.java
@@ -107,7 +107,13 @@ public abstract class OliveClauseNodeBaseJoin extends OliveClauseNode {
       innerKey.collectFreeVariables(freeVariables, Flavour::needsCapture);
     }
     final var inputSource =
-        source.render(oliveBuilder, definitions, "", "", v -> false, v -> false);
+        source.render(
+            oliveBuilder,
+            definitions,
+            String.format("%s %d:%d", syntax(), line(), column()),
+            "",
+            v -> false,
+            v -> false);
 
     final var join =
         oliveBuilder.join(

--- a/shesmu-server/src/test/resources/run/join-twice.shesmu
+++ b/shesmu-server/src/test/resources/run/join-twice.shesmu
@@ -1,0 +1,13 @@
+Version 1;
+Input test;
+
+Define foo()
+ Let a = accession, p = project, s = std::signature::sha1;
+
+Define bar()
+ Let ab = accession, pb = project, sb = std::signature::sha1;
+
+Olive
+ Join accession To Call foo() a
+ Join accession To Call bar() ab
+ Run ok With ok = p == project && pb == project && s != "" && sb != "";


### PR DESCRIPTION
Corrects a bug where multiple `Join` or `IntersectionJoin` clauses in a single olive would generate duplicate fields for signatures. This prefixes the fields correctly so they do not overlap.

- [X] Updates Changelog
- [X] Updates developer documentation
