### PR TITLE
[GP-4103] Use UnloadResponse when unloading from vidarr

### DIFF
--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/BaseUnloadAction.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/BaseUnloadAction.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import ca.on.oicr.gsi.vidarr.JsonBodyHandler;
 import ca.on.oicr.gsi.vidarr.UnloadFilter;
 import ca.on.oicr.gsi.vidarr.api.UnloadRequest;
+import ca.on.oicr.gsi.vidarr.api.UnloadResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.http.HttpRequest;
@@ -88,9 +89,9 @@ public abstract class BaseUnloadAction extends Action {
                                     BodyPublishers.ofByteArray(
                                         VidarrPlugin.MAPPER.writeValueAsBytes(request)))
                                 .build(),
-                            new JsonBodyHandler<>(VidarrPlugin.MAPPER, String.class));
+                            new JsonBodyHandler<>(VidarrPlugin.MAPPER, UnloadResponse.class));
                     if (response.statusCode() < 400) {
-                      vidarrOutputName = response.body().get();
+                      vidarrOutputName = response.body().get().getFilename();
                       return new Pair<>(ActionState.SUCCEEDED, List.of());
                     }
                     return new Pair<>(


### PR DESCRIPTION
JIRA Ticket: GP-4103

would need a vidarr release (and the dependency in the pom updated) before merge
see https://github.com/oicr-gsi/vidarr/pull/338

- [n/a] Updates Changelog
- [n/a] Updates developer documentation
