### PR TITLE
Improve display of action tiles in UI

### DIFF
--- a/changes/fix_action_tile.md
+++ b/changes/fix_action_tile.md
@@ -1,0 +1,1 @@
+* Fix placement of action title in UI

--- a/shesmu-server-ui/src/action.ts
+++ b/shesmu-server-ui/src/action.ts
@@ -24,6 +24,7 @@ import {
   link,
   makeUrl,
   multipaneState,
+  paragraph,
   popupMenu,
   preformatted,
   refreshButton,
@@ -1089,7 +1090,7 @@ export function title(action: Action, label: string): UIElement {
   const title =
     action.state + (action.updateInProgress ? " Update in progress" : "");
   const element = action.url
-    ? link(action.url, label, title)
+    ? paragraph(link(action.url, label, title))
     : text(label, title);
   const fileNameFormatter = commonPathPrefix(
     action.locations.map((l: { file: any }) => l.file)


### PR DESCRIPTION
Fixes a bug where action titles that were links would be displayed on the same line as the ID and buttons rather than on a separate line.

- [X] Updates Changelog
- [NA] Updates developer documentation
