### PR TITLE
Prepare compiler for modularization

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -2037,7 +2037,7 @@ public final class Server implements ServerConfig, ActionServices {
                   })
                   .compile(
                       script,
-                      "shesmu/dyn/Checker",
+                      BaseHotloadingCompiler.TARGET_INTERNAL,
                       "Uploaded Check Script.shesmu",
                       () -> Stream.concat(definitionRepository.constants(), compiler.constants()),
                       definitionRepository::signatures,
@@ -2433,14 +2433,8 @@ public final class Server implements ServerConfig, ActionServices {
               for (final var stack : thread.getStackTrace()) {
                 var current = "";
                 if (stack.getModuleName() == null) {
-                  if (stack.getClassName().startsWith("shesmu.dyn.")) {
-                    if (stack.getFileName() == null) {
-                      continue;
-                    } else {
-                      current = stack.getFileName();
-                    }
-                  } else {
-                    current = stack.getClassName();
+                  if (stack.getFileName() != null) {
+                    current = stack.getFileName();
                   }
                 } else if (stack.getModuleName().startsWith("java.")
                     || stack.getModuleName().startsWith("jdk.")) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BaseOliveBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/BaseOliveBuilder.java
@@ -15,6 +15,7 @@ import ca.on.oicr.gsi.shesmu.runtime.InputProvider;
 import ca.on.oicr.gsi.shesmu.runtime.OliveServices;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import ca.on.oicr.gsi.shesmu.runtime.SignatureAccessor;
+import ca.on.oicr.gsi.shesmu.server.BaseHotloadingCompiler;
 import io.prometheus.client.Gauge;
 import java.util.*;
 import java.util.function.*;
@@ -335,7 +336,8 @@ public abstract class BaseOliveBuilder {
       Imyhat unrollType,
       boolean copySignatures,
       LoadableValue... capturedVariables) {
-    final var className = String.format("shesmu/dyn/Flatten %d:%d", line, column);
+    final var className =
+        String.format("%s/Flatten %d:%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column);
 
     final var oldType = currentType;
     final var newType = Type.getObjectType(className);
@@ -420,7 +422,8 @@ public abstract class BaseOliveBuilder {
       JoinInputSource innerType,
       Imyhat keyType,
       LoadableValue... capturedVariables) {
-    final var className = String.format("shesmu/dyn/Join %d:%d", line, column);
+    final var className =
+        String.format("%s/Join %d:%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column);
 
     final var oldType = currentType;
     final var newType = Type.getObjectType(className);
@@ -476,8 +479,11 @@ public abstract class BaseOliveBuilder {
       Imyhat keyType,
       BiConsumer<SignatureDefinition, Renderer> innerSigner,
       LoadableValue... capturedVariables) {
-    final var joinedClassName = String.format("shesmu/dyn/LeftJoinTemporary %d:%d", line, column);
-    final var outputClassName = String.format("shesmu/dyn/LeftJoin %d:%d", line, column);
+    final var joinedClassName =
+        String.format(
+            "%s/LeftJoinTemporary %d:%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column);
+    final var outputClassName =
+        String.format("%s/LeftJoin %d:%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column);
 
     final var oldType = currentType;
     final var joinedType = Type.getObjectType(joinedClassName);
@@ -551,7 +557,8 @@ public abstract class BaseOliveBuilder {
   }
 
   public final LetBuilder let(int line, int column, LoadableValue... capturedVariables) {
-    final var className = String.format("shesmu/dyn/Let %d:%d", line, column);
+    final var className =
+        String.format("%s/Let %d:%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column);
 
     final var oldType = currentType;
     final var newType = Type.getObjectType(className);
@@ -797,7 +804,8 @@ public abstract class BaseOliveBuilder {
 
   public final RegroupVariablesBuilder regroup(
       int line, int column, LoadableValue... capturedVariables) {
-    final var className = String.format("shesmu/dyn/Group_%d_%d", line, column);
+    final var className =
+        String.format("%s/Group_%d_%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column);
 
     final var oldType = currentType;
     final var newType = Type.getObjectType(className);
@@ -861,7 +869,9 @@ public abstract class BaseOliveBuilder {
       LoadableValue[] grouperCaptures,
       List<Pair<String, Type>> grouperVariables,
       LoadableValue... capturedVariables) {
-    final var className = String.format("shesmu/dyn/GroupWithGrouper_%d_%d", line, column);
+    final var className =
+        String.format(
+            "%s/GroupWithGrouper_%d_%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column);
     final var oldType = currentType;
     final var newType = Type.getObjectType(className);
     currentType = newType;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Compiler.java
@@ -20,8 +20,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -153,7 +151,6 @@ public abstract class Compiler {
                 signatures,
                 allowDuplicates,
                 allowUnused)) {
-      final var compileTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
       if (dashboardOutput != null && skipRender) {
         dashboardOutput.accept(program.get().dashboard(path, hash, "Bytecode not available."));
       }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeCall.java
@@ -5,6 +5,7 @@ import static org.objectweb.asm.Type.VOID_TYPE;
 
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputVariable;
+import ca.on.oicr.gsi.shesmu.server.BaseHotloadingCompiler;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
@@ -53,7 +54,10 @@ public class JoinSourceNodeCall extends JoinSourceNode {
       Predicate<String> signatureUsed,
       Predicate<String> signableUsed) {
     final var accessorType =
-        Type.getObjectType(String.format("shesmu/dyn/Join Signer Accessor %d:%d", line, column));
+        Type.getObjectType(
+            String.format(
+                "%s/Join Signer Accessor %d:%d",
+                BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column));
     final var signablesAlwaysUsed =
         format
             .baseStreamVariables()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveBuilder.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.compiler.definitions.SignatureDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.action.Action;
 import ca.on.oicr.gsi.shesmu.plugin.refill.Refiller;
 import ca.on.oicr.gsi.shesmu.runtime.OliveServices;
+import ca.on.oicr.gsi.shesmu.server.BaseHotloadingCompiler;
 import java.lang.invoke.LambdaMetafactory;
 import java.util.List;
 import java.util.function.Consumer;
@@ -232,7 +233,9 @@ public final class OliveBuilder extends BaseOliveBuilder {
     this.column = column;
     this.actionName = actionName;
     accessorType =
-        Type.getObjectType(String.format("shesmu/dyn/Signer Accessor %d:%d", line, column));
+        Type.getObjectType(
+            String.format(
+                "%s/Signer Accessor %d:%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column));
     signerPrefix = String.format("Olive %d:%d ", line, column);
     final var signables = signableNames.collect(Collectors.toList());
     owner

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PragmaNodeInputGuard.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PragmaNodeInputGuard.java
@@ -7,6 +7,7 @@ import ca.on.oicr.gsi.shesmu.compiler.Target.Flavour;
 import ca.on.oicr.gsi.shesmu.compiler.definitions.InputFormatDefinition;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
+import ca.on.oicr.gsi.shesmu.server.BaseHotloadingCompiler;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,7 +93,8 @@ public class PragmaNodeInputGuard extends PragmaNode {
     final Set<String> freeVariables = new HashSet<>();
     collector.collectFreeVariables(freeVariables, Flavour::needsCapture);
 
-    final var className = String.format("shesmu/dyn/Guard_%d_%d", line, column);
+    final var className =
+        String.format("%s/Guard_%d_%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column);
 
     final var newType = Type.getObjectType(className);
     final var capturedVariables =

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
@@ -18,6 +18,7 @@ import ca.on.oicr.gsi.shesmu.runtime.OliveServices;
 import io.prometheus.client.Gauge;
 import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -41,6 +42,8 @@ public abstract class RootBuilder {
   private static final Type A_GAUGE_TYPE = Type.getType(Gauge.class);
   private static final Type A_IMYHAT_TYPE = Type.getType(Imyhat.class);
   private static final Type A_INPUT_PROVIDER_TYPE = Type.getType(InputProvider.class);
+  private static final Type A_LOOKUP_TYPE = Type.getType(Lookup.class);
+  private static final Type A_METHOD_HANDLES_TYPE = Type.getType(MethodHandles.class);
   private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
   private static final Type A_OLIVE_SERVICES_TYPE = Type.getType(OliveServices.class);
   private static final Type A_STREAM_TYPE = Type.getType(Stream.class);
@@ -55,12 +58,14 @@ public abstract class RootBuilder {
           "bootstrap",
           Type.getMethodDescriptor(
               Type.getType(CallSite.class),
-              Type.getType(MethodHandles.Lookup.class),
+              A_LOOKUP_TYPE,
               A_STRING_TYPE,
               Type.getType(MethodType.class)),
           false);
   private static final Method METHOD_ACTION_GENERATOR__INPUTS =
       new Method("inputs", A_STREAM_TYPE, new Type[] {});
+  private static final Method METHOD_ACTION_GENERATOR__PRIVATE_LOOKUP =
+      new Method("privateLookup", A_LOOKUP_TYPE, new Type[] {});
   private static final Method METHOD_ACTION_GENERATOR__RUN =
       new Method("run", VOID_TYPE, new Type[] {A_OLIVE_SERVICES_TYPE, A_INPUT_PROVIDER_TYPE});
   private static final Method METHOD_ACTION_GENERATOR__RUN_PREPARE =
@@ -73,6 +78,8 @@ public abstract class RootBuilder {
           A_GAUGE_TYPE,
           new Type[] {A_STRING_TYPE, A_STRING_TYPE, A_STRING_ARRAY_TYPE});
   private static final Method METHOD_GAUGE__CLEAR = new Method("clear", VOID_TYPE, new Type[] {});
+  private static final Method METHOD_HANDLES__LOOKUP =
+      new Method("lookup", A_LOOKUP_TYPE, new Type[] {});
   private static final String METHOD_IMYHAT_DESC = Type.getMethodDescriptor(A_IMYHAT_TYPE);
   private static final Method METHOD_OLIVE_SERVICES__FIND_DUMPER =
       new Method(
@@ -228,6 +235,14 @@ public abstract class RootBuilder {
     timeoutMethod.returnValue();
     timeoutMethod.visitMaxs(0, 0);
     timeoutMethod.visitEnd();
+    final var lookupMethod =
+        new GeneratorAdapter(
+            Opcodes.ACC_PUBLIC, METHOD_ACTION_GENERATOR__PRIVATE_LOOKUP, null, null, classVisitor);
+    lookupMethod.visitCode();
+    lookupMethod.invokeStatic(A_METHOD_HANDLES_TYPE, METHOD_HANDLES__LOOKUP);
+    lookupMethod.returnValue();
+    lookupMethod.visitMaxs(0, 0);
+    lookupMethod.visitEnd();
   }
 
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/RootBuilder.java
@@ -64,8 +64,8 @@ public abstract class RootBuilder {
           false);
   private static final Method METHOD_ACTION_GENERATOR__INPUTS =
       new Method("inputs", A_STREAM_TYPE, new Type[] {});
-  private static final Method METHOD_ACTION_GENERATOR__PRIVATE_LOOKUP =
-      new Method("privateLookup", A_LOOKUP_TYPE, new Type[] {});
+  private static final Method METHOD_ACTION_GENERATOR__LOOKUP =
+      new Method("lookup", A_LOOKUP_TYPE, new Type[] {});
   private static final Method METHOD_ACTION_GENERATOR__RUN =
       new Method("run", VOID_TYPE, new Type[] {A_OLIVE_SERVICES_TYPE, A_INPUT_PROVIDER_TYPE});
   private static final Method METHOD_ACTION_GENERATOR__RUN_PREPARE =
@@ -237,7 +237,7 @@ public abstract class RootBuilder {
     timeoutMethod.visitEnd();
     final var lookupMethod =
         new GeneratorAdapter(
-            Opcodes.ACC_PUBLIC, METHOD_ACTION_GENERATOR__PRIVATE_LOOKUP, null, null, classVisitor);
+            Opcodes.ACC_PUBLIC, METHOD_ACTION_GENERATOR__LOOKUP, null, null, classVisitor);
     lookupMethod.visitCode();
     lookupMethod.invokeStatic(A_METHOD_HANDLES_TYPE, METHOD_HANDLES__LOOKUP);
     lookupMethod.returnValue();

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
@@ -77,7 +77,7 @@ public abstract class ConstantDefinition implements Target {
       classVisitor.visit(
           Opcodes.V1_8,
           Opcodes.ACC_PUBLIC,
-          "dyn/shesmu/Constant",
+          BaseHotloadingCompiler.TARGET_INTERNAL,
           null,
           A_OBJECT_TYPE.getInternalName(),
           new String[] {A_CONSTANT_LOADER_TYPE.getInternalName()});
@@ -110,7 +110,7 @@ public abstract class ConstantDefinition implements Target {
       classVisitor.visitEnd();
 
       try {
-        return load(ConstantLoader.class, "dyn.shesmu.Constant");
+        return load(ConstantLoader.class, BaseHotloadingCompiler.TARGET);
       } catch (InstantiationException
           | IllegalAccessException
           | ClassNotFoundException

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/constants/JsonFileDefinitionFile.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/core/constants/JsonFileDefinitionFile.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Function;
 
-public class JsonFileDefinitionFile extends JsonPluginFile<ObjectNode> {
+public final class JsonFileDefinitionFile extends JsonPluginFile<ObjectNode> {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static Pair<Imyhat, Object> convert(JsonNode value) {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/ActionGenerator.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/ActionGenerator.java
@@ -29,7 +29,9 @@ public abstract class ActionGenerator implements RequiredServices {
         }
 
         @Override
-        public Lookup privateLookup() {
+        public Lookup lookup() {
+          // Because this is a dummy instance, we're going to get the public lookup instance since
+          // there will be no exports that require using it.
           return MethodHandles.publicLookup();
         }
 
@@ -66,10 +68,12 @@ public abstract class ActionGenerator implements RequiredServices {
   /**
    * Gets a private lookup for this class
    *
-   * <p></p>This is kind of dangerous and weird, but since this is generated code, we need a way into the unnamed module it was compiled in, so we rummage.
+   * <p>This is kind of dangerous and weird, but since this is generated code, we need a way into
+   * the unnamed module it was compiled in, so we rummage.
+   *
    * @return the private lookup instance
    */
-  public abstract Lookup privateLookup();
+  public abstract Lookup lookup();
 
   /**
    * Add all Prometheus monitoring for this program.

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/ActionGenerator.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/ActionGenerator.java
@@ -4,6 +4,8 @@ import ca.on.oicr.gsi.shesmu.plugin.RequiredServices;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -24,6 +26,11 @@ public abstract class ActionGenerator implements RequiredServices {
         @Override
         public Stream<String> inputs() {
           return Stream.empty();
+        }
+
+        @Override
+        public Lookup privateLookup() {
+          return MethodHandles.publicLookup();
         }
 
         @Override
@@ -55,6 +62,14 @@ public abstract class ActionGenerator implements RequiredServices {
 
   /** All of the input formats that are used by this generator. */
   public abstract Stream<String> inputs();
+
+  /**
+   * Gets a private lookup for this class
+   *
+   * <p></p>This is kind of dangerous and weird, but since this is generated code, we need a way into the unnamed module it was compiled in, so we rummage.
+   * @return the private lookup instance
+   */
+  public abstract Lookup privateLookup();
 
   /**
    * Add all Prometheus monitoring for this program.

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/runtime/RuntimeSupport.java
@@ -11,6 +11,8 @@ import ca.on.oicr.gsi.shesmu.plugin.json.PackJsonObject;
 import ca.on.oicr.gsi.shesmu.plugin.json.UnpackJson;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
 import ca.on.oicr.gsi.shesmu.server.plugins.AnnotatedInputFormatDefinition;
+import ca.on.oicr.gsi.shesmu.server.plugins.InvokeDynamicActionParameterDescriptor;
+import ca.on.oicr.gsi.shesmu.server.plugins.InvokeDynamicRefillerParameterDescriptor;
 import ca.on.oicr.gsi.shesmu.server.plugins.PluginManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -89,6 +91,11 @@ public final class RuntimeSupport {
   static {
     MAPPER.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
     MAPPER.registerModule(new JavaTimeModule());
+  }
+
+  public static CallSite actionParameterBootstrap(
+      Lookup lookup, String methodName, MethodType type, String actionName) {
+    return InvokeDynamicActionParameterDescriptor.bootstrap(lookup, methodName, type, actionName);
   }
 
   /** Create a copy of a set with an additional item. */
@@ -248,12 +255,6 @@ public final class RuntimeSupport {
     }
 
     return joins.stream().map(p -> joiner.apply(inputs.get(p.first()), inners.get(p.second())));
-  }
-
-  public static CallSite pluginServicesBootstrap(
-      Lookup lookup, String methodName, MethodType methodType, String... fileNames) {
-    // This is redirects to the plugin manager; it's here to limit our export interface
-    return PluginManager.bootstrapServices(lookup, methodName, methodType, fileNames);
   }
 
   @RuntimeInterop
@@ -538,12 +539,24 @@ public final class RuntimeSupport {
     return PluginManager.bootstrap(lookup, methodName, methodType, filename);
   }
 
+  public static CallSite pluginServicesBootstrap(
+      Lookup lookup, String methodName, MethodType methodType, String... fileNames) {
+    // This is redirects to the plugin manager; it's here to limit our export interface
+    return PluginManager.bootstrapServices(lookup, methodName, methodType, fileNames);
+  }
+
   @RuntimeInterop
   public static int populateArray(String[] array, Set<String> items, int index) {
     for (final var item : items) {
       array[index++] = item;
     }
     return index;
+  }
+
+  public static CallSite refillerParameterBootstrap(
+      Lookup lookup, String methodName, MethodType type, String refillerName) {
+    return InvokeDynamicRefillerParameterDescriptor.bootstrap(
+        lookup, methodName, type, refillerName);
   }
 
   /**

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionRunnerCompiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionRunnerCompiler.java
@@ -62,7 +62,7 @@ public final class ActionRunnerCompiler extends BaseHotloadingCompiler {
     classVisitor.visit(
         Opcodes.V1_8,
         Opcodes.ACC_PUBLIC,
-        "dyn/shesmu/ActionRunner",
+        BaseHotloadingCompiler.TARGET_INTERNAL,
         null,
         A_OBJECT_TYPE.getInternalName(),
         new String[] {A_ACTION_RUNNER_TYPE.getInternalName()});
@@ -127,7 +127,7 @@ public final class ActionRunnerCompiler extends BaseHotloadingCompiler {
     classVisitor.visitEnd();
 
     try {
-      return load(ActionRunner.class, "dyn.shesmu.ActionRunner");
+      return load(ActionRunner.class, BaseHotloadingCompiler.TARGET);
     } catch (InstantiationException
         | IllegalAccessException
         | ClassNotFoundException

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/BaseHotloadingCompiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/BaseHotloadingCompiler.java
@@ -1,8 +1,8 @@
 package ca.on.oicr.gsi.shesmu.server;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
@@ -39,7 +39,10 @@ public abstract class BaseHotloadingCompiler {
     }
   }
 
-  private final Map<String, byte[]> bytecode = new HashMap<>();
+  public static final String PACKAGE_INTERNAL = "dyn/shesmu";
+  public static final String TARGET = "dyn.shesmu.Generated";
+  public static final String TARGET_INTERNAL = "dyn/shesmu/Generated";
+  private final Map<String, byte[]> bytecode = new TreeMap<>();
 
   private final ClassLoader classloader =
       new ClassLoader() {

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/FunctionRunnerCompiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/FunctionRunnerCompiler.java
@@ -85,7 +85,7 @@ public final class FunctionRunnerCompiler extends BaseHotloadingCompiler {
     classVisitor.visit(
         Opcodes.V1_8,
         Opcodes.ACC_PUBLIC,
-        "dyn/shesmu/Function",
+        BaseHotloadingCompiler.TARGET_INTERNAL,
         null,
         A_OBJECT_TYPE.getInternalName(),
         new String[] {A_FUNCTION_RUNNER_TYPE.getInternalName()});
@@ -135,7 +135,7 @@ public final class FunctionRunnerCompiler extends BaseHotloadingCompiler {
     classVisitor.visitEnd();
 
     try {
-      return load(FunctionRunner.class, "dyn.shesmu.Function");
+      return load(FunctionRunner.class, BaseHotloadingCompiler.TARGET);
     } catch (InstantiationException
         | IllegalAccessException
         | ClassNotFoundException

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/HotloadingCompiler.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/HotloadingCompiler.java
@@ -185,7 +185,7 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
                     try {
                       exportConsumer.constant(
                           instance
-                              .privateLookup()
+                              .lookup()
                               .unreflectGetter(instance.getClass().getField(name + "$constant"))
                               .bindTo(instance),
                           name,
@@ -208,7 +208,7 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
                     try {
                       exportConsumer.defineOlive(
                           instance
-                              .privateLookup()
+                              .lookup()
                               .unreflect(
                                   instance
                                       .getClass()
@@ -241,7 +241,7 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
                                           v.flavour(),
                                           v.type(),
                                           instance
-                                              .privateLookup()
+                                              .lookup()
                                               .unreflect(
                                                   instance
                                                       .getClass()
@@ -266,7 +266,7 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
                                               v.flavour(),
                                               v.type(),
                                               instance
-                                                  .privateLookup()
+                                                  .lookup()
                                                   .unreflect(
                                                       instance
                                                           .getClass()
@@ -295,7 +295,7 @@ public final class HotloadingCompiler extends BaseHotloadingCompiler {
                     try {
                       exportConsumer.function(
                           instance
-                              .privateLookup()
+                              .lookup()
                               .unreflect(
                                   instance
                                       .getClass()

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/InvokeDynamicActionParameterDescriptor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/InvokeDynamicActionParameterDescriptor.java
@@ -11,6 +11,7 @@ import ca.on.oicr.gsi.shesmu.plugin.action.JsonActionParameter;
 import ca.on.oicr.gsi.shesmu.plugin.action.JsonParameterisedAction;
 import ca.on.oicr.gsi.shesmu.plugin.json.JsonParameter;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import java.lang.invoke.CallSite;
 import java.lang.invoke.ConstantCallSite;
 import java.lang.invoke.MethodHandle;
@@ -38,8 +39,8 @@ public final class InvokeDynamicActionParameterDescriptor implements ActionParam
   private static final Handle BSM_HANDLE =
       new Handle(
           Opcodes.H_INVOKESTATIC,
-          Type.getType(InvokeDynamicActionParameterDescriptor.class).getInternalName(),
-          "bootstrap",
+          Type.getType(RuntimeSupport.class).getInternalName(),
+          "actionParameterBootstrap",
           Type.getMethodDescriptor(
               Type.getType(CallSite.class),
               Type.getType(Lookup.class),

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/InvokeDynamicRefillerParameterDescriptor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/InvokeDynamicRefillerParameterDescriptor.java
@@ -7,6 +7,7 @@ import ca.on.oicr.gsi.shesmu.plugin.refill.CustomRefillerParameter;
 import ca.on.oicr.gsi.shesmu.plugin.refill.Refiller;
 import ca.on.oicr.gsi.shesmu.plugin.refill.RefillerParameter;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.runtime.RuntimeSupport;
 import java.lang.invoke.*;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.*;
@@ -22,9 +23,9 @@ import org.objectweb.asm.Type;
 
 public final class InvokeDynamicRefillerParameterDescriptor implements RefillerParameterDefinition {
   public static CallSite bootstrap(
-      Lookup lookup, String methodName, MethodType type, String actionName) {
+      Lookup lookup, String methodName, MethodType type, String refillerName) {
     return new ConstantCallSite(
-        REGISTRY.get(new Pair<>(actionName, methodName)).dynamicInvoker().asType(type));
+        REGISTRY.get(new Pair<>(refillerName, methodName)).dynamicInvoker().asType(type));
   }
 
   public static Stream<RefillerParameterDefinition> findRefillerDefinitionsByAnnotation(
@@ -206,8 +207,8 @@ public final class InvokeDynamicRefillerParameterDescriptor implements RefillerP
   private static final Handle BSM_HANDLE =
       new Handle(
           Opcodes.H_INVOKESTATIC,
-          Type.getType(InvokeDynamicRefillerParameterDescriptor.class).getInternalName(),
-          "bootstrap",
+          Type.getType(RuntimeSupport.class).getInternalName(),
+          "refillerParameterBootstrap",
           Type.getMethodDescriptor(
               Type.getType(CallSite.class),
               Type.getType(Lookup.class),

--- a/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/CompilerTest.java
+++ b/shesmu-server/src/test/java/ca/on/oicr/gsi/shesmu/CompilerTest.java
@@ -17,6 +17,7 @@ import ca.on.oicr.gsi.shesmu.plugin.action.Action;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionServices;
 import ca.on.oicr.gsi.shesmu.plugin.action.ActionState;
 import ca.on.oicr.gsi.shesmu.plugin.types.Imyhat;
+import ca.on.oicr.gsi.shesmu.server.BaseHotloadingCompiler;
 import ca.on.oicr.gsi.shesmu.util.NameLoader;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -269,7 +270,7 @@ public class CompilerTest {
       // know everything based on the errors generated.
       compiler.compile(
           Files.readAllBytes(file),
-          "dyn/shesmu/Program",
+          BaseHotloadingCompiler.TARGET_INTERNAL,
           file.toString(),
           CONSTANTS::stream,
           Stream::empty,


### PR DESCRIPTION
The compiler currently emits classes that are incompatible with the Java 9 Jigsaw module system. This change refactors the compiler so that it generates module-compliant code in preparation for modularization. It does this by:

- making sure that all generated classes are in a single package
- adding a new method to `ActionGenerator` to provide a `MethodHandles.Lookup` instance

Under modularization, classes cannot reflect into classes outside of their own module visibility. For generated code, this makes it impossible for the compiler to rummage around in the class it just generated. To circumvent this, the generated class must create a `Lookup` instance with the generated class's visibility rules and then share this with the compiler.

- [NA] Updates Changelog (no visible changes)
- [X] Updates developer documentation
