### PR TITLE
[GP-4040] ValueCache refactor out unneccessary second generic

### DIFF
--- a/changes/change_cache.md
+++ b/changes/change_cache.md
@@ -1,0 +1,1 @@
+Remove confusing second generic from cache types

--- a/plugin-cerberus/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusPlugin.java
+++ b/plugin-cerberus/src/main/java/ca/on/oicr/gsi/shesmu/cerberus/CerberusPlugin.java
@@ -32,8 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class CerberusPlugin extends JsonPluginFile<Configuration> {
-  private class FileProvenanceCache
-      extends ValueCache<Optional<FileProvenanceOutput>, Optional<FileProvenanceOutput>> {
+  private class FileProvenanceCache extends ValueCache<Optional<FileProvenanceOutput>> {
 
     public FileProvenanceCache(String name) {
       super("cerberus-fpr " + name, 10, SimpleRecord::new);

--- a/plugin-github/src/main/java/ca/on/oicr/gsi/shesmu/github/GitHubBranchesApiPluginType.java
+++ b/plugin-github/src/main/java/ca/on/oicr/gsi/shesmu/github/GitHubBranchesApiPluginType.java
@@ -23,8 +23,7 @@ import org.kohsuke.MetaInfServices;
 public class GitHubBranchesApiPluginType
     extends PluginFileType<GitHubBranchesApiPluginType.GitHubRemote> {
   static class GitHubRemote extends JsonPluginFile<Configuration> {
-    private class BranchCache
-        extends ValueCache<Stream<GithubBranchValue>, Stream<GithubBranchValue>> {
+    private class BranchCache extends ValueCache<Stream<GithubBranchValue>> {
 
       public BranchCache(Path fileName) {
         super("github-branches " + fileName.toString(), 10, ReplacingRecord::new);

--- a/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/GuanyinRemote.java
+++ b/plugin-guanyin/src/main/java/ca/on/oicr/gsi/shesmu/guanyin/GuanyinRemote.java
@@ -24,8 +24,7 @@ import java.util.stream.Stream;
 
 public class GuanyinRemote extends JsonPluginFile<Configuration> {
 
-  private class ReportsCache
-      extends ValueCache<Stream<GuanyinReportValue>, Stream<GuanyinReportValue>> {
+  private class ReportsCache extends ValueCache<Stream<GuanyinReportValue>> {
     public ReportsCache(Path fileName) {
       super("guanyin-reports " + fileName, 20, ReplacingRecord::new);
     }

--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
@@ -34,8 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class JiraConnection extends JsonPluginFile<Configuration> {
-  private class FilterCache
-      extends KeyValueCache<String, Stream<JiraActionFilter>, Stream<JiraActionFilter>> {
+  private class FilterCache extends KeyValueCache<String, Stream<JiraActionFilter>> {
     public FilterCache(Path fileName) {
       super("jira-filters " + fileName.toString(), 15, ReplacingRecord::new);
     }
@@ -78,7 +77,7 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
     }
   }
 
-  private class IssueCache extends ValueCache<Stream<Issue>, Stream<Issue>> {
+  private class IssueCache extends ValueCache<Stream<Issue>> {
     public IssueCache(Path fileName) {
       super("jira-issues " + fileName.toString(), 15, MergingRecord.by(Issue::getId));
     }

--- a/plugin-mongo/src/main/java/ca/on/oicr/gsi/shesmu/mongo/MongoServer.java
+++ b/plugin-mongo/src/main/java/ca/on/oicr/gsi/shesmu/mongo/MongoServer.java
@@ -47,7 +47,7 @@ public class MongoServer extends JsonPluginFile<Configuration> {
           function.getSelector().type(function.getResultType().type()),
           new VariadicFunction() {
             private final Definer<MongoServer> definer = MongoServer.this.definer;
-            private final KeyValueCache<Tuple, Optional<Object>, Optional<Object>> cache =
+            private final KeyValueCache<Tuple, Optional<Object>> cache =
                 new KeyValueCache<>(
                     String.format("mongo %s %s", MongoServer.this.fileName(), entry.getKey()),
                     function.getTtl(),

--- a/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuPlugin.java
+++ b/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuPlugin.java
@@ -21,8 +21,7 @@ import java.util.stream.Stream;
 
 public class NabuPlugin extends JsonPluginFile<NabuConfiguration> {
 
-  private final class CaseArchiveCache
-      extends ValueCache<Stream<NabuCaseArchiveValue>, Stream<NabuCaseArchiveValue>> {
+  private final class CaseArchiveCache extends ValueCache<Stream<NabuCaseArchiveValue>> {
 
     private CaseArchiveCache(Path fileName) {
       super("case_archive " + fileName.toString(), 30, ReplacingRecord::new);
@@ -70,8 +69,7 @@ public class NabuPlugin extends JsonPluginFile<NabuConfiguration> {
     }
   }
 
-  private final class FileQcCache
-      extends ValueCache<Stream<NabuFileQcValue>, Stream<NabuFileQcValue>> {
+  private final class FileQcCache extends ValueCache<Stream<NabuFileQcValue>> {
 
     private FileQcCache(Path fileName) {
       super("file_qc " + fileName.toString(), 30, ReplacingRecord::new);

--- a/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
+++ b/plugin-pinery/src/main/java/ca/on/oicr/gsi/shesmu/pinery/PinerySource.java
@@ -46,8 +46,7 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
    * This input format filters out skipped samples and lanes, and provides only items that would be
    * desirable to analyze.
    */
-  private final class AnalysisItemCache
-      extends ValueCache<Stream<PineryIUSForAnalysisValue>, Stream<PineryIUSForAnalysisValue>> {
+  private final class AnalysisItemCache extends ValueCache<Stream<PineryIUSForAnalysisValue>> {
     private AnalysisItemCache(Path fileName) {
       super("pinery " + fileName.toString(), 30, ReplacingRecord::new);
     }
@@ -326,8 +325,7 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
 
   /** This input format includes skipped samples and lanes. */
   private final class IncludeSkippedItemCache
-      extends ValueCache<
-          Stream<PineryIUSIncludeSkippedValue>, Stream<PineryIUSIncludeSkippedValue>> {
+      extends ValueCache<Stream<PineryIUSIncludeSkippedValue>> {
     private IncludeSkippedItemCache(Path fileName) {
       super("pinery-include-skipped " + fileName.toString(), 30, ReplacingRecord::new);
     }
@@ -602,8 +600,7 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
     }
   }
 
-  private final class PlatformCache
-      extends ValueCache<Optional<Map<String, String>>, Optional<Map<String, String>>> {
+  private final class PlatformCache extends ValueCache<Optional<Map<String, String>>> {
     private PlatformCache(Path fileName) {
       super("pinery-platform " + fileName.toString(), 30, SimpleRecord::new);
     }
@@ -629,8 +626,7 @@ public class PinerySource extends JsonPluginFile<PineryConfiguration> {
     }
   }
 
-  private class ProjectCache
-      extends ValueCache<Stream<SampleProjectDto>, Stream<SampleProjectDto>> {
+  private class ProjectCache extends ValueCache<Stream<SampleProjectDto>> {
 
     public ProjectCache(Path fileName) {
       super(

--- a/plugin-prometheus/src/main/java/ca/on/oicr/gsi/shesmu/prometheus/PrometheusAlertManagerPluginType.java
+++ b/plugin-prometheus/src/main/java/ca/on/oicr/gsi/shesmu/prometheus/PrometheusAlertManagerPluginType.java
@@ -50,7 +50,7 @@ public class PrometheusAlertManagerPluginType
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   static class AlertManagerEndpoint extends JsonPluginFile<Configuration> {
-    private class AlertCache extends ValueCache<Stream<AlertDto>, Stream<AlertDto>> {
+    private class AlertCache extends ValueCache<Stream<AlertDto>> {
       public AlertCache(Path fileName) {
         super("alertmanager " + fileName.toString(), 5, ReplacingRecord::new);
       }

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SftpServer.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/SftpServer.java
@@ -54,8 +54,7 @@ import net.schmizz.sshj.sftp.SFTPException;
 public class SftpServer extends JsonPluginFile<Configuration> {
 
   private class FileAttributeCache
-      extends KeyValueCache<
-          Pair<Path, Boolean>, Optional<AlgebraicValue>, Optional<AlgebraicValue>> {
+      extends KeyValueCache<Pair<Path, Boolean>, Optional<AlgebraicValue>> {
     public FileAttributeCache(Path fileName) {
       super("sftp " + fileName.toString(), 10, SimpleRecord::new);
     }
@@ -472,7 +471,7 @@ public class SftpServer extends JsonPluginFile<Configuration> {
       final var returns = entry.getValue().getReturns();
       final var parameters = entry.getValue().getParameters().toArray(Imyhat[]::new);
       final var cache =
-          new KeyValueCache<Tuple, Optional<Object>, Optional<Object>>(
+          new KeyValueCache<Tuple, Optional<Object>>(
               String.format("sftp-function %s %s", fileName(), entry.getKey()),
               entry.getValue().getTtl(),
               SimpleRecord::new) {

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
@@ -49,8 +49,7 @@ import java.util.stream.Stream;
 
 public class VidarrPlugin extends JsonPluginFile<Configuration> {
 
-  private class MaxInFlightCache
-      extends ValueCache<Optional<MaxInFlightDeclaration>, Optional<MaxInFlightDeclaration>> {
+  private class MaxInFlightCache extends ValueCache<Optional<MaxInFlightDeclaration>> {
 
     public MaxInFlightCache(String name) {
       super("max-in-flight " + name, 10, SimpleRecord::new);
@@ -76,8 +75,7 @@ public class VidarrPlugin extends JsonPluginFile<Configuration> {
     }
   }
 
-  private class WorkflowRunInformationCache
-      extends KeyValueCache<String, Optional<Tuple>, Optional<Tuple>> {
+  private class WorkflowRunInformationCache extends KeyValueCache<String, Optional<Tuple>> {
 
     public WorkflowRunInformationCache(String instanceName) {
       super("workflow-info " + instanceName, 10, SimpleRecord::new);

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/InvalidatableRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/InvalidatableRecord.java
@@ -14,7 +14,7 @@ public class InvalidatableRecord<V> implements Record<Optional<V>> {
    * @param isValid the predicate to check if the cached value is still valid
    * @param destructor the clean up procedure
    */
-  public static <V> RecordFactory<Optional<V>, Optional<V>> checking(
+  public static <V> RecordFactory<Optional<V>> checking(
       Predicate<? super V> isValid, Consumer<? super V> destructor) {
     return (fetcher) -> new InvalidatableRecord<>(fetcher, isValid, destructor);
   }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/KeyValueCache.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/KeyValueCache.java
@@ -79,7 +79,7 @@ public abstract class KeyValueCache<K, V> implements Owner, Iterable<Map.Entry<K
 
   private long maxCount = 0;
   private final String name;
-  private final RecordFactory<V, V> recordFactory;
+  private final RecordFactory<V> recordFactory;
   private final Map<K, Record<V>> records = new ConcurrentHashMap<>();
   private int ttl;
 
@@ -89,7 +89,7 @@ public abstract class KeyValueCache<K, V> implements Owner, Iterable<Map.Entry<K
    * @param name the name, as presented to Prometheus
    * @param ttl the number of minutes an item will remain in cache
    */
-  public KeyValueCache(String name, int ttl, RecordFactory<V, V> recordFactory) {
+  public KeyValueCache(String name, int ttl, RecordFactory<V> recordFactory) {
     super();
     this.name = name;
     this.ttl = ttl;

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/LabelledKeyValueCache.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/LabelledKeyValueCache.java
@@ -88,7 +88,7 @@ public abstract class LabelledKeyValueCache<K, L, V>
 
   private final String name;
 
-  private final RecordFactory<V, V> recordCtor;
+  private final RecordFactory<V> recordCtor;
   private final Map<L, Record<V>> records = new ConcurrentHashMap<>();
   private int ttl;
 
@@ -98,7 +98,7 @@ public abstract class LabelledKeyValueCache<K, L, V>
    * @param name the name, as presented to Prometheus
    * @param ttl the number of minutes an item will remain in cache
    */
-  public LabelledKeyValueCache(String name, int ttl, RecordFactory<V, V> recordCtor) {
+  public LabelledKeyValueCache(String name, int ttl, RecordFactory<V> recordCtor) {
     super();
     this.name = name;
     this.ttl = ttl;

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/MergingRecord.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/MergingRecord.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 public final class MergingRecord<V, I> extends BaseRecord<Stream<V>, List<V>> {
 
   /** Merge records by the supplied id */
-  public static <V, I> RecordFactory<Stream<V>, Stream<V>> by(Function<V, I> getId) {
+  public static <V, I> RecordFactory<Stream<V>> by(Function<V, I> getId) {
     return fetcher -> new MergingRecord<>(fetcher, getId);
   }
 

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/RecordFactory.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/RecordFactory.java
@@ -3,10 +3,9 @@ package ca.on.oicr.gsi.shesmu.plugin.cache;
 /**
  * Producer of new records for updater
  *
- * @param <I> the type returned by the updater
  * @param <V> the type returned by the record
  */
-public interface RecordFactory<I, V> {
+public interface RecordFactory<V> {
 
-  Record<V> create(Updater<I> updater);
+  Record<V> create(Updater<V> updater);
 }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/ValueCache.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/cache/ValueCache.java
@@ -54,7 +54,7 @@ public abstract class ValueCache<S> implements Owner {
    * @param name the name, as presented to Prometheus
    * @param ttl the number of minutes an item will remain in cache
    */
-  public ValueCache(String name, int ttl, RecordFactory<S, S> recordCtor) {
+  public ValueCache(String name, int ttl, RecordFactory<S> recordCtor) {
     super();
     this.name = name;
     this.ttl = ttl;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/Server.java
@@ -3030,7 +3030,7 @@ public final class Server implements ServerConfig, ActionServices {
     pluginManager.log("Shesmu started.", Map.of());
   }
 
-  private <L, V> void storeEntries(ObjectNode entries, LabelledKeyValueCache<?, ?, ?, ?> cache) {
+  private <L, V> void storeEntries(ObjectNode entries, LabelledKeyValueCache<?, ?, ?> cache) {
     for (final var record : cache) {
       final var node = entries.putObject(record.getKey().toString());
       node.put("collectionSize", record.getValue().collectionSize());
@@ -3038,7 +3038,7 @@ public final class Server implements ServerConfig, ActionServices {
     }
   }
 
-  private <K, V> void storeEntries(ObjectNode entries, KeyValueCache<?, ?, ?> cache) {
+  private <K, V> void storeEntries(ObjectNode entries, KeyValueCache<?, ?> cache) {
     for (final var record : cache) {
       final var node = entries.putObject(record.getKey().toString());
       node.put("collectionSize", record.getValue().collectionSize());

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/AnnotatedInputFormatDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/AnnotatedInputFormatDefinition.java
@@ -151,7 +151,7 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
   }
 
   private class DynamicInputDataSourceFromJsonStream implements DynamicInputDataSource {
-    private final LabelledKeyValueCache<Object, String, Stream<Object>, Stream<Object>> cache;
+    private final LabelledKeyValueCache<Object, String, Stream<Object>> cache;
 
     public DynamicInputDataSourceFromJsonStream(
         String name, int ttl, DynamicInputJsonSource source) {
@@ -195,7 +195,7 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
   }
 
   private class InputDataSourceFromJsonStream implements InputDataSource {
-    private final ValueCache<Stream<Object>, Stream<Object>> cache;
+    private final ValueCache<Stream<Object>> cache;
 
     public InputDataSourceFromJsonStream(String name, int ttl, JsonInputSource source) {
       cache =
@@ -236,7 +236,7 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
     private final ConfigurationSection configuration;
     private volatile boolean dirty = true;
     private final String fileName;
-    private final ValueCache<Optional<List<Object>>, Optional<List<Object>>> values;
+    private final ValueCache<Optional<List<Object>>> values;
 
     public LocalJsonFile(Path fileName) {
       this.fileName = fileName.toString();
@@ -302,7 +302,7 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
   }
 
   private class RemoteJsonSource implements WatchedFileListener {
-    private class RemoteReloader extends ValueCache<Stream<Object>, Stream<Object>> {
+    private class RemoteReloader extends ValueCache<Stream<Object>> {
       public RemoteReloader(Path fileName) {
         super("remotejson " + format.name() + " " + fileName.toString(), 10, ReplacingRecord::new);
       }
@@ -332,7 +332,7 @@ public final class AnnotatedInputFormatDefinition implements InputFormatDefiniti
       }
     }
 
-    private final ValueCache<Stream<Object>, Stream<Object>> cache;
+    private final ValueCache<Stream<Object>> cache;
     private Optional<Configuration> config = Optional.empty();
     private final Path fileName;
 


### PR DESCRIPTION
JIRA Ticket: GP-4040

Caches and RecordFactory being able to transform its data was needed to deal with some of Niassa's data formats.
It's no longer needed, and confusing to plugin developers to have to define the same type twice. 
Remove the second generic.

- [X] Updates Changelog
- [N/A] Updates developer documentation
