### PR TITLE
Allow JSON function arguments on _Definitions_ page

### DIFF
--- a/changes/change_tryit_format.md
+++ b/changes/change_tryit_format.md
@@ -1,0 +1,1 @@
+* Allow _Try It_ for functions on _Definitions_ page to take JSON or Shesmu input

--- a/shesmu-server-ui/src/html.ts
+++ b/shesmu-server-ui/src/html.ts
@@ -2829,10 +2829,16 @@ export function inputText(initial?: string): InputField<string> {
 /**
  * Create a big text input box.
  */
-export function inputTextArea(initial?: string): InputField<string> {
+export function inputTextArea(
+  initial?: string,
+  short?: boolean
+): InputField<string> {
   const input = createUiFromTag("textarea");
   if (initial) {
     input.element.value = initial;
+  }
+  if (!short) {
+    input.element.classList.add("tall");
   }
   return {
     ui: input,

--- a/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
+++ b/shesmu-server/src/main/resources/ca/on/oicr/gsi/shesmu/main.css
@@ -837,6 +837,8 @@ th {
 
 textarea {
   width: 100%;
+}
+textarea.tall {
   height: 50vh;
 }
 


### PR DESCRIPTION
Provide a choice between Shesmu and raw JSON for function arguments in the _Try It_ dialog.

- [X] Updates Changelog
- [NA] Updates developer documentation
