### PR TITLE
Add Vidarr retry failed provision-out command

### DIFF
--- a/changes/add_vidarr_retry_provision_out.md
+++ b/changes/add_vidarr_retry_provision_out.md
@@ -1,0 +1,1 @@
+* Add Vidarr _retry failed provision-out_ command

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/AvailableCommands.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/AvailableCommands.java
@@ -1,0 +1,98 @@
+package ca.on.oicr.gsi.shesmu.vidarr;
+
+import ca.on.oicr.gsi.shesmu.plugin.FrontEndIcon;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionCommand;
+import ca.on.oicr.gsi.shesmu.plugin.action.ActionCommand.Preference;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public enum AvailableCommands {
+  RESET_ONLY(false) {
+    @Override
+    public Stream<ActionCommand<?>> commands() {
+      return Stream.of(RESET);
+    }
+  },
+  CAN_RETRY(true) {
+    @Override
+    public Stream<ActionCommand<?>> commands() {
+      return Stream.of(DELETE, RETRY_PROVISION_OUT, RESET);
+    }
+  },
+  CAN_REATTEMPT(true) {
+    @Override
+    public Stream<ActionCommand<?>> commands() {
+      return Stream.of(DELETE, REATTEMPT, RESET);
+    }
+  };
+  static final ActionCommand<SubmitAction> DELETE =
+      new ActionCommand<>(
+          SubmitAction.class,
+          "VIDARR-DELETE",
+          FrontEndIcon.PLUG,
+          "Delete and Purge",
+          Preference.ALLOW_BULK,
+          Preference.PROMPT,
+          Preference.ANNOY_USER) {
+        @Override
+        protected Response execute(SubmitAction action, Optional<String> user) {
+          return action.owner.get().url().map(action.state::delete).orElse(false)
+              ? Response.PURGE
+              : Response.IGNORED;
+        }
+      };
+  static final ActionCommand<SubmitAction> REATTEMPT =
+      new ActionCommand<>(
+          SubmitAction.class,
+          "VIDARR-REATTEMPT",
+          FrontEndIcon.ARROW_REPEAT,
+          "Reattempt Failed Workflow",
+          Preference.PROMPT,
+          Preference.ALLOW_BULK) {
+        @Override
+        protected Response execute(SubmitAction action, Optional<String> user) {
+          final var result = action.state.reattempt();
+          result.ifPresent(s -> action.state = s);
+          return result.isPresent() ? Response.RESET : Response.IGNORED;
+        }
+      };
+  static final ActionCommand<SubmitAction> RESET =
+      new ActionCommand<>(
+          SubmitAction.class,
+          "VIDARR-RESET",
+          FrontEndIcon.PLUG,
+          "Search Vidarr Again",
+          Preference.ALLOW_BULK) {
+        @Override
+        protected Response execute(SubmitAction action, Optional<String> user) {
+          action.state = new RunStateAttemptSubmit();
+          return Response.RESET;
+        }
+      };
+  static final ActionCommand<SubmitAction> RETRY_PROVISION_OUT =
+      new ActionCommand<>(
+          SubmitAction.class,
+          "VIDARR-RETRY-PROVISION-OUT",
+          FrontEndIcon.ARROW_RIGHT_SQUARE_FILL,
+          "Retry Provision Out",
+          Preference.ALLOW_BULK,
+          Preference.PROMPT) {
+        @Override
+        protected Response execute(SubmitAction action, Optional<String> user) {
+          return action.owner.get().url().map(action.state::retry).orElse(false)
+              ? Response.ACCEPTED
+              : Response.IGNORED;
+        }
+      };
+  private final boolean canRetry;
+
+  AvailableCommands(boolean canRetry) {
+    this.canRetry = canRetry;
+  }
+
+  public boolean canRetry() {
+    return canRetry;
+  }
+
+  public abstract Stream<ActionCommand<?>> commands();
+}

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunState.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunState.java
@@ -43,7 +43,7 @@ abstract class RunState {
     }
   }
 
-  public abstract boolean canReattempt();
+  public abstract AvailableCommands commands();
 
   public abstract boolean delete(URI vidarrUrl);
 
@@ -58,6 +58,8 @@ abstract class RunState {
       throws IOException, InterruptedException;
 
   public abstract Optional<RunState> reattempt();
+
+  public abstract boolean retry(URI vidarrUrl);
 
   public abstract long retryMinutes();
 

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
@@ -36,8 +36,8 @@ final class RunStateAttemptSubmit extends RunState {
   }
 
   @Override
-  public boolean canReattempt() {
-    return false;
+  public AvailableCommands commands() {
+    return AvailableCommands.RESET_ONLY;
   }
 
   @Override
@@ -119,6 +119,11 @@ final class RunStateAttemptSubmit extends RunState {
   @Override
   public Optional<RunState> reattempt() {
     return Optional.empty();
+  }
+
+  @Override
+  public boolean retry(URI vidarrUrl) {
+    return false;
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateConflicted.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateConflicted.java
@@ -26,8 +26,8 @@ final class RunStateConflicted extends RunState {
   }
 
   @Override
-  public boolean canReattempt() {
-    return false;
+  public AvailableCommands commands() {
+    return AvailableCommands.RESET_ONLY;
   }
 
   @Override
@@ -57,6 +57,11 @@ final class RunStateConflicted extends RunState {
   @Override
   public Optional<RunState> reattempt() {
     return Optional.empty();
+  }
+
+  @Override
+  public boolean retry(URI vidarrUrl) {
+    return false;
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateDead.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateDead.java
@@ -14,8 +14,8 @@ import java.util.stream.Stream;
 final class RunStateDead extends RunState {
 
   @Override
-  public boolean canReattempt() {
-    return false;
+  public AvailableCommands commands() {
+    return AvailableCommands.RESET_ONLY;
   }
 
   @Override
@@ -41,6 +41,11 @@ final class RunStateDead extends RunState {
   @Override
   public Optional<RunState> reattempt() {
     return Optional.empty();
+  }
+
+  @Override
+  public boolean retry(URI vidarrUrl) {
+    return false;
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
@@ -34,8 +34,8 @@ final class RunStateMissing extends RunState {
   }
 
   @Override
-  public boolean canReattempt() {
-    return false;
+  public AvailableCommands commands() {
+    return AvailableCommands.RESET_ONLY;
   }
 
   @Override
@@ -65,6 +65,11 @@ final class RunStateMissing extends RunState {
   @Override
   public Optional<RunState> reattempt() {
     return Optional.empty();
+  }
+
+  @Override
+  public boolean retry(URI vidarrUrl) {
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Allows the new `/api/retry-provision-out` endpoint to be accessed via action command.

This PR will require an updated Vidarr dependency once https://github.com/oicr-gsi/vidarr/pull/342 is released.

- [X] Updates Changelog
- [NA] Updates developer documentation
