### PR TITLE
Remove unnecessary `ActionState.sortPriority`

### DIFF
--- a/changes/remove_sort_priority.md
+++ b/changes/remove_sort_priority.md
@@ -1,0 +1,1 @@
+* Remove unused `ActionState.sortPriority`

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/action/ActionState.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/action/ActionState.java
@@ -3,31 +3,31 @@ package ca.on.oicr.gsi.shesmu.plugin.action;
 /** Describe the current completeness of an action */
 public enum ActionState {
   /** The action has been attempted and encounter an error (possibly recoverable). */
-  FAILED(3, 2),
+  FAILED(2),
   /**
    * The action is in a state where it needs human attention or intervention to correct itself.
    *
    * <p>Usually, this means that the action has tried to recover state and found itself in an
    * inconsistent state that it can't recover from without doing something dangerous.
    */
-  HALP(2, 2),
+  HALP(2),
   /** The action is currently being executed. */
-  INFLIGHT(2, 1),
+  INFLIGHT(1),
   /** The action is waiting for a remote system to start it. */
-  QUEUED(2, 1),
+  QUEUED(1),
   /** The action has encountered some user-defined limit stopping it from proceeding. */
-  SAFETY_LIMIT_REACHED(2, 2),
+  SAFETY_LIMIT_REACHED(2),
   /** The action is complete. */
-  SUCCEEDED(1, 2),
+  SUCCEEDED(2),
   /**
    * The action is being rate limited by a {@link ActionServices#isOverloaded(String...)} or by an
    * over-capacity signal from the remote system.
    */
-  THROTTLED(2, 2),
+  THROTTLED(2),
   /**
    * The actions state is not currently known either due to an error or not having been attempted
    */
-  UNKNOWN(2, 2),
+  UNKNOWN(2),
   /**
    * The action cannot be started due to a resource being unavailable
    *
@@ -36,7 +36,7 @@ public enum ActionState {
    * capacity is available. This might be due to needing another action to complete or requiring
    * user intervention.
    */
-  WAITING(2, 2),
+  WAITING(2),
   /**
    * The action is never going to complete. This is not necessarily a failed state; testing or
    * debugging actions should be in this state.
@@ -44,35 +44,19 @@ public enum ActionState {
    * <p>This is similar to {@link #SUCCEEDED} in that the action will never be checked again, but it
    * didn't really succeed. More reached a state of terminal stuckness.
    */
-  ZOMBIE(1, 2);
+  ZOMBIE(2);
 
-  /**
-   * sortPriority: available to plugins and the server for sorting Actions by type <br>
-   * processPriority: used by the server to prioritize checking the status of certain types of
-   * actions first, as having up-to-date information from a remote server on these actions is more
-   * important.
-   *
-   * <p>Both are intended to be used by Comparators, so lower values indicate higher priority. Both
-   * are separate from an individual Action's priority value.
-   */
-  private final int sortPriority, processPriority;
+  private final int processPriority;
 
-  ActionState(int sortPriority, int processPriority) {
-    this.sortPriority = sortPriority;
+  ActionState(int processPriority) {
     this.processPriority = processPriority;
   }
 
   /**
-   * The priority of an action state where the largest number indicates the most miserable action
-   *
-   * @return an integer indicating relative misery
-   */
-  public int sortPriority() {
-    return sortPriority;
-  }
-
-  /**
    * The priority of an action state for polling
+   *
+   * <p>Used by the server to prioritize checking the status of certain types of actions first, as
+   * having up-to-date information from a remote server on these actions is more important.
    *
    * @return an integer indicating relative processing urgency
    */

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/ActionProcessor.java
@@ -185,7 +185,7 @@ public final class ActionProcessor
     }
   }
 
-  private static class Information {
+  private static class Information implements Comparable<Information> {
 
     public final Instant created = Instant.now();
     final String id;
@@ -210,6 +210,11 @@ public final class ActionProcessor
         id = "";
       }
       this.id = id;
+    }
+
+    @Override
+    public int compareTo(Information information) {
+      return Integer.compare(lastState.processPriority(), information.lastState.processPriority());
     }
   }
 
@@ -1706,7 +1711,7 @@ public final class ActionProcessor
                                     .getSeconds()
                                 / 600)
                     .thenComparingInt(e -> e.getKey().priority()))
-            .sorted(Comparator.comparingInt(x -> x.getValue().lastState.processPriority()))
+            .sorted(Map.Entry.comparingByValue())
             .limit(1000L * ACTION_PERFORM_THREADS - currentRunningActions.get())
             .collect(Collectors.toList());
     currentRunningActionsGauge.set(currentRunningActions.addAndGet(candidates.size()));


### PR DESCRIPTION
This method was only used by the now-defunct JIRA client.

- [x] Updates Changelog
- [x] Updates developer documentation
