### PR TITLE
Fix JSON serialization bug with input formats

### DIFF
--- a/changes/change_json_serialize.md
+++ b/changes/change_json_serialize.md
@@ -1,0 +1,1 @@
+* Fix bug causing wrong field names in serialization

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/BaseInputFormatDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/server/plugins/BaseInputFormatDefinition.java
@@ -468,7 +468,7 @@ public abstract class BaseInputFormatDefinition implements InputFormatDefinition
             .map(
                 variable ->
                     new Pair<>(
-                        name,
+                        variable.name(),
                         MethodHandleProxies.asInterfaceInstance(
                             JsonFieldWriter.class,
                             MethodHandles.collectArguments(


### PR DESCRIPTION
This mistake was causing each variable to be output the field name rather than the variable name.

JIRA Ticket: 

- [X] Updates Changelog
- [NA] Updates developer documentation
