### PR TITLE
Fix authentication using ShAWK client

### DIFF
--- a/changes/fix_shawk_pass.md
+++ b/changes/fix_shawk_pass.md
@@ -1,0 +1,1 @@
+* Fix authentication using ShAWK client


### PR DESCRIPTION
Corrects a bug where authentication would discard the password from the user and send a passwordless `Basic` header and allows the user to try again if authorization fails.

JIRA Ticket: 

- [X] Updates Changelog
- [NA] Updates developer documentation
