### PR TITLE
Fix `json-dir-list` dependencies on Windows

### DIFF
--- a/changes/fix_json_dir_list_deps.md
+++ b/changes/fix_json_dir_list_deps.md
@@ -1,0 +1,1 @@
+* Remove `users` crate from dependency list when building `json-dir-list` on Windows

--- a/json-dir-list/Cargo.toml
+++ b/json-dir-list/Cargo.toml
@@ -17,4 +17,5 @@ chrono = "^0.4"
 gethostname = "^0.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
+[target.'cfg(unix)'.dependencies]
 users = "^0.11"


### PR DESCRIPTION
As titled.

- [X] Updates Changelog
- [NA] Updates developer documentation
