### PR TITLE
[GP-4245] format comment according to version

### DIFF
--- a/changes/fix_v3.md
+++ b/changes/fix_v3.md
@@ -1,0 +1,2 @@
+Fix compatibility with Jira V3 API 
+

--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
@@ -419,7 +419,11 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
                 .add(
                     MAPPER
                         .createObjectNode()
-                        .set("add", MAPPER.createObjectNode().put("body", comment))));
+                        .set(
+                            "add",
+                            MAPPER
+                                .createObjectNode()
+                                .set("body", version.createDocument(comment)))));
         request.setUpdate(updateComment);
 
         final var requestBuilder =


### PR DESCRIPTION
JIRA Ticket: GP-4245
For compatibility with JIRA Cloud API
if 'version' is JiraVersion.V2, does nothing
if 'version' is JiraVersion.V3, wraps comment in all the json nonsense Atlassian expects

- [X] Updates Changelog
- [ ] Updates developer documentation
