### PR TITLE
Let text searches access the vidarr id

### DIFF
--- a/changes/fix_vidarr-search.md
+++ b/changes/fix_vidarr-search.md
@@ -1,0 +1,2 @@
+Text search includes vidarr id
+

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunState.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunState.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -19,6 +20,8 @@ import java.util.stream.Stream;
  * state.
  */
 abstract class RunState {
+
+  public abstract boolean search(Pattern query);
 
   public static final class PerformResult {
     private final ActionState actionState;

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateAttemptSubmit.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /** State when we have no knowledge of what's going on in Vidarr */
@@ -34,6 +35,11 @@ final class RunStateAttemptSubmit extends RunState {
 
   public RunStateAttemptSubmit(int attempt) {
     this.attempt = attempt;
+  }
+
+  @Override
+  public boolean search(Pattern query) {
+    return false;
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateConflicted.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateConflicted.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 final class RunStateConflicted extends RunState {
@@ -24,6 +25,11 @@ final class RunStateConflicted extends RunState {
         List.of(
             "Multiple possible Vidarr matches! Fix workflow runs in Vidarr and reset this action or change the olive and purge this action: "
                 + String.join(", ", ids));
+  }
+
+  @Override
+  public boolean search(Pattern query) {
+    return ids.stream().anyMatch(id -> query.matcher(id).matches());
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateDead.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateDead.java
@@ -10,9 +10,15 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 final class RunStateDead extends RunState {
+
+  @Override
+  public boolean search(Pattern query) {
+    return false;
+  }
 
   @Override
   public AvailableCommands commands() {

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMissing.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,6 +33,11 @@ final class RunStateMissing extends RunState {
                                 "LIMS key %s/%s does not have a version that overlaps with LIMS key in Vidarr workflow run %s.",
                                 k.getProvider(), k.getId(), id)))
             .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean search(Pattern query) {
+    return query.matcher(id).matches();
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/RunStateMonitor.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 final class RunStateMonitor extends RunState {
@@ -91,6 +92,11 @@ final class RunStateMonitor extends RunState {
     super();
     this.workflowRunUrl = workflowRunUrl;
     this.status = status;
+  }
+
+  @Override
+  public boolean search(Pattern query) {
+    return query.matcher(status.getId()).matches();
   }
 
   @Override

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/SubmitAction.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/SubmitAction.java
@@ -226,7 +226,8 @@ public final class SubmitAction extends Action {
                                         || query.matcher(v.getValue()).matches()))
         || checkJson(request.getArguments(), query)
         || checkJson(request.getMetadata(), query)
-        || checkJson(request.getEngineParameters(), query);
+        || checkJson(request.getEngineParameters(), query)
+        || state.search(query);
   }
 
   @ActionParameter(required = false)


### PR DESCRIPTION
Since we removed the vidarr-id tag due to being way too many tags, we need a new way to search actions by vidarr id. 
This change makes Text Search look at the vidarr id.

JIRA Ticket: n/a

- [x] Updates Changelog
- [ ] Updates developer documentation
