### PR TITLE
[GP-4352] Standard Output Logger plugin

### DIFF
--- a/changes/add_stdout.md
+++ b/changes/add_stdout.md
@@ -1,0 +1,2 @@
+Add Standard Output Logger as debugging alternative to Loki plugin.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,7 @@ information about how to extend the system. The plugins available are:
 - [Token Bucket Throttling](plugin-ratelimit.md)
 - [Run Scanner](plugin-runscanner.md)
 - [SFTP servers](plugin-sftp.md)
+- [Standard Output Logger](plugin-stdout.md)
 - [Tab-separated files](plugin-tsv.md)
 - [Víðarr](plugin-vidarr.md)
 

--- a/docs/plugin-loki.md
+++ b/docs/plugin-loki.md
@@ -8,7 +8,7 @@ ending `.loki` with the following:
       "labels": {
         "environment": "foo"
       },
-      "level": INFO
+      "level": "INFO"
     }
 
 The `"url"` property is the URL of the Loki server to push logs into. The

--- a/docs/plugin-stdout.md
+++ b/docs/plugin-stdout.md
@@ -1,0 +1,19 @@
+# Standard Output Logger
+The Standard Output Logger plugin provides an alternative to the [Loki plugin](plugin-loki.md) 
+which is useful in debugging scenarios where sending a development environment's logging output to Loki
+would be too noisy. **This plugin is not meant for production use.**
+
+To configure the Standard Output Logger, create a file ending with `.stdout` as follows:
+
+    {
+      "level": "INFO"
+    }
+
+The `"level"` property is one of:
+1. FATAL
+2. ERROR
+3. WARN
+4. INFO
+5. DEBUG
+
+All messages at or above the setting in severity will be logged to standard output. 

--- a/install-pom.xml
+++ b/install-pom.xml
@@ -106,6 +106,11 @@
     </dependency>
     <dependency>
       <groupId>ca.on.oicr.gsi</groupId>
+      <artifactId>shesmu-plugin-stdout</artifactId>
+      <version>${VERSION}</version>
+    </dependency>
+    <dependency>
+      <groupId>ca.on.oicr.gsi</groupId>
       <artifactId>shesmu-plugin-tsv</artifactId>
       <version>${VERSION}</version>
     </dependency>

--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
@@ -475,7 +475,8 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
               .append(commentResult.body());
           Map<String, String> lokiLabels = new HashMap<>();
           lokiLabels.put("issue", issue.getKey());
-          ((Definer<JiraConnection>) definer).log(errorBuilder.toString(), lokiLabels);
+          ((Definer<JiraConnection>) definer)
+              .log(errorBuilder.toString(), LogLevel.ERROR, lokiLabels);
         }
         return isGood;
       }

--- a/plugin-stdout/pom.xml
+++ b/plugin-stdout/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ca.on.oicr.gsi</groupId>
+        <artifactId>shesmu</artifactId>
+        <version>1.33.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>shesmu-plugin-stdout</artifactId>
+    <packaging>jar</packaging>
+    <name>Shesmu Decision-Action Server - Standard Output Logger</name>
+    <url>https://github.com/oicr-gsi/shesmu</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>ca.on.oicr.gsi</groupId>
+            <artifactId>shesmu-pluginapi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>shesmu-plugin-stdout</finalName>
+    </build>
+</project>

--- a/plugin-stdout/src/main/java/ca/on/oicr/gsi/shesmu/stdout/Configuration.java
+++ b/plugin-stdout/src/main/java/ca/on/oicr/gsi/shesmu/stdout/Configuration.java
@@ -1,0 +1,5 @@
+package ca.on.oicr.gsi.shesmu.stdout;
+
+import ca.on.oicr.gsi.shesmu.plugin.LogLevel;
+
+public record Configuration(LogLevel level) {}

--- a/plugin-stdout/src/main/java/ca/on/oicr/gsi/shesmu/stdout/StdoutPlugin.java
+++ b/plugin-stdout/src/main/java/ca/on/oicr/gsi/shesmu/stdout/StdoutPlugin.java
@@ -1,0 +1,45 @@
+package ca.on.oicr.gsi.shesmu.stdout;
+
+import ca.on.oicr.gsi.shesmu.plugin.Definer;
+import ca.on.oicr.gsi.shesmu.plugin.LogLevel;
+import ca.on.oicr.gsi.shesmu.plugin.json.JsonPluginFile;
+import ca.on.oicr.gsi.status.SectionRenderer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+public class StdoutPlugin extends JsonPluginFile<Configuration> {
+  private final Definer<StdoutPlugin> definer;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private Optional<Configuration> configuration = Optional.empty();
+
+  public StdoutPlugin(Path fileName, String instanceName, Definer<StdoutPlugin> definer) {
+    super(fileName, instanceName, MAPPER, Configuration.class);
+    this.definer = definer;
+  }
+
+  @Override
+  public void configuration(SectionRenderer renderer) {
+    configuration.ifPresent(value -> renderer.line("Level", value.level().toString()));
+  }
+
+  @Override
+  protected Optional<Integer> update(Configuration value) {
+    this.configuration = Optional.of(value);
+    return Optional.empty();
+  }
+
+  @Override
+  public synchronized void writeLog(
+      String message, LogLevel level, Map<String, String> attributes) {
+    if (level.compareTo(this.configuration.get().level()) >= 0) {
+      StringBuilder writeOut = new StringBuilder();
+      writeOut.append(message);
+      for (Map.Entry<String, String> e : attributes.entrySet()) {
+        writeOut.append(", ").append(e.getKey()).append(": ").append(e.getValue());
+      }
+      System.out.println(writeOut);
+    }
+  }
+}

--- a/plugin-stdout/src/main/java/ca/on/oicr/gsi/shesmu/stdout/StdoutPluginType.java
+++ b/plugin-stdout/src/main/java/ca/on/oicr/gsi/shesmu/stdout/StdoutPluginType.java
@@ -1,0 +1,18 @@
+package ca.on.oicr.gsi.shesmu.stdout;
+
+import ca.on.oicr.gsi.shesmu.plugin.Definer;
+import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+
+/** Allows logging through the Definer to stdout */
+public class StdoutPluginType extends PluginFileType<StdoutPlugin> {
+  public StdoutPluginType() {
+    super(MethodHandles.lookup(), StdoutPlugin.class, ".stdout", "stdout");
+  }
+
+  @Override
+  public StdoutPlugin create(Path filePath, String instanceName, Definer<StdoutPlugin> definer) {
+    return new StdoutPlugin(filePath, instanceName, definer);
+  }
+}

--- a/plugin-stdout/src/main/java/module-info.java
+++ b/plugin-stdout/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+import ca.on.oicr.gsi.shesmu.plugin.PluginFileType;
+import ca.on.oicr.gsi.shesmu.stdout.StdoutPluginType;
+
+module plugin.stdout {
+  exports ca.on.oicr.gsi.shesmu.stdout;
+
+  requires ca.on.oicr.gsi.shesmu;
+  requires ca.on.oicr.gsi.serverutils;
+  requires com.fasterxml.jackson.databind;
+
+  provides PluginFileType with
+      StdoutPluginType;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
     <module>plugin-prometheus</module>
     <module>plugin-ratelimit</module>
     <module>plugin-sftp</module>
+    <module>plugin-stdout</module>
     <module>plugin-tsv</module>
     <module>plugin-vidarr</module>
     <module>maintenance-editor</module>


### PR DESCRIPTION
JIRA Ticket: GP-4352

If no plugin with logging (ie, only Loki at this time) is configured, logs written out through the Definer are simply lost.
The PluginManager cannot have enough insight into the plugins in order to determine whether one of the plugins actually does anything with the log lines, so the PluginManager cannot itself provide a stdout fallback.
Implements a stdout logging plugin for use in local development scenarios where you do not want to connect your local shesmu to loki and pollute the logs there.

Also fixes a compilation problem on master.

- [X] Updates Changelog
- [ ] Updates developer documentation
