### PR TITLE
Fix value/list keys in `IntersectionJoin`

### DIFF
--- a/changes/fix_intersection_join.md
+++ b/changes/fix_intersection_join.md
@@ -1,0 +1,1 @@
+* Made `IntersectionJoin` match value/list keys instead of just list/list keys. This makes it match the docs.

--- a/docs/language.md
+++ b/docs/language.md
@@ -263,8 +263,8 @@ sources must not overlap. Rows are joined if _outerkey_ and _innerkey_ match:
 | Operation          | Outer Key | Inner Key | Behaviour |
 |--------------------|-----------|-----------|---|
 | `Join`             | _k_       | _i_       | Matches if _k_ = _i_. |
-| `IntersectionJoin` | _k_       | _i_       | Matches if `For x In `_k`_`: Any x In `_i_ |
-| `IntersectionJoin` | `[`_k_`]` | _i_       | Matches if _k`_` In `_i_ |
+| `IntersectionJoin` | _k_       | _i_       | Matches if `For x In `_k_`: Any x In `_i_ |
+| `IntersectionJoin` | `[`_k_`]` | _i_       | Matches if _k_` In `_i_ |
 | `IntersectionJoin` | _k_       | `[`_i_`]` | Matches if _i_` In `_k_ |
 
 In `Join`, keys are values that must match exactly. In `IntersectionJoin`, the

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinKind.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinKind.java
@@ -1,0 +1,52 @@
+package ca.on.oicr.gsi.shesmu.compiler;
+
+import java.util.*;
+import java.util.function.*;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
+
+public enum JoinKind {
+  DIRECT(false) {},
+  INTERSECTION(true) {},
+  INTERSECTION_LIFT_INNER(true) {
+    @Override
+    public void renderInnerKeyWrapper(Renderer renderer) {
+      liftFunction(renderer);
+    }
+  },
+  INTERSECTION_LIFT_OUTER(true) {
+    public void renderOuterKeyWrapper(Renderer renderer) {
+      liftFunction(renderer);
+    }
+  };
+
+  private static void liftFunction(Renderer renderer) {
+    LambdaBuilder.pushStatic(
+        renderer, A_SET_TYPE, "of", LambdaBuilder.function(A_SET_TYPE, A_OBJECT_TYPE), true);
+    renderer.methodGen().invokeInterface(A_FUNCTION_TYPE, METHOD_FUNCTION__AND_THEN);
+  }
+
+  private static final Type A_FUNCTION_TYPE = Type.getType(Function.class);
+  private static final Type A_OBJECT_TYPE = Type.getType(Object.class);
+  private static final Type A_SET_TYPE = Type.getType(Set.class);
+  private static final Method METHOD_FUNCTION__AND_THEN =
+      new Method("andThen", A_FUNCTION_TYPE, new Type[] {A_FUNCTION_TYPE});
+
+  private final boolean intersection;
+
+  private JoinKind(boolean intersection) {
+    this.intersection = intersection;
+  }
+
+  public final boolean intersection() {
+    return intersection;
+  }
+
+  public void renderInnerKeyWrapper(Renderer renderer) {
+    // Do nothing.
+  }
+
+  public void renderOuterKeyWrapper(Renderer renderer) {
+    // Do nothing.
+  }
+}

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LambdaBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/LambdaBuilder.java
@@ -800,6 +800,12 @@ public final class LambdaBuilder {
 
   /** Create a lambda that calls a static method. */
   public static void pushStatic(Renderer renderer, Type owner, String name, LambdaType lambda) {
+    pushStatic(renderer, owner, name, lambda, false);
+  }
+
+  /** Create a lambda that calls a static method. */
+  public static void pushStatic(
+      Renderer renderer, Type owner, String name, LambdaType lambda, boolean isInterface) {
     renderer
         .methodGen()
         .invokeDynamic(
@@ -816,7 +822,7 @@ public final class LambdaBuilder {
                 Type.getMethodDescriptor(
                     lambda.returnType(AccessMode.REAL),
                     lambda.parameterTypes(AccessMode.REAL).toArray(Type[]::new)),
-                false),
+                isInterface),
             Type.getMethodType(
                 lambda.returnType(AccessMode.BOXED),
                 lambda.parameterTypes(AccessMode.BOXED).toArray(Type[]::new)));

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeIntersectionJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeIntersectionJoin.java
@@ -17,17 +17,21 @@ public class OliveClauseNodeIntersectionJoin extends OliveClauseNodeBaseJoin {
   }
 
   @Override
-  protected boolean intersection() {
-    return true;
-  }
-
-  @Override
   public String syntax() {
     return "IntersectionJoin";
   }
 
   @Override
-  protected Optional<Imyhat> typeCheckExtra(Imyhat type) {
-    return type instanceof ListImyhat ? Optional.empty() : Optional.of(type.asList());
+  protected Optional<JoinKind> typeCheckKeys(Imyhat outerKey, Imyhat innerKey) {
+    if (innerKey.isSame(outerKey) && innerKey instanceof ListImyhat) {
+      return Optional.of(JoinKind.INTERSECTION);
+    }
+    if (innerKey.isSame(outerKey.asList()) && innerKey instanceof ListImyhat) {
+      return Optional.of(JoinKind.INTERSECTION_LIFT_OUTER);
+    }
+    if (innerKey.asList().isSame(outerKey) && outerKey instanceof ListImyhat) {
+      return Optional.of(JoinKind.INTERSECTION_LIFT_INNER);
+    }
+    return Optional.empty();
   }
 }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeJoin.java
@@ -16,17 +16,12 @@ public class OliveClauseNodeJoin extends OliveClauseNodeBaseJoin {
   }
 
   @Override
-  protected boolean intersection() {
-    return false;
-  }
-
-  @Override
   public String syntax() {
     return "Join";
   }
 
   @Override
-  protected Optional<Imyhat> typeCheckExtra(Imyhat type) {
-    return Optional.empty();
+  protected Optional<JoinKind> typeCheckKeys(Imyhat outerKey, Imyhat innerKey) {
+    return innerKey.isSame(outerKey) ? Optional.of(JoinKind.DIRECT) : Optional.empty();
   }
 }

--- a/shesmu-server/src/test/resources/run/intersectionjoin-liftinner.shesmu
+++ b/shesmu-server/src/test/resources/run/intersectionjoin-liftinner.shesmu
@@ -1,0 +1,8 @@
+Version 1;
+Input test;
+
+Olive
+ Let accession
+ IntersectionJoin [False, True] To inner_test True
+ Group By accession Into ls = List l
+ Run ok With ok = (For l In ls: Count) == 2;

--- a/shesmu-server/src/test/resources/run/intersectionjoin-liftouter.shesmu
+++ b/shesmu-server/src/test/resources/run/intersectionjoin-liftouter.shesmu
@@ -1,0 +1,8 @@
+Version 1;
+Input test;
+
+Olive
+ Let accession
+ IntersectionJoin True To inner_test [True]
+ Group By accession Into ls = List l
+ Run ok With ok = (For l In ls: Count) == 2;


### PR DESCRIPTION
The documentation says that `IntersectionJoin` can match value/list keys instead of just list/list keys, but this functionality was missing.

JIRA Ticket: 

- [X] Updates Changelog
- [X] Updates developer documentation
