### PR TITLE
Update deprecated `json-dir-list` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,13 +544,13 @@ dependencies = [
 
 [[package]]
 name = "json-dir-list"
-version = "1.34.2"
+version = "1.35.0"
 dependencies = [
  "chrono",
  "gethostname",
  "serde",
  "serde_json",
- "users",
+ "uzers",
 ]
 
 [[package]]
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "shawk"
-version = "1.34.2"
+version = "1.35.0"
 dependencies = [
  "clap",
  "directories",
@@ -1188,20 +1188,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uzers"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "vcpkg"

--- a/changes/fix_jdl_deps.md
+++ b/changes/fix_jdl_deps.md
@@ -1,0 +1,1 @@
+* Update deprecated dependencies for `json-dir-list`

--- a/json-dir-list/Cargo.toml
+++ b/json-dir-list/Cargo.toml
@@ -19,4 +19,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 
 [target.'cfg(unix)'.dependencies]
-users = "^0.11"
+uzers = "^0.12"

--- a/json-dir-list/src/main.rs
+++ b/json-dir-list/src/main.rs
@@ -40,10 +40,10 @@ fn write_record(
         (time as f64) + (time_ns as f64) / 1e9
     }
 
-    let Some(user) = users::get_user_by_uid(metadata.uid()) else {
+    let Some(user) = uzers::get_user_by_uid(metadata.uid()) else {
         return;
     };
-    let Some(group) = users::get_group_by_gid(metadata.gid()) else {
+    let Some(group) = uzers::get_group_by_gid(metadata.gid()) else {
         return;
     };
     output


### PR DESCRIPTION
Replace unmaintained `users` crate with `uzers` crate.

- [X] Updates Changelog
- [NA] Updates developer documentation
