### PR TITLE
Add timeouts to SSH refillers

### DIFF
--- a/changes/fix_ssh_refiller_timeout.md
+++ b/changes/fix_ssh_refiller_timeout.md
@@ -1,0 +1,2 @@
+* Adds a timeout for SSH refillers
+* Changes the SSH refiller syntax to use the environment variable `SHESMU_REFILLER_HASH` instead of a command line argument. Use `jq '.refillers = (.refillers[] | .command += " $SHESMU_REFILLER_HASH")'` to restore the command line argument. This change can be safely applied before upgrading since it will be a no-op in the previous version.

--- a/plugin-pinery/pom.xml
+++ b/plugin-pinery/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/plugin-sftp/pom.xml
+++ b/plugin-sftp/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
     </dependency>

--- a/plugin-sftp/shesmu-json-refiller
+++ b/plugin-sftp/shesmu-json-refiller
@@ -4,64 +4,65 @@
 #
 # This does no processing to the data and therefore can be used with any format.
 
-NEW_CHECKSUM=MISSING
 HELP=false
 NAME=refiller
 TARGET_DIR=.
-
+if [ "x${SHESMU_REFILLER_HASH}" = "x" ]; then
+	HELP=true
+fi
 set -eu
 
-TEMP=`getopt c:d:hn: "$@"`
+TEMP=$(getopt d:hn: "$@")
 
-if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
-
-eval set -- "$TEMP"
-
-while true ; do
-	case "$1" in
-		-c)
-			NEW_CHECKSUM="$2"
-			shift 2
-			;;
-		-d)
-			TARGET_DIR="$2"
-			shift 2
-			;;
-		-h)
-			HELP=true
-      shift
-			;;
-		-n)
-			NAME="$2"
-			shift 2
-			;;
-		--)
-			shift
-			break
-			;;
-		*) echo "Internal error!" ; exit 1 ;;
-	esac
-done
-
-if $HELP || [ $# -ne 0 ] || [ "${NEW_CHECKSUM}" = "MISSING" ]
-then
-	echo $0 '-c checksum [-d outputdir] [-n name]'
-	echo '  -c  The checksum provided by Shesmu'
-	echo '  -d  Directory to place output in (default is current directory)'
-	echo '  -h  Display help'
-	echo '  -n  The prefix of the output file (default is refiller)'
+if [ $? != 0 ]; then
+	echo "Terminating..." >&2
 	exit 1
 fi
 
+eval set -- "$TEMP"
+
+while true; do
+	case "$1" in
+	-d)
+		TARGET_DIR="$2"
+		shift 2
+		;;
+	-h)
+		HELP=true
+		shift
+		;;
+	-n)
+		NAME="$2"
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	*)
+		echo "Internal error!"
+		exit 1
+		;;
+	esac
+done
+
+if $HELP || [ $# -ne 0 ]; then
+	echo $0 '[-d outputdir] [-n name]'
+	echo '  -d  Directory to place output in (default is current directory)'
+	echo '  -h  Display help'
+	echo '  -n  The prefix of the output file (default is refiller)'
+	echo 'SHESMU_REFILLER_HASH must also be set'
+	exit 1
+fi
 
 cd "${TARGET_DIR}"
 if [ -f "${NAME}.checksum" ]; then
 	EXISTING_CHECKSUM="$(cat "${NAME}.checksum")"
-	if [ "${NEW_CHECKSUM}" = "${EXISTING_CHECKSUM}" ]; then
+	if [ "${SHESMU_REFILLER_HASH}" = "${EXISTING_CHECKSUM}" ]; then
 		echo OK
 		exit 0
 	fi
 fi
 echo UPDATE
 cat >"${NAME}.json"
-echo "${NEW_CHECKSUM}" >"${NAME}.checksum"
+echo "${SHESMU_REFILLER_HASH}" >"${NAME}.checksum"

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/Configuration.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/Configuration.java
@@ -11,6 +11,7 @@ public class Configuration {
   private List<JsonDataSource> jsonSources = List.of();
   private String listCommand;
   private int port;
+  private Integer refillerTimeout;
   private Map<String, RefillerConfig> refillers = Map.of();
   private String user;
 
@@ -40,6 +41,10 @@ public class Configuration {
 
   public int getPort() {
     return port;
+  }
+
+  public Integer getRefillerTimeout() {
+    return refillerTimeout;
   }
 
   public Map<String, RefillerConfig> getRefillers() {
@@ -76,6 +81,10 @@ public class Configuration {
 
   public void setPort(int port) {
     this.port = port;
+  }
+
+  public void setRefillerTimeout(Integer refillerTimeout) {
+    this.refillerTimeout = refillerTimeout;
   }
 
   public void setRefillers(Map<String, RefillerConfig> refillers) {

--- a/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/RefillerConfig.java
+++ b/plugin-sftp/src/main/java/ca/on/oicr/gsi/shesmu/sftp/RefillerConfig.java
@@ -6,6 +6,7 @@ import java.util.Map;
 public class RefillerConfig {
   private String command;
   private Map<String, Imyhat> parameters;
+  private Integer timeout;
 
   public String getCommand() {
     return command;
@@ -15,11 +16,19 @@ public class RefillerConfig {
     return parameters;
   }
 
+  public Integer getTimeout() {
+    return timeout;
+  }
+
   public void setCommand(String command) {
     this.command = command;
   }
 
   public void setParameters(Map<String, Imyhat> parameters) {
     this.parameters = parameters;
+  }
+
+  public void setTimeout(Integer timeout) {
+    this.timeout = timeout;
   }
 }

--- a/plugin-sftp/src/main/java/module-info.java
+++ b/plugin-sftp/src/main/java/module-info.java
@@ -8,12 +8,13 @@ module ca.on.oicr.gsi.shesmu.plugin.sftp {
   requires ca.on.oicr.gsi.shesmu;
   requires com.fasterxml.jackson.databind;
   requires com.hierynomus.sshj;
-  requires simpleclient;
+  requires org.apache.commons.text;
+  requires org.bouncycastle.pkix;
+  requires org.bouncycastle.provider;
+  requires org.bouncycastle.util;
   requires org.slf4j.jul;
   requires org.slf4j;
-  requires org.bouncycastle.util;
-  requires org.bouncycastle.provider;
-  requires org.bouncycastle.pkix;
+  requires simpleclient;
 
   provides PluginFileType with
       SftpPluginType;

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
         <artifactId>commons-csv</artifactId>
         <version>1.10.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.10.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <modules>


### PR DESCRIPTION
Force all SSH refillers to be run through the `timeout` command to limit their runtime. This also moves the provided checksum from a command line argument to an environment variable.

JIRA Ticket: 

- [X] Updates Changelog
- [X] Updates developer documentation
