### PR TITLE
[GP-4560] Follow 301 locations

### DIFF
--- a/changes/fix_301.md
+++ b/changes/fix_301.md
@@ -1,0 +1,1 @@
+Follow location header when 301 received on initial plugin configuration

--- a/plugin-runscanner/src/main/java/module-info.java
+++ b/plugin-runscanner/src/main/java/module-info.java
@@ -12,6 +12,7 @@ module ca.on.oicr.gsi.shesmu.plugin.runscanner {
   requires com.fasterxml.jackson.databind;
   requires com.fasterxml.jackson.datatype.jsr310;
   requires java.net.http;
+  requires simpleclient;
 
   provides GrouperDefinition with
       LaneSplittingGrouperDefinition;

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/VidarrPlugin.java
@@ -1,10 +1,7 @@
 package ca.on.oicr.gsi.shesmu.vidarr;
 
 import ca.on.oicr.gsi.Pair;
-import ca.on.oicr.gsi.shesmu.plugin.Definer;
-import ca.on.oicr.gsi.shesmu.plugin.Parser;
-import ca.on.oicr.gsi.shesmu.plugin.SupplementaryInformation;
-import ca.on.oicr.gsi.shesmu.plugin.Tuple;
+import ca.on.oicr.gsi.shesmu.plugin.*;
 import ca.on.oicr.gsi.shesmu.plugin.action.CustomActionParameter;
 import ca.on.oicr.gsi.shesmu.plugin.action.ShesmuAction;
 import ca.on.oicr.gsi.shesmu.plugin.cache.KeyValueCache;
@@ -36,12 +33,8 @@ import java.net.http.HttpRequest;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -421,6 +414,12 @@ public class VidarrPlugin extends JsonPluginFile<Configuration> {
           }
         }
         return Optional.of(10);
+      } else if (workflowsResult.statusCode() == 301) {
+        value.setUrl(Utils.get301LocationUrl(workflowsResult, definer));
+        return update(value);
+      } else if (targetsResult.statusCode() == 301) {
+        value.setUrl(Utils.get301LocationUrl(targetsResult, definer));
+        return update(value);
       } else {
         return Optional.of(2);
       }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Utils.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/Utils.java
@@ -1,10 +1,11 @@
 package ca.on.oicr.gsi.shesmu.plugin;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
-import java.util.Iterator;
-import java.util.Optional;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -63,4 +64,24 @@ public class Utils {
   private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
   private Utils() {}
+
+  public static String get301LocationUrl(HttpResponse httpResponse, Definer definer) {
+    HttpHeaders headers = httpResponse.headers();
+    try {
+      URI urlFrom301 = new URI(headers.map().get("location").get(0));
+      String newUrl = new URI(urlFrom301.getScheme() + "://" + urlFrom301.getHost()).toString();
+      definer.log(
+          "Got 301 when configuring plugin, updating URL to " + newUrl,
+          LogLevel.WARN,
+          new TreeMap<>());
+      return newUrl;
+    } catch (URISyntaxException use) {
+      definer.log(
+          "Got 301 when configuring plugin, HTTP location header invalid: "
+              + headers.map().get("location").get(0),
+          LogLevel.ERROR,
+          new TreeMap<>());
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
JIRA Ticket: GP-4560

Get the URL from the 'location' header a 301 response is supposed to have, recursively try again with updated configuration.

Only did plugins that try to communicate with a remote service on configuration update()

- [x] Updates Changelog
- [ ] Updates developer documentation
