### PR TITLE
Link to run's /run/ URL if run is completed, and to /status/ URL if run is not completed

### DIFF
--- a/changes/change_vidarr_link.md
+++ b/changes/change_vidarr_link.md
@@ -1,0 +1,1 @@
+On Vidarr action card, if run is completed, link to run's `/run/<id>` page. If run is not completed, continue to link to run's `/status/<id>` page.

--- a/plugin-vidarr/src/main/resources/ca/on/oicr/gsi/shesmu/vidarr/renderer.js
+++ b/plugin-vidarr/src/main/resources/ca/on/oicr/gsi/shesmu/vidarr/renderer.js
@@ -74,7 +74,9 @@ const vidarrStateRenderer = {
   monitor: (a) => [
     table(
       [
-        ["Vidarr ID", link(a.workflowRunUrl, a.info.id)],
+        ["Vidarr ID", link(
+		(a.info.completed ? a.workflowRunUrl.replace("status", "run") : a.workflowRunUrl), 
+		a.info.id)],
         ["Modified", timespan(a.modified)],
         ["Created", timespan(a.info.created)],
         ["Started", timespan(a.info.started)],


### PR DESCRIPTION
JIRA Ticket: 

- [x] Updates Changelog
- [ ] Updates developer documentation

The `/run/<id>` page has info you'd want to see for a completed run, like its analysis info. The `/status/<id>` page has info you'd want to see for a non-completed run, like its operations and status. This is a small convenience change to make it so I don't keep manually changing `status` to `run` when I'm looking for info on a completed run's page.