### PR TITLE
Add metadata for case archive

### DIFF
--- a/changes/add_metadata_to_case_archive.md
+++ b/changes/add_metadata_to_case_archive.md
@@ -1,0 +1,1 @@
+Add metadata to Nabu archive_case action

--- a/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveDto.java
+++ b/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveDto.java
@@ -1,6 +1,7 @@
 package ca.on.oicr.gsi.shesmu.nabu;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Set;
 
 /** This class allows for proper deserialization of JSON data */
@@ -14,6 +15,7 @@ public class NabuCaseArchiveDto {
   private String filesCopiedToOffsiteArchiveStagingDir;
   private String filesLoadedIntoVidarrArchival;
   private Set<String> limsIds;
+  private ObjectNode metadata;
   private String modified;
   private long requisitionId;
   private Set<String> workflowRunIdsForOffsiteArchive;
@@ -45,6 +47,10 @@ public class NabuCaseArchiveDto {
 
   public Set<String> getLimsIds() {
     return limsIds;
+  }
+
+  public ObjectNode getMetadata() {
+    return metadata;
   }
 
   public String getModified() {
@@ -90,6 +96,10 @@ public class NabuCaseArchiveDto {
 
   public void setLimsIds(Set<String> limsIds) {
     this.limsIds = limsIds;
+  }
+
+  public void setMetadata(ObjectNode metadata) {
+    this.metadata = metadata;
   }
 
   public void setModified(String modified) {

--- a/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveValue.java
+++ b/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveValue.java
@@ -128,7 +128,7 @@ public class NabuCaseArchiveValue {
 
   @ShesmuVariable(
       type =
-          "o5case_total_size$qioffsite_archive_size$qionsite_archive_size$qiassay_name$qsassay_version$qs")
+          "o5assay_name$qsassay_version$qscase_total_size$qioffsite_archive_size$qionsite_archive_size$qi")
   // If this object's size changes, the deserialization code needs to change as well
   public Tuple metadata() {
     return metadata;

--- a/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveValue.java
+++ b/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuCaseArchiveValue.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.nabu;
 
+import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.input.ShesmuVariable;
 import java.time.Instant;
 import java.util.Objects;
@@ -15,6 +16,7 @@ public class NabuCaseArchiveValue {
   private final Optional<Instant> files_copied_to_offsite_archive_staging_dir;
   private final Optional<Instant> files_loaded_into_vidarr_archival;
   private final Set<String> lims_ids;
+  private final Tuple metadata;
   private final Instant modified;
   private final long requisition_id;
   private final Set<String> workflow_run_ids_for_offsite_archive;
@@ -28,6 +30,7 @@ public class NabuCaseArchiveValue {
       Optional<Instant> files_copied_to_offsite_archive_staging_dir,
       Optional<Instant> files_loaded_into_vidarr_archival,
       Set<String> lims_ids,
+      Tuple metadata,
       Instant modified,
       long requisition_id,
       Set<String> workflow_run_ids_for_offsite_archive,
@@ -40,6 +43,7 @@ public class NabuCaseArchiveValue {
     this.files_copied_to_offsite_archive_staging_dir = files_copied_to_offsite_archive_staging_dir;
     this.files_loaded_into_vidarr_archival = files_loaded_into_vidarr_archival;
     this.lims_ids = lims_ids;
+    this.metadata = metadata;
     this.modified = modified;
     this.requisition_id = requisition_id;
     this.workflow_run_ids_for_offsite_archive = workflow_run_ids_for_offsite_archive;
@@ -83,6 +87,7 @@ public class NabuCaseArchiveValue {
             == that.files_copied_to_offiste_archive_staging_dir()
         && files_loaded_into_vidarr_archival == that.files_loaded_into_vidarr_archival()
         && lims_ids.equals(that.lims_ids())
+        && metadata.equals(that.metadata())
         && modified.equals(that.modified())
         && requisition_id == that.requisition_id()
         && workflow_run_ids_for_offsite_archive.equals(that.workflow_run_ids_for_offsite_archive())
@@ -109,6 +114,7 @@ public class NabuCaseArchiveValue {
         files_copied_to_offsite_archive_staging_dir,
         files_loaded_into_vidarr_archival,
         lims_ids,
+        metadata,
         modified,
         requisition_id,
         workflow_run_ids_for_offsite_archive,
@@ -118,6 +124,14 @@ public class NabuCaseArchiveValue {
   @ShesmuVariable
   public Set<String> lims_ids() {
     return lims_ids;
+  }
+
+  @ShesmuVariable(
+      type =
+          "o5case_total_size$qioffsite_archive_size$qionsite_archive_size$qiassay_name$qsassay_version$qs")
+  // If this object's size changes, the deserialization code needs to change as well
+  public Tuple metadata() {
+    return metadata;
   }
 
   @ShesmuVariable

--- a/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuPlugin.java
+++ b/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuPlugin.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.shesmu.nabu;
 
 import ca.on.oicr.gsi.shesmu.plugin.Definer;
 import ca.on.oicr.gsi.shesmu.plugin.ErrorableStream;
+import ca.on.oicr.gsi.shesmu.plugin.Tuple;
 import ca.on.oicr.gsi.shesmu.plugin.action.ShesmuAction;
 import ca.on.oicr.gsi.shesmu.plugin.cache.ReplacingRecord;
 import ca.on.oicr.gsi.shesmu.plugin.cache.ValueCache;
@@ -9,6 +10,7 @@ import ca.on.oicr.gsi.shesmu.plugin.input.ShesmuInputSource;
 import ca.on.oicr.gsi.shesmu.plugin.json.JsonListBodyHandler;
 import ca.on.oicr.gsi.shesmu.plugin.json.JsonPluginFile;
 import ca.on.oicr.gsi.status.SectionRenderer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
@@ -53,12 +55,36 @@ public class NabuPlugin extends JsonPluginFile<NabuConfiguration> {
                           ? Optional.empty()
                           : Optional.of(Instant.parse(ca.getFilesLoadedIntoVidarrArchival())),
                       ca.getLimsIds(),
+                      deserializeMetadata(ca.getMetadata()),
                       Instant.parse(ca.getModified()),
                       ca.getRequisitionId(),
                       ca.getWorkflowRunIdsForOffsiteArchive(),
                       ca.getWorkflowRunIdsForVidarrArchival() == null
                           ? Optional.empty()
                           : Optional.of(ca.getWorkflowRunIdsForVidarrArchival())));
+    }
+
+    private Tuple deserializeMetadata(JsonNode metadata) {
+      if (metadata == null) {
+        return new Tuple();
+      } else {
+        return new Tuple(
+            metadata.findValue("case_total_size") == null
+                ? Optional.empty()
+                : metadata.get("case_total_size"),
+            metadata.findValue("offsite_archive_size") == null
+                ? Optional.empty()
+                : metadata.get("offsite_archive_size"),
+            metadata.findValue("onsite_archive_size") == null
+                ? Optional.empty()
+                : metadata.get("onsite_archive_size"),
+            metadata.findValue("assay_name") == null
+                ? Optional.empty()
+                : metadata.get("assay_name"),
+            metadata.findValue("assay_version") == null
+                ? Optional.empty()
+                : metadata.get("assay_version"));
+      }
     }
 
     @Override
@@ -131,7 +157,7 @@ public class NabuPlugin extends JsonPluginFile<NabuConfiguration> {
 
   @ShesmuAction(
       description = "send archiving info for case to Nabu (completes when files archived)")
-  public ArchiveCaseAction archive() {
+  public ArchiveCaseAction archive_case() {
     return new ArchiveCaseAction(definer);
   }
 

--- a/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuPlugin.java
+++ b/plugin-nabu/src/main/java/ca/on/oicr/gsi/shesmu/nabu/NabuPlugin.java
@@ -69,21 +69,21 @@ public class NabuPlugin extends JsonPluginFile<NabuConfiguration> {
         return new Tuple();
       } else {
         return new Tuple(
-            metadata.findValue("case_total_size") == null
-                ? Optional.empty()
-                : metadata.get("case_total_size"),
-            metadata.findValue("offsite_archive_size") == null
-                ? Optional.empty()
-                : metadata.get("offsite_archive_size"),
-            metadata.findValue("onsite_archive_size") == null
-                ? Optional.empty()
-                : metadata.get("onsite_archive_size"),
             metadata.findValue("assay_name") == null
                 ? Optional.empty()
-                : metadata.get("assay_name"),
+                : Optional.of(metadata.get("assay_name").textValue()),
             metadata.findValue("assay_version") == null
                 ? Optional.empty()
-                : metadata.get("assay_version"));
+                : Optional.of(metadata.get("assay_version").textValue()),
+            metadata.findValue("case_total_size") == null
+                ? Optional.empty()
+                : Optional.of(metadata.get("case_total_size").longValue()),
+            metadata.findValue("offsite_archive_size") == null
+                ? Optional.empty()
+                : Optional.of(metadata.get("offsite_archive_size").longValue()),
+            metadata.findValue("onsite_archive_size") == null
+                ? Optional.empty()
+                : Optional.of(metadata.get("onsite_archive_size").longValue()));
       }
     }
 


### PR DESCRIPTION
JIRA Ticket: GP-4647

- [x] Updates Changelog
- [ ] Updates developer documentation

Deployed on shesmu-dev; it's creating one archive_case action and you can test out the PR using the following olive which shows that it's correctly deserializing both case archives without the metadata and those with the metadata:

```
Version 1;
Input case_archive;

Olive
Where requisition_id In [1117, 649]
Dump All To dumpr

Run std::nothing With value = case_identifier;
```