### PR TITLE
Patch for null filename, but why is filename null?

### DIFF
--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/ConstantDefinition.java
@@ -358,6 +358,6 @@ public abstract class ConstantDefinition implements Target {
 
   @Override
   public String toString() {
-    return filename().toString();
+    return null == filename() ? description() : filename().toString();
   }
 }


### PR DESCRIPTION
JIRA Ticket: n/a

Patch for #1376 

As for why this happens: backlogged GP-4906

- [n/a] Updates Changelog
- [n/a] Updates developer documentation
