### PR TITLE
Fix code generation with aliased signatures

### DIFF
--- a/changes/fix_import_signature.md
+++ b/changes/fix_import_signature.md
@@ -1,0 +1,1 @@
+* Fixes multiple bugs where `Import std::*` would create duplicate, broken signatures for `std::signature::json` and friends

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FlattenBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/FlattenBuilder.java
@@ -53,7 +53,10 @@ public class FlattenBuilder {
             Stream.concat(
                     Stream.of(originalType, unrollType),
                     copySignatures
-                        ? owner.signatureVariables().map(s -> s.type().apply(TO_ASM))
+                        ? owner
+                            .signatureVariables()
+                            .filter(signer -> signer.name().equals(signer.unaliasedName()))
+                            .map(s -> s.type().apply(TO_ASM))
                         : Stream.empty())
                 .toArray(Type[]::new));
     final var ctor = new GeneratorAdapter(Opcodes.ACC_PUBLIC, ctorType, null, null, classVisitor);
@@ -77,6 +80,7 @@ public class FlattenBuilder {
     if (copySignatures) {
       owner
           .signatureVariables()
+          .filter(signer -> signer.name().equals(signer.unaliasedName()))
           .forEach(
               new Consumer<>() {
                 private int index = 2;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeCall.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeCall.java
@@ -84,6 +84,7 @@ public class JoinSourceNodeCall extends JoinSourceNode {
     oliveBuilder
         .owner
         .signatureVariables()
+        .filter(signer -> signer.name().equals(signer.unaliasedName()))
         .forEach(
             signer ->
                 OliveBuilder.createSignatureInfrastructure(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeInput.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/JoinSourceNodeInput.java
@@ -43,7 +43,10 @@ public final class JoinSourceNodeInput extends JoinSourceNode {
     oliveBuilder
         .owner
         .signatureVariables()
-        .filter(signature -> signatureUsed.test(variablePrefix + signature.name()))
+        .filter(
+            signature ->
+                signatureUsed.test(variablePrefix + signature.name())
+                    && signature.name().equals(signature.unaliasedName()))
         .forEach(
             signatureDefinition ->
                 oliveBuilder.createSignature(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveBuilder.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveBuilder.java
@@ -15,7 +15,6 @@ import java.lang.invoke.LambdaMetafactory;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
@@ -63,6 +62,7 @@ public final class OliveBuilder extends BaseOliveBuilder {
     staticMethod.visitCode();
     owner
         .signatureVariables()
+        .filter(signer -> signer.name().equals(signer.unaliasedName()))
         .forEach(
             signer -> {
               final var resultType = signer.type().apply(TypeUtils.TO_ASM);
@@ -237,9 +237,10 @@ public final class OliveBuilder extends BaseOliveBuilder {
             String.format(
                 "%s/Signer Accessor %d:%d", BaseHotloadingCompiler.PACKAGE_INTERNAL, line, column));
     signerPrefix = String.format("Olive %d:%d ", line, column);
-    final var signables = signableNames.collect(Collectors.toList());
+    final var signables = signableNames.toList();
     owner
         .signatureVariables()
+        .filter(signer -> signer.name().equals(signer.unaliasedName()))
         .forEach(
             signer -> createSignature(signerPrefix, initialFormat, signables.stream(), signer));
   }

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDumpAll.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/OliveClauseNodeDumpAll.java
@@ -58,9 +58,14 @@ public final class OliveClauseNodeDumpAll extends OliveClauseNodeBaseDump implem
       OliveCompilerServices oliveCompilerServices,
       NameDefinitions defs,
       Consumer<String> errorHandler) {
+    // The unaliased names are checked to avoid emitting signatures that are duplicated by an
+    // import.
     columns =
         defs.stream()
-            .filter(i -> i.flavour() == Flavour.STREAM || i.flavour() == Flavour.STREAM_SIGNABLE)
+            .filter(
+                i ->
+                    (i.flavour() == Flavour.STREAM || i.flavour() == Flavour.STREAM_SIGNABLE)
+                        && i.name().equals(i.unaliasedName()))
             .sorted(Comparator.comparing(Target::name))
             .collect(Collectors.toList());
     return defs;

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PragmaNodeInputGuard.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/PragmaNodeInputGuard.java
@@ -123,6 +123,7 @@ public class PragmaNodeInputGuard extends PragmaNode {
             .collect(Collectors.toList());
     final var prefix = String.format("Guard %d:%d ", line, column);
     root.signatureVariables()
+        .filter(signer -> signer.name().equals(signer.unaliasedName()))
         .forEach(
             signer ->
                 BaseOliveBuilder.createSignatureInfrastructure(

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Target.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/Target.java
@@ -141,6 +141,11 @@ public interface Target {
       public Imyhat type() {
         return target.type();
       }
+
+      @Override
+      public String unaliasedName() {
+        return target.unaliasedName();
+      }
     };
   }
 

--- a/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureDefinition.java
+++ b/shesmu-server/src/main/java/ca/on/oicr/gsi/shesmu/compiler/definitions/SignatureDefinition.java
@@ -37,6 +37,11 @@ public abstract class SignatureDefinition implements Target {
     public void read() {
       original.read();
     }
+
+    @Override
+    public String unaliasedName() {
+      return original.unaliasedName();
+    }
   }
 
   private final String name;

--- a/shesmu-server/src/test/resources/run/intersectionjoin-dump.shesmu
+++ b/shesmu-server/src/test/resources/run/intersectionjoin-dump.shesmu
@@ -1,0 +1,10 @@
+Version 1;
+Input test;
+Import std::*;
+
+Olive
+ Let accession
+ IntersectionJoin [False, True] To inner_test [True]
+ Dump All To this_is_fine_actually
+ Group By accession Into ls = List l
+ Run ok With ok = (For l In ls: Count) == 2;


### PR DESCRIPTION
Addresses a bug where signatures that were aliased by an import would generate incorrect code. Shesmu only handles things by name, so when `Import std::*;`, there will be two signatures `std::signature::json` and `signature::json`. Some code paths would generate both versions and some only one. This bug was discovered with a `Dump All` since it iterates over all possible stream variables, but a user could just have easily written `signature::json`. This adds checks in multiple places to only process unaliased signatures.

JIRA Ticket: 

- [X] Updates Changelog
- [X] Updates developer documentation (or N/A)
