### PR TITLE
ObjectNode to actually store labels in

### DIFF
--- a/changes/fix_import-labels-npe.md
+++ b/changes/fix_import-labels-npe.md
@@ -1,0 +1,1 @@
+NullPointerException when import action requires labels

--- a/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/ImportAction.java
+++ b/plugin-vidarr/src/main/java/ca/on/oicr/gsi/shesmu/vidarr/ImportAction.java
@@ -38,6 +38,7 @@ public class ImportAction extends VidarrAction {
     workflowRun.setWorkflowName(request.getWorkflow().getName());
     workflowRun.setWorkflowVersion(request.getWorkflowVersion().getVersion());
     workflowRun.setEngineParameters(VidarrPlugin.MAPPER.createObjectNode());
+    workflowRun.setLabels(VidarrPlugin.MAPPER.createObjectNode());
 
     priority = workflow.getName().hashCode() % 100;
 


### PR DESCRIPTION
Trying to store() labels (VidarrPlugin:631) would NPE because request.getWorkflowRun().getLabels() would return null, and you can't put() a new json value into null

- [x] Updates Changelog
- [ ] Updates developer documentation (or N/A)
