### PR TITLE
Fix issue where apikey and apikey-file config wasn't correctly deserialized

### DIFF
--- a/changes/fix_reading_apikey_config.md
+++ b/changes/fix_reading_apikey_config.md
@@ -1,0 +1,1 @@
+`apikey` and `apikey-file` configuration is correctly parsed now

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/authentication/AuthenticationConfigurationAPIkey.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/authentication/AuthenticationConfigurationAPIkey.java
@@ -1,10 +1,12 @@
 package ca.on.oicr.gsi.shesmu.plugin.authentication;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.IOException;
 
 public final class AuthenticationConfigurationAPIkey extends AuthenticationConfiguration {
   private String apikey;
 
+  @JsonProperty("apikey")
   public String getAPIkey() {
     return apikey;
   }
@@ -14,6 +16,7 @@ public final class AuthenticationConfigurationAPIkey extends AuthenticationConfi
     return apikey;
   }
 
+  @JsonProperty("apikey")
   public void setAPIkey(String apikey) {
     this.apikey = apikey;
   }

--- a/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/authentication/AuthenticationConfigurationFileAPIkey.java
+++ b/shesmu-pluginapi/src/main/java/ca/on/oicr/gsi/shesmu/plugin/authentication/AuthenticationConfigurationFileAPIkey.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.shesmu.plugin.authentication;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -7,6 +8,7 @@ import java.nio.file.Paths;
 public final class AuthenticationConfigurationFileAPIkey extends AuthenticationConfiguration {
   private String apikeyFile;
 
+  @JsonProperty("apikeyFile")
   public String getAPIkeyFile() {
     return apikeyFile;
   }
@@ -16,6 +18,7 @@ public final class AuthenticationConfigurationFileAPIkey extends AuthenticationC
     return Files.readString(Paths.get(apikeyFile)).trim();
   }
 
+  @JsonProperty("apikeyFile")
   public void setAPIkeyFile(String apikeyFile) {
     this.apikeyFile = apikeyFile;
   }


### PR DESCRIPTION
Jackson 3 defaults to requiring standard Java naming for deserializing, so these getters and setters need annotations

JIRA Ticket: GP-5883

- [x] Updates Changelog
- [x] Updates developer documentation (or N/A)
