### PR TITLE
Allow null booleans in JIRA transition fields

### DIFF
--- a/changes/fix_issue_with_jira_tickets.md
+++ b/changes/fix_issue_with_jira_tickets.md
@@ -1,0 +1,1 @@
+Jira ticket actions with empty optional values and no default value configured no longer throw errors

--- a/plugin-jira/pom.xml
+++ b/plugin-jira/pom.xml
@@ -26,6 +26,16 @@
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <finalName>shesmu-plugin-jira</finalName>

--- a/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
+++ b/plugin-jira/src/main/java/ca/on/oicr/gsi/shesmu/jira/JiraConnection.java
@@ -36,6 +36,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.cfg.DateTimeFeature;
@@ -103,6 +104,7 @@ public class JiraConnection extends JsonPluginFile<Configuration> {
       JsonMapper.builder()
           .configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, true)
           .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+          .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
           .build();
 
   /**

--- a/plugin-jira/src/test/java/ca/on/oicr/gsi/shesmu/jira/TransitionsResponseTest.java
+++ b/plugin-jira/src/test/java/ca/on/oicr/gsi/shesmu/jira/TransitionsResponseTest.java
@@ -1,0 +1,188 @@
+package ca.on.oicr.gsi.shesmu.jira;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Check that a JIRA transitions response can be deserialised even when the server sends nulls for
+ * the boolean flags on a field
+ *
+ * <p>JIRA answers {@code /issue/{id}/transitions?expand=transitions.fields} with {@code
+ * "hasDefaultValue": null} for some fields. Jackson 3 turned on {@code
+ * DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES} by default, so mapping those nulls into the
+ * {@code boolean} components of {@link IssueField} throws and no issue can be transitioned at all.
+ */
+public class TransitionsResponseTest {
+
+  /** A transitions response as JIRA sends it, with nulls for {@code hasDefaultValue} */
+  private static final String TRANSITIONS_WITH_NULL_HAS_DEFAULT_VALUE =
+      """
+      {
+        "expand": "transitions",
+        "transitions": [
+          {
+            "id": "31",
+            "name": "Close Issue",
+            "to": {
+              "description": "The issue is considered finished.",
+              "id": "6",
+              "name": "Closed"
+            },
+            "hasScreen": true,
+            "isGlobal": true,
+            "isInitial": false,
+            "isAvailable": true,
+            "isConditional": false,
+            "fields": {
+              "assignee": {
+                "required": false,
+                "name": "Assignee",
+                "key": "assignee",
+                "hasDefaultValue": null,
+                "operations": ["set"]
+              },
+              "resolution": {
+                "required": true,
+                "name": "Resolution",
+                "key": "resolution",
+                "hasDefaultValue": null,
+                "operations": ["set"]
+              }
+            }
+          }
+        ]
+      }
+      """;
+
+  /** The same response with the flags present, which is the case that always worked */
+  private static final String TRANSITIONS_WITH_FLAGS =
+      """
+      {
+        "expand": "transitions",
+        "transitions": [
+          {
+            "id": "31",
+            "name": "Close Issue",
+            "to": {
+              "description": "The issue is considered finished.",
+              "id": "6",
+              "name": "Closed"
+            },
+            "fields": {
+              "assignee": {
+                "required": false,
+                "name": "Assignee",
+                "key": "assignee",
+                "hasDefaultValue": true,
+                "operations": ["set"]
+              },
+              "resolution": {
+                "required": true,
+                "name": "Resolution",
+                "key": "resolution",
+                "hasDefaultValue": false,
+                "operations": ["set"]
+              }
+            }
+          }
+        ]
+      }
+      """;
+
+  /** A response where the flags are missing rather than null */
+  private static final String TRANSITIONS_WITHOUT_FLAGS =
+      """
+      {
+        "transitions": [
+          {
+            "id": "31",
+            "name": "Close Issue",
+            "to": {
+              "description": "The issue is considered finished.",
+              "id": "6",
+              "name": "Closed"
+            },
+            "fields": {
+              "resolution": {
+                "name": "Resolution",
+                "key": "resolution",
+                "operations": ["set"]
+              }
+            }
+          }
+        ]
+      }
+      """;
+
+  public TransitionsResponseTest() {}
+
+  private IssueField field(String json, String name) {
+    final TransitionsResponse response =
+        JiraConnection.MAPPER.readValue(json, TransitionsResponse.class);
+    Assertions.assertEquals(1, response.transitions().size(), "Wrong number of transitions");
+    final Transition transition = response.transitions().get(0);
+    Assertions.assertEquals("Closed", transition.to().name(), "Wrong transition target");
+    final IssueField field = transition.fields().get(name);
+    Assertions.assertNotNull(field, "Missing the " + name + " field");
+    return field;
+  }
+
+  /**
+   * A null {@code hasDefaultValue} must deserialise instead of throwing, since JIRA sends nulls and
+   * a failure here stops every transition
+   */
+  @Test
+  public void testNullHasDefaultValueIsDeserialized() {
+    Assertions.assertFalse(
+        field(TRANSITIONS_WITH_NULL_HAS_DEFAULT_VALUE, "assignee").hasDefaultValue(),
+        "A null hasDefaultValue must be treated as false");
+    Assertions.assertFalse(
+        field(TRANSITIONS_WITH_NULL_HAS_DEFAULT_VALUE, "resolution").hasDefaultValue(),
+        "A null hasDefaultValue must be treated as false");
+  }
+
+  /** A null flag must not disturb the flags that were sent alongside it */
+  @Test
+  public void testRequiredSurvivesANullHasDefaultValue() {
+    Assertions.assertFalse(
+        field(TRANSITIONS_WITH_NULL_HAS_DEFAULT_VALUE, "assignee").required(),
+        "Wrong required flag for assignee");
+    Assertions.assertTrue(
+        field(TRANSITIONS_WITH_NULL_HAS_DEFAULT_VALUE, "resolution").required(),
+        "Wrong required flag for resolution");
+  }
+
+  /**
+   * A field with a null {@code hasDefaultValue} must be one that {@link
+   * JiraConnection#processTransition} fills in from the configured default values, which is only
+   * true if the null becomes false
+   */
+  @Test
+  public void testANullHasDefaultValueNeedsAValueSupplied() {
+    final IssueField resolution = field(TRANSITIONS_WITH_NULL_HAS_DEFAULT_VALUE, "resolution");
+    Assertions.assertTrue(
+        resolution.required() && !resolution.hasDefaultValue(),
+        "A required field with a null hasDefaultValue must be given a value in the transition"
+            + " request");
+  }
+
+  /** Flags that are actually sent must still be read as sent */
+  @Test
+  public void testFlagsAreDeserialized() {
+    Assertions.assertTrue(
+        field(TRANSITIONS_WITH_FLAGS, "assignee").hasDefaultValue(),
+        "Wrong hasDefaultValue for assignee");
+    Assertions.assertFalse(
+        field(TRANSITIONS_WITH_FLAGS, "resolution").hasDefaultValue(),
+        "Wrong hasDefaultValue for resolution");
+  }
+
+  /** Absent flags are the same as null ones as far as the transition logic is concerned */
+  @Test
+  public void testAbsentFlagsAreDeserialized() {
+    final IssueField resolution = field(TRANSITIONS_WITHOUT_FLAGS, "resolution");
+    Assertions.assertFalse(
+        resolution.hasDefaultValue(), "An absent hasDefaultValue must be treated as false");
+    Assertions.assertFalse(resolution.required(), "An absent required must be treated as false");
+  }
+}


### PR DESCRIPTION
JIRA sends "hasDefaultValue": null on transition fields, and Jackson 3 enables FAIL_ON_NULL_FOR_PRIMITIVES by default, so deserialising a transitions response threw and no issue could be transitioned. The same happens when the flags are absent, since Jackson passes absent record components to the canonical constructor as null.

This is one where the desired behaviour is to translate nulls to false - it's what Shesmu had been doing in the Jackson 2 code. 

None of the other plugins are significantly affected (e.g. Cardea, Guanyin and Nabu all have non-null values for the primitives in the Shesmu DTO classes). The only other place where this might come into play is for `.shesmuschema` files, which we are not using and are not planning to use; if this were to have a null primitive, it would crash Shesmu at startup which would be obvious, and the fix would be updating the type in the schema before restarting Shesmu.

JIRA Ticket: GP-5891

- [x] Updates Changelog
- [x] Updates developer documentation (or N/A)
